### PR TITLE
kotlin: Create aar files from kotlin_library jar rather than relying on android_binary

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -36,7 +36,7 @@ aar_with_jni(
 )
 
 android_library(
-    name = "android_lib_j",
+    name = "android_lib",
     srcs = ["library/java/io/envoyproxy/envoymobile/Envoy.java"],
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "library/EnvoyManifest.xml",
@@ -57,7 +57,7 @@ android_library(
 )
 
 kt_android_library(
-    name = "android_lib",
+    name = "android_lib_kt",
     srcs = ["library/kotlin/io/envoyproxy/envoymobile/Envoy.kt"],
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "library/EnvoyManifest.xml",

--- a/BUILD
+++ b/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_framework", "ios_static_framework")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 
 envoy_package()
 
@@ -35,11 +36,32 @@ aar_with_jni(
 )
 
 android_library(
-    name = "android_lib",
+    name = "android_lib_j",
     srcs = ["library/java/io/envoyproxy/envoymobile/Envoy.java"],
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "library/EnvoyManifest.xml",
     deps = ["//library/common:envoy_jni_interface_lib"],
+)
+
+# Work around for transtive dependencies related to not including cc_libraries for kt_jvm_library
+# Related to: https://github.com/bazelbuild/rules_kotlin/issues/132
+#
+# This work around is to use an empty java_library to include the cc_library dependencies needed
+# for the kotlin jni layer
+android_library(
+    name = "java_cc_alias",
+    srcs = ["library/kotlin/io/envoyproxy/envoymobile/EnovyKotlinEmptyClass.java"],
+    custom_package = "io.envoyproxy.envoymobile",
+    manifest = "library/EnvoyManifest.xml",
+    deps = ["//library/common:envoy_jni_interface_lib"],
+)
+
+kt_android_library(
+    name = "android_lib",
+    srcs = ["library/kotlin/io/envoyproxy/envoymobile/Envoy.kt"],
+    custom_package = "io.envoyproxy.envoymobile",
+    manifest = "library/EnvoyManifest.xml",
+    deps = ["java_cc_alias"],
 )
 
 genrule(

--- a/BUILD
+++ b/BUILD
@@ -35,6 +35,14 @@ aar_with_jni(
     visibility = ["//visibility:public"],
 )
 
+kt_android_library(
+    name = "android_lib",
+    srcs = ["library/java/io/envoyproxy/envoymobile/Envoy.java", "library/java/io/envoyproxy/envoymobile/EnvoyEmptyClass.kt"],
+    custom_package = "io.envoyproxy.envoymobile",
+    manifest = "library/EnvoyManifest.xml",
+    deps = ["java_cc_alias"],
+)
+
 # Work around for transtive dependencies related to not including cc_libraries for kt_jvm_library
 # Related to: https://github.com/bazelbuild/rules_kotlin/issues/132
 #
@@ -49,7 +57,7 @@ android_library(
 )
 
 kt_android_library(
-    name = "android_lib",
+    name = "android_lib_kotlin",
     srcs = ["library/kotlin/io/envoyproxy/envoymobile/Envoy.kt"],
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "library/EnvoyManifest.xml",

--- a/BUILD
+++ b/BUILD
@@ -37,7 +37,10 @@ aar_with_jni(
 
 kt_android_library(
     name = "android_lib",
-    srcs = ["library/java/io/envoyproxy/envoymobile/Envoy.java", "library/java/io/envoyproxy/envoymobile/EnvoyEmptyClass.kt"],
+    srcs = [
+        "library/java/io/envoyproxy/envoymobile/Envoy.java",
+        "library/java/io/envoyproxy/envoymobile/EnvoyEmptyClass.kt",
+    ],
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "library/EnvoyManifest.xml",
     deps = ["java_cc_alias"],

--- a/BUILD
+++ b/BUILD
@@ -35,14 +35,6 @@ aar_with_jni(
     visibility = ["//visibility:public"],
 )
 
-android_library(
-    name = "android_lib",
-    srcs = ["library/java/io/envoyproxy/envoymobile/Envoy.java"],
-    custom_package = "io.envoyproxy.envoymobile",
-    manifest = "library/EnvoyManifest.xml",
-    deps = ["//library/common:envoy_jni_interface_lib"],
-)
-
 # Work around for transtive dependencies related to not including cc_libraries for kt_jvm_library
 # Related to: https://github.com/bazelbuild/rules_kotlin/issues/132
 #
@@ -57,7 +49,7 @@ android_library(
 )
 
 kt_android_library(
-    name = "android_lib_kt",
+    name = "android_lib",
     srcs = ["library/kotlin/io/envoyproxy/envoymobile/Envoy.kt"],
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "library/EnvoyManifest.xml",

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -23,6 +23,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# android_library's implicit aar doesn't flatten its transitive
+# dependencies. When using the kotlin rules, the kt_android_library rule
+# creates a few underlying libraries, because of this the classes.jar in
+# the aar we built was empty. This rule separately builds the underlying
+# kt.jar file, and replaces the aar's classes.jar with the kotlin jar
 def aar_with_jni(name, android_library, archive_name = "", visibility = None):
     if not archive_name:
         archive_name = name

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -50,16 +50,17 @@ EOF
 
     native.genrule(
         name = name,
-        srcs = [android_library + ".aar", archive_name + "_jni_unsigned.apk"],
+        srcs = [android_library + "_kt.jar", android_library + ".aar", archive_name + "_jni_unsigned.apk"],
         outs = [archive_name + ".aar"],
         cmd = """
-cp $(location {}.aar) $(location :{}.aar)
-chmod +w $(location :{}.aar)
+cp $(location {android_library}.aar) $(location :{archive_name}.aar)
+chmod +w $(location :{archive_name}.aar)
 origdir=$$PWD
 cd $$(mktemp -d)
-unzip $$origdir/$(location :{}_jni_unsigned.apk) "lib/*"
+unzip $$origdir/$(location :{archive_name}_jni_unsigned.apk) "lib/*"
 cp -r lib jni
-zip -r $$origdir/$(location :{}.aar) jni/*/*.so
-""".format(android_library, archive_name, archive_name, archive_name, archive_name),
+cp $$origdir/$(location {android_library}_kt.jar) classes.jar
+zip -r $$origdir/$(location :{archive_name}.aar) jni/*/*.so classes.jar
+""".format(android_library = android_library, archive_name = archive_name),
         visibility = visibility,
     )

--- a/examples/java/hello_world/BUILD
+++ b/examples/java/hello_world/BUILD
@@ -2,9 +2,12 @@ licenses(["notice"])  # Apache 2
 
 android_binary(
     name = "hello_envoy",
-    srcs = glob([
-        "*.java",
-    ]),
+    srcs = [
+        "MainActivity.java",
+        "Response.java",
+        "ResponseRecyclerViewAdapter.java",
+        "ResponseViewHolder.java",
+    ],
     custom_package = "io.envoyproxy.envoymobile.helloenvoy",
     manifest = "AndroidManifest.xml",
     resource_files = glob(["res/**"]),

--- a/examples/java/hello_world/BUILD
+++ b/examples/java/hello_world/BUILD
@@ -3,10 +3,7 @@ licenses(["notice"])  # Apache 2
 android_binary(
     name = "hello_envoy",
     srcs = glob([
-        "MainActivity.java",
-        "Response.java",
-        "ResponseRecyclerViewAdapter.java",
-        "ResponseViewHolder.java",
+        "*.java",
     ]),
     custom_package = "io.envoyproxy.envoymobile.helloenvoy",
     manifest = "AndroidManifest.xml",

--- a/examples/kotlin/hello_world/BUILD
+++ b/examples/kotlin/hello_world/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 envoy_package()
 
 android_binary(
-    name = "hello_envoy_kotlin",
+    name = "hello_envoy_kt",
     custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
     manifest = "AndroidManifest.xml",
     deps = [

--- a/examples/kotlin/hello_world/BUILD
+++ b/examples/kotlin/hello_world/BUILD
@@ -16,9 +16,12 @@ android_binary(
 
 kt_android_library(
     name = "hello_envoy_kt_lib",
-    srcs = glob([
-        "*.kt",
-    ]),
+    srcs = [
+        "MainActivity.kt",
+        "Response.kt",
+        "ResponseRecyclerViewAdapter.kt",
+        "ResponseViewHolder.kt",
+    ],
     custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
     manifest = "AndroidManifest.xml",
     resource_files = glob([

--- a/examples/kotlin/hello_world/BUILD
+++ b/examples/kotlin/hello_world/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 envoy_package()
 
 android_binary(
-    name = "hello_envoy_kt",
+    name = "hello_envoy_kotlin",
     custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
     manifest = "AndroidManifest.xml",
     deps = [
@@ -17,10 +17,7 @@ android_binary(
 kt_android_library(
     name = "hello_envoy_kt_lib",
     srcs = glob([
-        "MainActivity.kt",
-        "Response.kt",
-        "ResponseRecyclerViewAdapter.kt",
-        "ResponseViewHolder.kt",
+        "*.kt",
     ]),
     custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
     manifest = "AndroidManifest.xml",

--- a/library/java/io/envoyproxy/envoymobile/Envoy.java
+++ b/library/java/io/envoyproxy/envoymobile/Envoy.java
@@ -45,7 +45,7 @@ public class Envoy {
   // initialization with the configuration provided. If the Envoy native library and its
   // dependencies haven't been loaded and initialized yet, this will happen lazily when
   // the first instance is created.
-  public Envoy(Context context, String config) {
+  public Envoy(final Context context, String config) {
     // Lazily initialize Envoy and its dependencies, if necessary.
     load(context);
 

--- a/library/java/io/envoyproxy/envoymobile/Envoy.java
+++ b/library/java/io/envoyproxy/envoymobile/Envoy.java
@@ -45,7 +45,7 @@ public class Envoy {
   // initialization with the configuration provided. If the Envoy native library and its
   // dependencies haven't been loaded and initialized yet, this will happen lazily when
   // the first instance is created.
-  public Envoy(final Context context, String config) {
+  public Envoy(final Context context, final String config) {
     // Lazily initialize Envoy and its dependencies, if necessary.
     load(context);
 

--- a/library/java/io/envoyproxy/envoymobile/EnvoyEmptyClass.kt
+++ b/library/java/io/envoyproxy/envoymobile/EnvoyEmptyClass.kt
@@ -1,2 +1,6 @@
 package library.java.io.envoyproxy.envoymobile
 
+/**
+ * This is so we can use a kotlin bazel rule to compile a module with only java sources. The kotlin bazel rule fails
+ *  otherwise
+ */

--- a/library/java/io/envoyproxy/envoymobile/EnvoyEmptyClass.kt
+++ b/library/java/io/envoyproxy/envoymobile/EnvoyEmptyClass.kt
@@ -1,0 +1,2 @@
+package library.java.io.envoyproxy.envoymobile
+

--- a/library/kotlin/io/envoyproxy/envoymobile/EnovyKotlinEmptyClass.java
+++ b/library/kotlin/io/envoyproxy/envoymobile/EnovyKotlinEmptyClass.java
@@ -5,10 +5,8 @@ package io.envoyproxy.envoymobile;
  * kt_android_library for Envoy JNI in kotlin. There's an issue with transitive dependencies
  * related to kt_jvm_library which errors with a message:
  * <p>
- * ...in deps attribute of kt_jvm_library rule //:android_lib_kt: '//library/common:envoy_jni_interface_lib'
- * does not have mandatory providers: 'JavaInfo'
- * <p>
+ * ...in deps attribute of kt_jvm_library rule //:android_lib_kt:
+ * '//library/common:envoy_jni_interface_lib' does not have mandatory providers: 'JavaInfo' <p>
  * Could be related to: https://github.com/bazelbuild/rules_kotlin/issues/132
  */
-public class EnovyKotlinEmptyClass {
-}
+public class EnovyKotlinEmptyClass {}

--- a/library/kotlin/io/envoyproxy/envoymobile/EnovyKotlinEmptyClass.java
+++ b/library/kotlin/io/envoyproxy/envoymobile/EnovyKotlinEmptyClass.java
@@ -1,0 +1,14 @@
+package io.envoyproxy.envoymobile;
+
+/**
+ * This class is used as a workaround to compile cc_libraries into a java_library for
+ * kt_android_library for Envoy JNI in kotlin. There's an issue with transitive dependencies
+ * related to kt_jvm_library which errors with a message:
+ * <p>
+ * ...in deps attribute of kt_jvm_library rule //:android_lib_kt: '//library/common:envoy_jni_interface_lib'
+ * does not have mandatory providers: 'JavaInfo'
+ * <p>
+ * Could be related to: https://github.com/bazelbuild/rules_kotlin/issues/132
+ */
+public class EnovyKotlinEmptyClass {
+}

--- a/library/kotlin/io/envoyproxy/envoymobile/Envoy.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/Envoy.kt
@@ -1,0 +1,25 @@
+package io.envoyproxy.envoymobile
+
+import android.content.Context
+import android.net.ConnectivityManager
+
+class Envoy {
+
+  fun load() {
+    System.loadLibrary("envoy_jni")
+  }
+
+  fun run(context: Context, config: String) {
+    val thread = Thread(Runnable {
+      initialize(context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager)
+      runEnvoy(config.trim())
+    })
+    thread.start()
+  }
+
+  private external fun initialize(connectivityManager: ConnectivityManager): Int
+
+  private external fun isAresInitialized(): Boolean
+
+  private external fun runEnvoy(config: String): Int
+}

--- a/library/kotlin/io/envoyproxy/envoymobile/EnvoyKotlinEmptyClass.java
+++ b/library/kotlin/io/envoyproxy/envoymobile/EnvoyKotlinEmptyClass.java
@@ -9,4 +9,4 @@ package io.envoyproxy.envoymobile;
  * '//library/common:envoy_jni_interface_lib' does not have mandatory providers: 'JavaInfo' <p>
  * Could be related to: https://github.com/bazelbuild/rules_kotlin/issues/132
  */
-public class EnovyKotlinEmptyClass {}
+public class EnvoyKotlinEmptyClass {}

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -15,5 +15,5 @@ fi
 envoy/tools/check_format.py \
     --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./dist/Envoy.framework/ \
     --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" \
-    --namespace_check_excluded_paths ./examples/ ./library/java/
+    --namespace_check_excluded_paths ./examples/ ./library/java/ ./library/kotlin
 envoy/tools/format_python_tools.sh check


### PR DESCRIPTION
The primary goal this achieves is that it unlocks our ability to develop the Envoy mobile shim in kotlin rather than java. 

The gist of this change is that `android_library`'s implicit `aar` doesn't flatten its transitive dependencies. When using the kotlin rules, the `kt_android_library` rule creates a few underlying libraries, because of this the `classes.jar` in the `aar` we built was empty. This change separately builds the underlying `*kt.jar` file, and replaces the `aar`'s `classes.jar` with the kotlin one.

https://github.com/lyft/envoy-mobile/issues/99

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Enable kotlin library development
Risk Level: low
Testing: ci, local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
