### PR TITLE
lib: make Android interface instance-based and threadsafe

### DIFF
--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -33,14 +33,17 @@ public class MainActivity extends Activity {
 
   private HandlerThread thread = new HandlerThread(REQUEST_HANDLER_THREAD_NAME);
 
+  private Envoy envoy;
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    // Load an envoy config, and run envoy on a separate thread.
-    Envoy envoy = new Envoy();
-    envoy.load();
+    Context context = getBaseContext();
+    Envoy.load(context);
+
+    // Create envoy instance with config.
     String config = null;
     try {
       config = loadEnvoyConfig(getBaseContext(), R.raw.config);
@@ -48,7 +51,7 @@ public class MainActivity extends Activity {
       Log.d("MainActivity", "exception getting config.", e);
       throw new RuntimeException("Can't get config to run envoy.");
     }
-    envoy.run(getBaseContext(), config);
+    envoy = new Envoy(context, config);
 
     recyclerView = (RecyclerView)findViewById(R.id.recycler_view);
     recyclerView.setLayoutManager(new LinearLayoutManager(this));

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -25,15 +25,16 @@ private const val ENVOY_SERVER_HEADER = "server"
 class MainActivity : Activity() {
   private lateinit var recyclerView: RecyclerView
   private val thread = HandlerThread(REQUEST_HANDLER_THREAD_NAME)
+  private lateinit var envoy: Envoy
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
 
-    // Load an envoy config, and run envoy on a separate thread.
-    val envoy = Envoy()
-    envoy.load()
-    envoy.run(baseContext, loadEnvoyConfig(baseContext, R.raw.config))
+    Envoy.load(baseContext)
+ 
+    // Create Envoy instance with config.
+    envoy = Envoy(baseContext, loadEnvoyConfig(baseContext, R.raw.config))
 
     recyclerView = findViewById(R.id.recycler_view) as RecyclerView
     recyclerView.layoutManager = LinearLayoutManager(this)

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -20,15 +20,15 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
   return JNI_VERSION_1_6;
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_Envoy_runEnvoy(JNIEnv* env,
-                                                                                jobject, // this
-                                                                                jstring config) {
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_Envoy_run(JNIEnv* env,
+                                                                           jobject, // this
+                                                                           jstring config) {
   return run_envoy(env->GetStringUTFChars(config, nullptr));
 }
 
 extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_Envoy_initialize(JNIEnv* env,
-                                                jobject, // this
+                                                jclass, // class
                                                 jobject connectivity_manager) {
   // See note above about c-ares.
   return ares_library_init_android(connectivity_manager);
@@ -36,7 +36,7 @@ Java_io_envoyproxy_envoymobile_Envoy_initialize(JNIEnv* env,
 
 extern "C" JNIEXPORT jboolean JNICALL Java_io_envoyproxy_envoymobile_Envoy_isAresInitialized(
     JNIEnv* env,
-    jobject // this
+    jclass // class
 ) {
   return ares_library_android_initialized() == ARES_SUCCESS;
 }

--- a/library/java/io/envoyproxy/envoymobile/Envoy.java
+++ b/library/java/io/envoyproxy/envoymobile/Envoy.java
@@ -9,22 +9,69 @@ import java.io.*;
 // Wrapper class that allows for easy calling of Envoy's JNI interface in native Java.
 public class Envoy {
 
-  public void load() { System.loadLibrary("envoy_jni"); }
+  // Internal reference to helper object used to load and initialize the native library.
+  // Volatile to ensure double-checked locking works correctly.
+  private static volatile EnvoyLoader loader = null;
 
-  public void run(Context context, String config) {
-    Thread thread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        initialize((ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE));
-        runEnvoy(config.trim());
-      }
-    });
-    thread.start();
+  // Dedicated thread for running this instance of Envoy.
+  private final Thread runner;
+
+  // Private helper class used by the load method to ensure the native library and its
+  // dependencies are loaded and initialized at most once.
+  private static class EnvoyLoader {
+
+    EnvoyLoader(Context context) {
+      System.loadLibrary("envoy_jni");
+      initialize((ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE));
+    }
   }
 
-  private native int initialize(ConnectivityManager connectivityManager);
+  // Load and initialize Envoy and its dependencies, but only once.
+  public static void load(Context context) {
+    if (loader != null) {
+      return;
+    }
 
-  private native boolean isAresInitialized();
+    synchronized(Envoy.class) {
+      if (loader != null) {
+        return;
+      }
 
-  private native int runEnvoy(String config);
+      loader = new EnvoyLoader(context);
+    }
+  }
+
+  // Create a new Envoy instance. The Envoy runner Thread is started as part of instance
+  // initialization with the configuration provided. If the Envoy native library and its
+  // dependencies haven't been loaded and initialized yet, this will happen lazily when
+  // the first instance is created.
+  public Envoy(Context context, String config) {
+    // Lazily initialize Envoy and its dependencies, if necessary.
+    load(context);
+
+    runner = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        Envoy.this.run(config.trim());
+      }
+    });
+    runner.start();
+  }
+
+  // Returns whether the Envoy instance is currently active and running.
+  public boolean isRunning() {
+    final Thread.State state = runner.getState();
+    return state != Thread.State.NEW && state != Thread.State.TERMINATED;
+  }
+
+  // Returns whether the Envoy instance is terminated.
+  public boolean isTerminated() {
+    return runner.getState() == Thread.State.TERMINATED;
+  }
+
+  private static native int initialize(ConnectivityManager connectivityManager);
+
+  private static native boolean isAresInitialized();
+
+  private native int run(String config);
 }

--- a/library/java/io/envoyproxy/envoymobile/Envoy.java
+++ b/library/java/io/envoyproxy/envoymobile/Envoy.java
@@ -32,7 +32,7 @@ public class Envoy {
       return;
     }
 
-    synchronized(Envoy.class) {
+    synchronized (Envoy.class) {
       if (loader != null) {
         return;
       }
@@ -65,9 +65,7 @@ public class Envoy {
   }
 
   // Returns whether the Envoy instance is terminated.
-  public boolean isTerminated() {
-    return runner.getState() == Thread.State.TERMINATED;
-  }
+  public boolean isTerminated() { return runner.getState() == Thread.State.TERMINATED; }
 
   private static native int initialize(ConnectivityManager connectivityManager);
 


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>

Description: Updates Android interface to statically load and initialize the library, but allow multiple Envoy instances to be created with their own configuration and tied to their own thread.
Risk Level: Moderate
Testing: Built and ran library and apps locally
