### PR TITLE
pre-commit: add spelling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,7 @@ repos:
     - id: check-yaml
     - id: detect-private-key
     - id: mixed-line-ending
+- repo: https://github.com/codespell-project/codespell
+  rev: v1.15.0
+  hooks:
+    - id: codespell


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

Description: add spelling pre-commit hook. Note that I did not go with the tools in upstream because they are more entrenched in the organization of the upstream project. This suffices for now. Also note that none of the solutions (this one, or the ones upstream -- misspell, aspell) are 100% great; meaning that let through a significant amount of misspellings. For instance, `enfornced` was not caught by any of the solutions.
Risk Level: low -- new pre-commit hook.
Testing: ran locally.
