### PR TITLE
bazel: Add stamping to android_dist genrule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -46,12 +46,12 @@ genrule(
     name = "android_dist",
     srcs = ["//:android_aar"],
     outs = ["android_out"],
-    stamp = True,
     cmd = """
 cp $< dist/envoy.aar
 chmod 755 dist/envoy.aar
 touch $@
 """,
+    stamp = True,
 )
 
 define_kt_toolchain(

--- a/BUILD
+++ b/BUILD
@@ -25,6 +25,7 @@ genrule(
 unzip -o $< -d dist/
 touch $@
 """,
+    stamp = True,
 )
 
 aar_with_jni(

--- a/BUILD
+++ b/BUILD
@@ -46,6 +46,7 @@ genrule(
     name = "android_dist",
     srcs = ["//:android_aar"],
     outs = ["android_out"],
+    stamp = True,
     cmd = """
 cp $< dist/envoy.aar
 chmod 755 dist/envoy.aar


### PR DESCRIPTION
Since we are circumventing bazel's normal input / output file checking
for building our aar, we discovered some issues. When building this dist
library, some changes would not cause overwrites of the aar that is
outside of the source tree. The easiest way for me to repro this was:

```
bazel build android_dist
ls dist # here you see envoy.aar
rm -f dist/envoy.aar bazel-bin/android_out
bazel build android_dist
ls dist # here you don't see envoy.aar
```

The actual issue we found with this was if you built this library, and
altered the linkopts of envoy_jni_interface_lib, the library in dist
would not have the updated binaries, resulting in seemingly flaky
behavior when building.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>

Fixes https://github.com/lyft/envoy-mobile/issues/148