### PR TITLE
lib: make iOS interface instantiable and internalize thread

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,7 +13,6 @@ ios_static_framework(
     name = "ios_framework",
     hdrs = [
         "//library/objective-c:envoy_framework_headers",
-        #"//library/objective-c:Envoy-Bridging-Header.h",
     ],
     bundle_name = "Envoy",
     minimum_os_version = "10.0",

--- a/BUILD
+++ b/BUILD
@@ -11,11 +11,14 @@ load("//bazel:aar_with_jni.bzl", "aar_with_jni")
 
 ios_static_framework(
     name = "ios_framework",
-    hdrs = ["//library/common:main_interface.h"],
+    hdrs = [
+        "//library/objective-c:envoy_framework_headers",
+        #"//library/objective-c:Envoy-Bridging-Header.h",
+    ],
     bundle_name = "Envoy",
     minimum_os_version = "10.0",
     visibility = ["//visibility:public"],
-    deps = ["//library/common:envoy_main_interface_lib"],
+    deps = ["//library/objective-c:envoy_objc_interface_lib"],
 )
 
 genrule(

--- a/examples/objective-c/hello_world/AppDelegate.mm
+++ b/examples/objective-c/hello_world/AppDelegate.mm
@@ -4,6 +4,7 @@
 #import "ViewController.h"
 
 @interface AppDelegate ()
+@property (nonatomic, strong) Envoy *envoy;
 @end
 
 @implementation AppDelegate
@@ -14,25 +15,12 @@
     [self.window setRootViewController:controller];
     [self.window makeKeyAndVisible];
 
-    [NSThread detachNewThreadSelector:@selector(startEnvoy) toTarget:self withObject:nil];
-    NSLog(@"Finished launching!");
-    return YES;
-}
-
-- (void)startEnvoy {
     NSString *configFile = [[NSBundle mainBundle] pathForResource:@"config" ofType:@"yaml"];
     NSString *configYaml = [NSString stringWithContentsOfFile:configFile encoding:NSUTF8StringEncoding error:NULL];
     NSLog(@"Loading config:\n%@", configYaml);
-
-    // Initialize the server's main context under a try/catch loop and simply return EXIT_FAILURE
-    // as needed. Whatever code in the initialization path that fails is expected to log an error
-    // message so the user can diagnose.
-    try {
-        run_envoy(configYaml.UTF8String);
-    } catch (NSException *e) {
-        NSLog(@"Error starting Envoy: %@", e);
-        exit(EXIT_FAILURE);
-    }
+    self.envoy = [[Envoy alloc] initWithConfig: configYaml];
+    NSLog(@"Finished launching!");
+    return YES;
 }
 
 @end

--- a/examples/swift/hello_world/AppDelegate.swift
+++ b/examples/swift/hello_world/AppDelegate.swift
@@ -7,21 +7,16 @@ private enum ConfigLoadError: Error {
 
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
+  var envoy: Envoy?
   var window: UIWindow?
 
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
   {
-    do {
-      let configYaml = try self.loadEnvoyConfig() as NSString
-      NSLog("Loading config:\n\(configYaml)")
-      Thread.detachNewThread {
-        run_envoy(configYaml.utf8String)
-      }
-    } catch let error {
-      NSLog("Failed to load config: \(error)")
-    }
+    let configYaml = try! self.loadEnvoyConfig()
+    NSLog("Loading config:\n\(configYaml)")
+    self.envoy = Envoy(config: configYaml)
 
     let window = UIWindow(frame: UIScreen.main.bounds)
     window.rootViewController = ViewController()

--- a/examples/swift/hello_world/AppDelegate.swift
+++ b/examples/swift/hello_world/AppDelegate.swift
@@ -7,16 +7,17 @@ private enum ConfigLoadError: Error {
 
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
-  var envoy: Envoy?
+  private var envoy: Envoy!
   var window: UIWindow?
 
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
   {
-    let configYaml = try! self.loadEnvoyConfig()
-    NSLog("Loading config:\n\(configYaml)")
-    self.envoy = Envoy(config: configYaml)
+    NSLog("Loading config")
+    let envoyConfig = try! self.loadEnvoyConfig()
+    NSLog("Loaded config:\n\(envoyConfig)")
+    self.envoy = Envoy(config: envoyConfig)
 
     let window = UIWindow(frame: UIScreen.main.bounds)
     window.rootViewController = ViewController()

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -16,9 +16,5 @@ objc_library(
     ],
     copts = ["-std=c++14"],
     visibility = ["//visibility:public"],
-    #sdk_dylibs = [
-    #    "resolv.9",
-    #    "c++",
-    #],
     deps = ["//library/common:envoy_main_interface_lib"],
 )

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -1,0 +1,24 @@
+licenses(["notice"])  # Apache 2
+
+filegroup(
+    name = "envoy_framework_headers",
+    srcs = [
+        "Envoy.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+objc_library(
+    name = "envoy_objc_interface_lib",
+    srcs = [
+        "Envoy.h",
+        "Envoy.mm",
+    ],
+    copts = ["-std=c++14"],
+    visibility = ["//visibility:public"],
+    #sdk_dylibs = [
+    #    "resolv.9",
+    #    "c++",
+    #],
+    deps = ["//library/common:envoy_main_interface_lib"],
+)

--- a/library/objective-c/Envoy.h
+++ b/library/objective-c/Envoy.h
@@ -1,8 +1,14 @@
 #import <Foundation/Foundation.h>
 
 @interface Envoy : NSObject
+
+/// Indicates whether this Envoy instance is currently active and running.
 @property (nonatomic, readonly, getter=isRunning) BOOL running;
+
+/// Returns whether the Envoy instance is terminated.
 @property (nonatomic, readonly, getter=isTerminated) BOOL terminated;
 
+/// Create a new Envoy instance. The Envoy runner NSThread is started as part of instance
+/// initialization with the configuration provided.
 - (id)initWithConfig:(NSString*)config;
 @end

--- a/library/objective-c/Envoy.h
+++ b/library/objective-c/Envoy.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@interface Envoy : NSObject
+@property (nonatomic, readonly, getter=isRunning) BOOL running;
+@property (nonatomic, readonly, getter=isTerminated) BOOL terminated;
+
+- (id)initWithConfig:(NSString*)config;
+@end

--- a/library/objective-c/Envoy.h
+++ b/library/objective-c/Envoy.h
@@ -10,5 +10,5 @@
 
 /// Create a new Envoy instance. The Envoy runner NSThread is started as part of instance
 /// initialization with the configuration provided.
-- (id)initWithConfig:(NSString*)config;
+- (instancetype)initWithConfig:(NSString*)config;
 @end

--- a/library/objective-c/Envoy.h
+++ b/library/objective-c/Envoy.h
@@ -3,10 +3,10 @@
 @interface Envoy : NSObject
 
 /// Indicates whether this Envoy instance is currently active and running.
-@property (nonatomic, readonly, getter=isRunning) BOOL running;
+@property (nonatomic, readonly) BOOL isRunning;
 
-/// Returns whether the Envoy instance is terminated.
-@property (nonatomic, readonly, getter=isTerminated) BOOL terminated;
+/// Indicates whether the Envoy instance is terminated.
+@property (nonatomic, readonly) BOOL isTerminated;
 
 /// Create a new Envoy instance. The Envoy runner NSThread is started as part of instance
 /// initialization with the configuration provided.

--- a/library/objective-c/Envoy.mm
+++ b/library/objective-c/Envoy.mm
@@ -1,0 +1,45 @@
+#import "library/objective-c/Envoy.h"
+
+#import "library/common/main_interface.h"
+
+
+@interface Envoy ()
+@property (nonatomic, strong) NSThread *runner;
+@end
+
+@implementation Envoy
+
+@synthesize runner;
+
+// Create a new Envoy instance. The Envoy runner NSThread is started as part of instance
+// initialization with the configuration provided.
+- (id)initWithConfig:(NSString *)config {
+  self.runner = [[NSThread alloc] initWithTarget:self selector:@selector(run:) object:config];
+  [self.runner start];
+}
+
+// Returns whether this Envoy instance is currently active and running.
+- (BOOL)isRunning {
+  return self.runner != NULL && self.runner.isExecuting;
+}
+
+// Returns whether the Envoy instance is terminated.
+- (BOOL)isTerminated {
+  return self.runner != NULL && self.runner.isFinished;
+}
+
+#pragma mark private
+
+- (void)run:(NSString *)config {
+  try {
+    run_envoy(config.UTF8String);
+  } catch (NSException *e) {
+    NSLog(@"Envoy exception: %@", e);
+    NSDictionary *userInfo = @{ @"exception": e};
+    [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyException"
+                                        object:self
+                                        userInfo:userInfo];
+  }
+}
+
+@end

--- a/library/objective-c/Envoy.mm
+++ b/library/objective-c/Envoy.mm
@@ -11,21 +11,21 @@
 
 @synthesize runner;
 
-// Create a new Envoy instance. The Envoy runner NSThread is started as part of instance
-// initialization with the configuration provided.
 - (id)initWithConfig:(NSString *)config {
-  self.runner = [[NSThread alloc] initWithTarget:self selector:@selector(run:) object:config];
-  [self.runner start];
+  if (self = [super init]) {
+    self.runner = [[NSThread alloc] initWithTarget:self selector:@selector(run:) object:config];
+    [self.runner start];
+  } else {
+    return nil;
+  }
 }
 
-// Returns whether this Envoy instance is currently active and running.
 - (BOOL)isRunning {
-  return self.runner != NULL && self.runner.isExecuting;
+  return self.runner.isExecuting;
 }
 
-// Returns whether the Envoy instance is terminated.
 - (BOOL)isTerminated {
-  return self.runner != NULL && self.runner.isFinished;
+  return self.runner.isFinished;
 }
 
 #pragma mark private

--- a/library/objective-c/Envoy.mm
+++ b/library/objective-c/Envoy.mm
@@ -12,12 +12,12 @@
 @synthesize runner;
 
 - (instancetype)initWithConfig:(NSString *)config {
-  if (self = [super init]) {
+  self = [super init];
+  if (self) {
     self.runner = [[NSThread alloc] initWithTarget:self selector:@selector(run:) object:config];
     [self.runner start];
-  } else {
-    return nil;
   }
+  return self;
 }
 
 - (BOOL)isRunning {

--- a/library/objective-c/Envoy.mm
+++ b/library/objective-c/Envoy.mm
@@ -11,7 +11,7 @@
 
 @synthesize runner;
 
-- (id)initWithConfig:(NSString *)config {
+- (instancetype)initWithConfig:(NSString *)config {
   if (self = [super init]) {
     self.runner = [[NSThread alloc] initWithTarget:self selector:@selector(run:) object:config];
     [self.runner start];

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -15,5 +15,5 @@ fi
 envoy/tools/check_format.py \
     --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./dist/Envoy.framework/ \
     --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" \
-    --namespace_check_excluded_paths ./examples/ ./library/java/ ./library/kotlin
+    --namespace_check_excluded_paths ./examples/ ./library/java/ ./library/kotlin ./library/objective-c
 envoy/tools/format_python_tools.sh check


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>

Description: Allow multiple Envoy instances to be created with their own configuration and tied to their own thread.
Risk Level: Low
Testing: Built and ran apps locally
