### PR TITLE
docs: note using git hooks needs envoy dependences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,11 @@ maximize the chances of your PR being merged.
   Please see [envoy/support/README.md](https://github.com/envoyproxy/envoy/tree/master/support) for
   more information on these hooks.
 
-  Note: these git hooks depend upon `realpath` which is part of `coreutils`. Install `coreutils` on macOS with:
+  Note: the git hooks depend upon many of the dependencies used to build envoy. Install these on macOS with:
 
   ```bash
-  brew install coreutils
+  brew install coreutils wget cmake libtool go bazel automake ninja clang-format autoconf aspell
+  go get github.com/bazelbuild/buildtools/buildifier
   ```
 
 * Create your PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,7 @@ maximize the chances of your PR being merged.
   Please see [envoy/support/README.md](https://github.com/envoyproxy/envoy/tree/master/support) for
   more information on these hooks.
 
-  Note: the git hooks depend upon many of the dependencies used to build envoy. Install these on macOS with:
-
-  ```bash
-  brew install coreutils wget cmake libtool go bazel automake ninja clang-format autoconf aspell
-  go get github.com/bazelbuild/buildtools/buildifier
-  ```
+  Note: the git hooks depend upon many of the dependencies used to build envoy via Bazel. To install these, folow the [Quick start Bazel build for developers](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#quick-start-bazel-build-for-developers) guide.
 
 * Create your PR.
 * Tests will automatically run for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ maximize the chances of your PR being merged.
   Please see [envoy/support/README.md](https://github.com/envoyproxy/envoy/tree/master/support) for
   more information on these hooks.
 
-  Note: the git hooks depend upon many of the dependencies used to build envoy via Bazel. To install these, follow the [Quick start Bazel build for developers](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#quick-start-bazel-build-for-developers) guide.
+  Note: the git hooks depend upon many of the dependencies used to build envoy via Bazel. Follow the [Quick start Bazel build for developers](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#quick-start-bazel-build-for-developers) guide to install these.
 
 * Create your PR.
 * Tests will automatically run for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ maximize the chances of your PR being merged.
   Please see [envoy/support/README.md](https://github.com/envoyproxy/envoy/tree/master/support) for
   more information on these hooks.
 
-  Note: the git hooks depend upon many of the dependencies used to build envoy via Bazel. To install these, folow the [Quick start Bazel build for developers](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#quick-start-bazel-build-for-developers) guide.
+  Note: the git hooks depend upon many of the dependencies used to build envoy via Bazel. To install these, follow the [Quick start Bazel build for developers](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#quick-start-bazel-build-for-developers) guide.
 
 * Create your PR.
 * Tests will automatically run for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ maximize the chances of your PR being merged.
   Please see [envoy/support/README.md](https://github.com/envoyproxy/envoy/tree/master/support) for
   more information on these hooks.
 
+  Note: these git hooks depend upon `realpath` which is part of `coreutils`. Install `coreutils` on macOS with:
+
+  ```bash
+  brew install coreutils
+  ```
+
 * Create your PR.
 * Tests will automatically run for you.
 * We will **not** merge any PR that is not passing tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,8 @@ maximize the chances of your PR being merged.
   Please see [envoy/support/README.md](https://github.com/envoyproxy/envoy/tree/master/support) for
   more information on these hooks.
 
-  Note: the git hooks depend upon many of the dependencies used to build envoy via Bazel. Follow the [Quick start Bazel build for developers](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#quick-start-bazel-build-for-developers) guide to install these.
+  Note: the git hooks depend upon many of the dependencies used to build envoy via Bazel. Follow the
+  [Quick start Bazel build for developers](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#quick-start-bazel-build-for-developers) guide to install these.
 
 * Create your PR.
 * Tests will automatically run for you.


### PR DESCRIPTION
Description:

As an uninitiated person improving the sample projects or documentation, running `./envoy/support/bootstrap` alone doesn't cut it. The `pre-push` hook uses a bunch of dependencies from the core envoy project (realpath, clang-format, buildifier).

This change clarifies this in Contributing.md since some folks may try to contribute without necessarily having full context on envoy's dependencies. An alternative would be to install dependencies in `bootstrap`.

Risk Level: None
Testing: None
Docs Changes: Only
Release Notes: N/a
