### PR TITLE
ci: run preformat on Objective-C++ files

### DIFF
--- a/examples/objective-c/hello_world/AppDelegate.mm
+++ b/examples/objective-c/hello_world/AppDelegate.mm
@@ -9,18 +9,21 @@
 
 @implementation AppDelegate
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    UIViewController *controller = [ViewController new];
-    self.window = [[UIWindow alloc] initWithFrame: [UIScreen mainScreen].bounds];
-    [self.window setRootViewController:controller];
-    [self.window makeKeyAndVisible];
+- (BOOL)application:(UIApplication *)application
+    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  UIViewController *controller = [ViewController new];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  [self.window setRootViewController:controller];
+  [self.window makeKeyAndVisible];
 
-    NSString *configFile = [[NSBundle mainBundle] pathForResource:@"config" ofType:@"yaml"];
-    NSString *configYaml = [NSString stringWithContentsOfFile:configFile encoding:NSUTF8StringEncoding error:NULL];
-    NSLog(@"Loading config:\n%@", configYaml);
-    self.envoy = [[Envoy alloc] initWithConfig: configYaml];
-    NSLog(@"Finished launching!");
-    return YES;
+  NSString *configFile = [[NSBundle mainBundle] pathForResource:@"config" ofType:@"yaml"];
+  NSString *configYaml = [NSString stringWithContentsOfFile:configFile
+                                                   encoding:NSUTF8StringEncoding
+                                                      error:NULL];
+  NSLog(@"Loading config:\n%@", configYaml);
+  self.envoy = [[Envoy alloc] initWithConfig:configYaml];
+  NSLog(@"Finished launching!");
+  return YES;
 }
 
 @end

--- a/examples/objective-c/hello_world/ViewController.mm
+++ b/examples/objective-c/hello_world/ViewController.mm
@@ -154,8 +154,7 @@ NSString *_ENDPOINT = @"http://localhost:9001/api.lyft.com/static/demo/hello_wor
 
   Result *result = self.results[indexPath.row];
   if (result.error == nil) {
-    cell.textLabel.text =
-        [NSString stringWithFormat:@"[%d] %@", result.identifier, result.body];
+    cell.textLabel.text = [NSString stringWithFormat:@"[%d] %@", result.identifier, result.body];
     cell.detailTextLabel.text =
         [NSString stringWithFormat:@"'Server' header: %@", result.serverHeader];
 
@@ -163,8 +162,7 @@ NSString *_ENDPOINT = @"http://localhost:9001/api.lyft.com/static/demo/hello_wor
     cell.detailTextLabel.textColor = [UIColor blackColor];
     cell.contentView.backgroundColor = [UIColor whiteColor];
   } else {
-    cell.textLabel.text =
-        [NSString stringWithFormat:@"[%d]", result.identifier];
+    cell.textLabel.text = [NSString stringWithFormat:@"[%d]", result.identifier];
     cell.detailTextLabel.text = result.error;
 
     cell.textLabel.textColor = [UIColor whiteColor];

--- a/examples/objective-c/hello_world/main.mm
+++ b/examples/objective-c/hello_world/main.mm
@@ -1,7 +1,7 @@
 #import "AppDelegate.h"
 
-int main(int argc, char * argv[]) {
-    @autoreleasepool {
-        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
-    }
+int main(int argc, char *argv[]) {
+  @autoreleasepool {
+    return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+  }
 }

--- a/library/objective-c/Envoy.mm
+++ b/library/objective-c/Envoy.mm
@@ -6,14 +6,10 @@ static NSString *const kConfig = @"config";
 static NSString *const kLogLevel = @"logLevel";
 
 static NSString *const kLogLevelToString[] = {
-  [EnvoyLogLevelTrace] = @"trace",
-  [EnvoyLogLevelDebug] = @"debug",
-  [EnvoyLogLevelInfo] = @"info",
-  [EnvoyLogLevelWarn] = @"warn",
-  [EnvoyLogLevelError] = @"error",
-  [EnvoyLogLevelCritical] = @"critical",
-  [EnvoyLogLevelOff] = @"off"
-};
+    [EnvoyLogLevelTrace] = @"trace", [EnvoyLogLevelDebug] = @"debug",
+    [EnvoyLogLevelInfo] = @"info",   [EnvoyLogLevelWarn] = @"warn",
+    [EnvoyLogLevelError] = @"error", [EnvoyLogLevelCritical] = @"critical",
+    [EnvoyLogLevelOff] = @"off"};
 
 @interface Envoy ()
 @property (nonatomic, strong) NSThread *runner;
@@ -32,8 +28,8 @@ static NSString *const kLogLevelToString[] = {
   self = [super init];
   if (self) {
     NSDictionary *args = @{
-      kConfig: config,
-      kLogLevel: kLogLevelToString[logLevel],
+      kConfig : config,
+      kLogLevel : kLogLevelToString[logLevel],
     };
     self.runner = [[NSThread alloc] initWithTarget:self selector:@selector(run:) object:args];
     [self.runner start];
@@ -56,10 +52,10 @@ static NSString *const kLogLevelToString[] = {
     run_envoy([args[kConfig] UTF8String], [args[kLogLevel] UTF8String]);
   } catch (NSException *e) {
     NSLog(@"Envoy exception: %@", e);
-    NSDictionary *userInfo = @{ @"exception": e};
+    NSDictionary *userInfo = @{@"exception" : e};
     [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyException"
-                                        object:self
-                                        userInfo:userInfo];
+                                                      object:self
+                                                    userInfo:userInfo];
   }
 }
 


### PR DESCRIPTION
The preformat `clang-format` checks don't run on `.m` or `.mm` files at the moment, so these files are malformatted. Pulls in upstream changes from https://github.com/envoyproxy/envoy/pull/7406 and runs the linter.

Resolves https://github.com/lyft/envoy-mobile/issues/191

Risk Level: Low
