### PR TITLE
bazel: Remove JVM limit

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,3 @@
-startup --host_jvm_args=-Xmx512m
-
 build \
   --define=google_grpc=disabled \
   --define=hot_restart=disabled \


### PR DESCRIPTION
When doing android builds bazel crashes with GC overhead reached.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>