### PR TITLE
docs: Add docs for battery/cpu analysis

### DIFF
--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -1,15 +1,65 @@
 .. _dev_performance_battery:
 
-Analysis of Battery impact
-==========================
+.. _ios_envoy_example_app: https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/swift/hello_world
+.. _android_envoy_example_app: https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/hello_world
+.. _android_envoy_example_control_app: https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/control
 
-Getting a build
-~~~~~~~~~~~~~~~
+Analysis of battery impact
+==========================
+In order to identify how Envoy impacts an application, we have created a control application with modifications to our
+current hello world example applications. To see the actual applications we used, you can go to `iOS Envoy example <ios_envoy_example_app>`_,
+`Android control app <android_envoy_example_control_app>`_, `Android Envoy example <android_envoy_example_app>`_.
+
+The current configurations we have are that we make a request every 200ms and disabled caching.
+
+Experimentation method
+~~~~~~~~~~~~~~~~~~~~~~
+
+iOS
+---
+* TODO
+
+.. _accu_battery: https://play.google.com/store/apps/details?id=com.digibites.accubattery&hl=en_US
+
+Android
+-------
+Getting the build:
+1. Build the library using ``bazel build android_dist --config=android``
+2. Control: ``bazel mobile-install //examples/kotlin/control:hello_control_kt``
+3. Envoy: ``bazel mobile-install //examples/kotlin/hello_world:hello_envoy_kt --fat_apk_cpu=armeabi-v7a``
+
+Experiment steps:
+1. Set a phone's display to sleep after 30minutes of inactivity
+2. Unplug the phone from any power source
+3. Open up an application
+4. Wait for the phone to sleep
+5. Look at the battery drain from an application like `AccuBattery <accu_battery>`_
+
+Results
+~~~~~~~
+
+iOS
+---
+
+Android
+-------
+The results after an hour of running both the applications:
+Envoy:
+Control:
+
 
 Analysis
 ~~~~~~~~
 
-Open issues regarding Battery usage
+iOS
+---
+* TODO
+
+Android
+-------
+There isn't a very 
+
+Open issues regarding battery usage
 -----------------------------------
 
 Current status

--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -1,0 +1,16 @@
+.. _dev_performance_battery:
+
+Analysis of Battery impact
+==========================
+
+Getting a build
+~~~~~~~~~~~~~~~
+
+Analysis
+~~~~~~~~
+
+Open issues regarding Battery usage
+-----------------------------------
+
+Current status
+~~~~~~~~~~~~~~

--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -1,14 +1,11 @@
 .. _dev_performance_battery:
 
-.. _ios_envoy_example_app: https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/swift/hello_world
-.. _android_envoy_example_app: https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/hello_world
-.. _android_envoy_example_control_app: https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/control
-
 Analysis of battery impact
 ==========================
+
 In order to identify how Envoy impacts an application, we have created a control application with modifications to our
-current hello world example applications. To see the actual applications we used, you can go to `iOS Envoy example <ios_envoy_example_app>`_,
-`Android control app <android_envoy_example_control_app>`_, `Android Envoy example <android_envoy_example_app>`_.
+current hello world example applications. To see the actual applications we used, you can go to `iOS Envoy example <https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/swift/hello_world>`_,
+`Android control app <https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/control>`_, `Android Envoy example <https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/hello_world>`_.
 
 The current configurations we have are that we make a request every 200ms and disabled caching.
 
@@ -17,12 +14,12 @@ Experimentation method
 
 iOS
 ---
-* TODO
 
-.. _accu_battery: https://play.google.com/store/apps/details?id=com.digibites.accubattery&hl=en_US
+* TODO
 
 Android
 -------
+
 Getting the build:
 1. Build the library using ``bazel build android_dist --config=android``
 2. Control: ``bazel mobile-install //examples/kotlin/control:hello_control_kt``
@@ -33,7 +30,7 @@ Experiment steps:
 2. Unplug the phone from any power source
 3. Open up an application
 4. Wait for the phone to sleep
-5. Look at the battery drain from an application like `AccuBattery <accu_battery>`_
+5. Look at the battery drain from an application like `AccuBattery <https://play.google.com/store/apps/details?id=com.digibites.accubattery&hl=en_US>`_
 
 Results
 ~~~~~~~
@@ -43,21 +40,21 @@ iOS
 
 Android
 -------
-The results after an hour of running both the applications:
-Envoy:
-Control:
 
+* TODO
 
 Analysis
 ~~~~~~~~
 
 iOS
 ---
+
 * TODO
 
 Android
 -------
-There isn't a very 
+
+* TODO
 
 Open issues regarding battery usage
 -----------------------------------

--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -7,7 +7,9 @@ In order to identify how Envoy impacts an application, we have created a control
 current hello world example applications. To see the actual applications we used, you can go to `iOS Envoy example <https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/swift/hello_world>`_,
 `Android control app <https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/control>`_, `Android Envoy example <https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/hello_world>`_.
 
-The current configurations we have are that we make a request every 200ms and disabled caching.
+The current configurations make network requests every 200ms and disable caching.
+
+* TODO: Fill more details about how Envoy is configured
 
 Experimentation method
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -28,9 +30,11 @@ Getting the build:
 Experiment steps:
 1. Set a phone's display to sleep after 30minutes of inactivity
 2. Unplug the phone from any power source
-3. Open up an application
+3. Open up the demo app
 4. Wait for the phone to sleep
 5. Look at the battery drain from an application like `AccuBattery <https://play.google.com/store/apps/details?id=com.digibites.accubattery&hl=en_US>`_
+
+* TODO: Instructions on how to use AccuBattery
 
 Results
 ~~~~~~~

--- a/docs/root/development/performance/cpu_impact.rst
+++ b/docs/root/development/performance/cpu_impact.rst
@@ -1,17 +1,59 @@
 .. _dev_performance_cpu:
 
+.. _ios_envoy_example_app: https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/swift/hello_world
+.. _android_envoy_example_app: https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/hello_world
+.. _android_envoy_example_control_app: https://github.com/lyft/envoy-mobile/tree/ac/envoy-battery-cpu-branch/examples/kotlin/control
+
 Analysis of CPU impact
 ======================
 
-Getting the data
-~~~~~~~~~~~~~~~
-We currently are using the example hello world applications for
+Experimentation method
+~~~~~~~~~~~~~~~~~~~~~~
+
+iOS
+---
+
+* TODO
+
+Android
+-------
+
+Getting the build:
+1. Build the library using ``bazel build android_dist --config=android``
+2. Control: ``bazel mobile-install //examples/kotlin/control:hello_control_kt``
+3. Envoy: ``bazel mobile-install //examples/kotlin/hello_world:hello_envoy_kt --fat_apk_cpu=armeabi-v7a``
+
+Experiment steps:
+* TODO
+
+Results
+~~~~~~~
+
+iOS
+---
+
+* TODO
+
+Android
+-------
+
+* TODO
 
 Analysis
 ~~~~~~~~
 
-Open issues regarding CPU usage
--------------------------------
+iOS
+---
+
+* TODO
+
+Android
+-------
+
+* TODO
+
+Open issues regarding battery usage
+-----------------------------------
 
 Current status
 ~~~~~~~~~~~~~~

--- a/docs/root/development/performance/cpu_impact.rst
+++ b/docs/root/development/performance/cpu_impact.rst
@@ -1,11 +1,7 @@
 .. _dev_performance_cpu:
 
-
 Analysis of CPU impact
 ======================
-
-Object files analysis
----------------------
 
 Getting a build
 ~~~~~~~~~~~~~~~

--- a/docs/root/development/performance/cpu_impact.rst
+++ b/docs/root/development/performance/cpu_impact.rst
@@ -3,8 +3,9 @@
 Analysis of CPU impact
 ======================
 
-Getting a build
+Getting the data
 ~~~~~~~~~~~~~~~
+We currently are using the example hello world applications for
 
 Analysis
 ~~~~~~~~

--- a/docs/root/development/performance/cpu_impact.rst
+++ b/docs/root/development/performance/cpu_impact.rst
@@ -1,0 +1,20 @@
+.. _dev_performance_cpu:
+
+
+Analysis of CPU impact
+======================
+
+Object files analysis
+---------------------
+
+Getting a build
+~~~~~~~~~~~~~~~
+
+Analysis
+~~~~~~~~
+
+Open issues regarding CPU usage
+-------------------------------
+
+Current status
+~~~~~~~~~~~~~~

--- a/docs/root/development/performance/performance.rst
+++ b/docs/root/development/performance/performance.rst
@@ -7,6 +7,8 @@ Performance Analysis
   :maxdepth: 2
 
   binary_size
+  battery_impact
+  cpu_impact
 
 Performance analysis can take several shapes in mobile applications. These docs
 describe the process (tools, analysis, measurements) that the Envoy Mobile team


### PR DESCRIPTION
Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: adding docs for ios and android battery/cpu profiling
Risk Level: low
Testing: locally with `./docs/build.sh`
Docs Changes: `docs/root/development/performance/`
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
