### PR TITLE
ci: run the iOS apps in ci

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -208,6 +208,21 @@ stages:
               targetPath: dist/Envoy.framework
           - script: bazel build --config=ios //examples/objective-c/hello_world:app
             displayName: 'Build objective-c app'
+          # Now check that the app actually runs on the simulator.
+          # This is a non-ideal way to check for liveliness, but does for now.
+          # First start the iOS simulator. Interestingly bazel run does start the simulator in CI.
+          # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
+          - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
+            displayName: 'Start the iOS simulator'
+          # Run the app in the background and redirect logs.
+          - script: bazel run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+            displayName: 'Run objective-c app'
+          # Wait for the app to start and get some requests/responses.
+          - script: sleep 10
+            displayName: 'Sleep'
+          # Check for the sentinel value that shows the app is alive and well.
+          - script: cat /tmp/envoy.log | grep 'Hello, world!'
+            displayName: 'Check liveliness'
       - job: mac_swift_helloworld
         dependsOn: mac_dist
         timeoutInMinutes: 60
@@ -227,3 +242,18 @@ stages:
               targetPath: dist/Envoy.framework
           - script: bazel build --config=ios //examples/swift/hello_world:app
             displayName: 'Build swift app'
+          # Now check that the app actually runs on the simulator.
+          # This is a non-ideal way to check for liveliness, but does for now.
+          # First start the iOS simulator. Interestingly bazel run does start the simulator in CI.
+          # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
+          - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
+            displayName: 'Start the iOS simulator'
+          # Run the app in the background and redirect logs.
+          - script: bazel run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
+            displayName: 'Run swift app'
+          # Wait for the app to start and get some requests/responses.
+          - script: sleep 10
+            displayName: 'Sleep'
+          # Check for the sentinel value that shows the app is alive and well.
+          - script: cat /tmp/envoy.log | grep 'Hello, world!'
+            displayName: 'Check liveliness'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,7 +218,7 @@ stages:
           - script: bazel run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
             displayName: 'Run objective-c app'
           # Wait for the app to start and get some requests/responses.
-          - script: sleep 10
+          - script: sleep 60
             displayName: 'Sleep'
           # Check for the sentinel value that shows the app is alive and well.
           - script: cat /tmp/envoy.log | grep 'Hello, world!'
@@ -252,7 +252,7 @@ stages:
           - script: bazel run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
             displayName: 'Run swift app'
           # Wait for the app to start and get some requests/responses.
-          - script: sleep 10
+          - script: sleep 60
             displayName: 'Sleep'
           # Check for the sentinel value that shows the app is alive and well.
           - script: cat /tmp/envoy.log | grep 'Hello, world!'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,8 +209,9 @@ stages:
           - script: bazel build --config=ios //examples/objective-c/hello_world:app
             displayName: 'Build objective-c app'
           # Now check that the app actually runs on the simulator.
-          # This is a non-ideal way to check for liveliness, but does for now.
-          # First start the iOS simulator. Interestingly bazel run does start the simulator in CI.
+          # This is a non-ideal way to check for liveliness, but works for now.
+          # First start the iOS simulator.
+          # Interestingly bazel run does not start the simulator in CI.
           # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
           - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
             displayName: 'Start the iOS simulator'
@@ -243,8 +244,9 @@ stages:
           - script: bazel build --config=ios //examples/swift/hello_world:app
             displayName: 'Build swift app'
           # Now check that the app actually runs on the simulator.
-          # This is a non-ideal way to check for liveliness, but does for now.
-          # First start the iOS simulator. Interestingly bazel run does start the simulator in CI.
+          # This is a non-ideal way to check for liveliness, but works for now.
+          # First start the iOS simulator.
+          # Interestingly bazel run does not start the simulator in CI.
           # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
           - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
             displayName: 'Start the iOS simulator'


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

Description: previously the CI runs would only build the demos. However we did not run them, or check for liveliness. This is a first iteration of doing so for iOS.
Risk Level: low - improved CI
Testing: tested locally and on CI

Part of #117 
