### PR TITLE
swift: fix demo when building on device

### DIFF
--- a/examples/swift/hello_world/Info.plist
+++ b/examples/swift/hello_world/Info.plist
@@ -22,6 +22,17 @@
 	<string>0.1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 private let kCellID = "cell-id"
 // swiftlint:disable:next force_unwrapping
-private let kURL = URL(string: "http://0.0.0.0:9001/api.lyft.com/static/demo/hello_world.txt")!
+private let kURL = URL(string: "http://localhost:9001/api.lyft.com/static/demo/hello_world.txt")!
 
 final class ViewController: UITableViewController {
   private var responses = [Response]()


### PR DESCRIPTION
Using `0.0.0.0` when connecting over a socket to Envoy doesn't work when building to a physical device even though it works fine on a simulator.

To fix this, we can use `localhost` and disable ATS for the demos.

As a long term fix, there are a few options, but the foremost/preferred is to call directly into Envoy over request interfaces instead of using a local socket. See [this section](https://docs.google.com/document/d/1eLbJEXog2Rn7wTBEbDIjpDV7dHecV_DV_dw8P5ZgbL4/edit#heading=h.nx6ynimf9ztp) for more details on this, slated for v0.2.

Discussion: https://envoyproxy.slack.com/archives/CKQ2LK23G/p1561146122069800

Risk Level: Low
Testing: Done locally
Docs Changes: None