### PR TITLE
build: remove unnecessary opts

### DIFF
--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -15,10 +15,5 @@ envoy_cc_library(
 cc_library(
     name = "envoy_jni_interface_lib",
     srcs = ["jni_interface.cc"],
-    copts = ["-std=c++14"],
-    linkopts = [
-        "-lm",
-        "-llog",
-    ],
     deps = [":envoy_main_interface_lib"],
 )


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>

Description: Clean up of build opts.
Risk Level: Low
Testing: Built and ran locally.

Fixes #52