### PR TITLE
performance: add Android battery/cpu profiling results

### DIFF
--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -22,19 +22,29 @@ iOS
 Android
 -------
 
+We're currently using HttpURLConnection to communicate and send requests to Envoy. Envoy in it's current state is run as
+a process
+
 Getting the build:
+
 1. Build the library using ``bazel build android_dist --config=android``
 2. Control: ``bazel mobile-install //examples/kotlin/control:hello_control_kt``
 3. Envoy: ``bazel mobile-install //examples/kotlin/hello_world:hello_envoy_kt --fat_apk_cpu=armeabi-v7a``
 
 Experiment steps:
+
 1. Set a phone's display to sleep after 30minutes of inactivity
 2. Unplug the phone from any power source
 3. Open up the demo app
 4. Wait for the phone to sleep
-5. Look at the battery drain from an application like `AccuBattery <https://play.google.com/store/apps/details?id=com.digibites.accubattery&hl=en_US>`_
+6. Look at the battery drain the battery settings in the phone to see the battery usage and drainage
 
-* TODO: Instructions on how to use AccuBattery
+Alternative profiling methods tried:
+
+1. `AccuBattery <https://play.google.com/store/apps/details?id=com.digibites.accubattery&hl=en_US>`_
+We were unable to get the running time of a given application on AccuBattery to more accurately identify battery usage per minute
+2. `Battery Historian <https://github.com/google/battery-historian>`_
+We were unable to get reliable data using this method. Often times, the battery usage of an application appears to use no batteries
 
 Results
 ~~~~~~~
@@ -45,7 +55,11 @@ iOS
 Android
 -------
 
-* TODO
+Through running the applications for 30minutes, the results are:
+Envoy   : 0.17%/min
+Control : 0.18%/min
+
+The results of Envoy and Control are very comparable
 
 Analysis
 ~~~~~~~~
@@ -58,7 +72,10 @@ iOS
 Android
 -------
 
-* TODO
+The results of this experiment is surprising since we should expect Envoy to use more battery than the control by a
+large margin. One explanation is that Envoy is running on its own native thread and the Android application is unable
+to associate the Envoy process to the Android application. This theory would be consistent with how we are using Envoy
+today because at the application layer, it is no different between the control application and the Envoy application.
 
 Open issues regarding battery usage
 -----------------------------------

--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -73,9 +73,11 @@ Android
 -------
 
 The results of this experiment is surprising since we should expect Envoy to use more battery than the control by a
-large margin. One explanation is that Envoy is running on its own native thread and the Android application is unable
-to associate the Envoy process to the Android application. This theory would be consistent with how we are using Envoy
-today because at the application layer, it is no different between the control application and the Envoy application.
+large margin.
+
+One explanation is that Envoy is running on its own native thread and the Android application is unable
+to associate the Envoy process to the Android application. However, when looking at the treads and CPU usage (via `adb shell top`),
+we are unable to observe another thread taking up CPU other than the running Envoy application.
 
 Open issues regarding battery usage
 -----------------------------------

--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -37,7 +37,7 @@ Experiment steps:
 2. Unplug the phone from any power source
 3. Open up the demo app
 4. Wait for the phone to sleep
-6. Look at the battery drain the battery settings in the phone to see the battery usage and drainage
+5. Look at the battery drain the battery settings in the phone to see the battery usage and drainage
 
 Alternative profiling methods tried:
 

--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -79,6 +79,9 @@ we are able to see:
 2. DNS resolution does happen every 5 seconds
 3. Stats are flushed every 5 seconds
 
+The DNS resolution and stats flush happening every 5 seconds was a concern but updating the frequency to 1 minute, we
+did not notice a big change.
+
 Open issues regarding battery usage
 -----------------------------------
 

--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -73,7 +73,7 @@ iOS
 Android
 -------
 
-The results of this experiment is that there isn't much of a difference between Envoy and Control. With the :repo:`CPU analysis </docs/root/development/performance/cpu_impact.rst>`,
+The results of this experiment is that there isn't much of a difference between Envoy and Control every 200ms. With the :repo:`CPU analysis </docs/root/development/performance/cpu_impact.rst>`,
 we are able to see:
 
 1. Requests to s3 are being logged in Envoy

--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -72,12 +72,12 @@ iOS
 Android
 -------
 
-The results of this experiment is surprising since we should expect Envoy to use more battery than the control by a
-large margin.
+The results of this experiment is that there isn't much of a difference between Envoy and Control. With the :repo:`CPU analysis </docs/root/development/performance/cpu_impact.rst>`,
+we are able to see:
 
-One explanation is that Envoy is running on its own native thread and the Android application is unable
-to associate the Envoy process to the Android application. However, when looking at the treads and CPU usage (via `adb shell top`),
-we are unable to observe another thread taking up CPU other than the running Envoy application.
+1. Requests to s3 are being logged in Envoy
+2. DNS resolution does happen every 5 seconds
+3. Stats are flushed every 5 seconds
 
 Open issues regarding battery usage
 -----------------------------------

--- a/docs/root/development/performance/battery_impact.rst
+++ b/docs/root/development/performance/battery_impact.rst
@@ -56,10 +56,11 @@ Android
 -------
 
 Through running the applications for 30minutes, the results are:
-Envoy   : 0.17%/min
-Control : 0.18%/min
 
-The results of Envoy and Control are very comparable
+- Envoy   : 0.17%/min
+- Control : 0.18%/min
+
+The results of Envoy and Control are very similar
 
 Analysis
 ~~~~~~~~

--- a/docs/root/development/performance/cpu_impact.rst
+++ b/docs/root/development/performance/cpu_impact.rst
@@ -63,11 +63,12 @@ iOS
 Android
 -------
 
-The results of this experiment is surprising since we should expect Envoy to use significantly more CPU than the control.
+The results of this experiment is that there is minimal difference between Envoy and Control. By enabling trace logging
+within Envoy, we are able to observe the following:
 
-One explanation is that Envoy is running on its own native thread and the Android application is unable
-to associate the Envoy process to the Android application. However, when looking at the treads and CPU usage (via `adb shell top`),
-we are unable to observe another thread taking up CPU other than the running Envoy application.
+1. Requests to s3 are being logged in Envoy
+2. DNS resolution does happen every 5 seconds
+3. Stats are flushed every 5 seconds
 
 Open issues regarding battery usage
 -----------------------------------

--- a/docs/root/development/performance/cpu_impact.rst
+++ b/docs/root/development/performance/cpu_impact.rst
@@ -29,7 +29,7 @@ Getting the build:
 
 Experiment steps:
 
-1. Run `adb shell top -H | grep envoy` to get the CPU usage of the application (the `-H` flag displays the running threads)
+1. Run ``adb shell top -H | grep envoy`` to get the CPU usage of the application (the ``-H`` flag displays the running threads)
 2. Wait 10minutes to gather a sample set of data to analyze
 3. Take the average CPU% and MEM%
 
@@ -45,12 +45,14 @@ Android
 -------
 
 Envoy:
-15.67560976	Avg CPU%
-2.696341463 Avg MEM%
+
+- Avg CPU: 15.67560976%
+- Avg MEM: 2.696341463%
 
 Control:
-11.27439024 Avg CPU%
-2.152439024 Avg MEM%
+
+- Avg CPU: 11.27439024%
+- Avg MEM: 2.152439024%
 
 Analysis
 ~~~~~~~~

--- a/docs/root/development/performance/cpu_impact.rst
+++ b/docs/root/development/performance/cpu_impact.rst
@@ -18,7 +18,8 @@ iOS
 Android
 -------
 
-We're currently using HttpURLConnection to communicate and send requests to Envoy. Envoy in it's current state is run as
+We're currently using HttpURLConnection to communicate and send requests to Envoy every 200ms.
+Envoy in it's current state is run as
 a process
 
 Getting the build:
@@ -46,13 +47,13 @@ Android
 
 Envoy:
 
-- Avg CPU: 15.67560976%
-- Avg MEM: 2.696341463%
+- Avg CPU: 33.16075949%
+- Avg MEM: 2.765822785%
 
 Control:
 
-- Avg CPU: 11.27439024%
-- Avg MEM: 2.152439024%
+- Avg CPU: 28.81012658%
+- Avg MEM: 2.169620253%
 
 Analysis
 ~~~~~~~~

--- a/docs/root/development/performance/cpu_impact.rst
+++ b/docs/root/development/performance/cpu_impact.rst
@@ -18,13 +18,20 @@ iOS
 Android
 -------
 
+We're currently using HttpURLConnection to communicate and send requests to Envoy. Envoy in it's current state is run as
+a process
+
 Getting the build:
+
 1. Build the library using ``bazel build android_dist --config=android``
 2. Control: ``bazel mobile-install //examples/kotlin/control:hello_control_kt``
 3. Envoy: ``bazel mobile-install //examples/kotlin/hello_world:hello_envoy_kt --fat_apk_cpu=armeabi-v7a``
 
 Experiment steps:
-* TODO
+
+1. Run `adb shell top -H | grep envoy` to get the CPU usage of the application (the `-H` flag displays the running threads)
+2. Wait 10minutes to gather a sample set of data to analyze
+3. Take the average CPU% and MEM%
 
 Results
 ~~~~~~~
@@ -37,7 +44,13 @@ iOS
 Android
 -------
 
-* TODO
+Envoy:
+15.67560976	Avg CPU%
+2.696341463 Avg MEM%
+
+Control:
+11.27439024 Avg CPU%
+2.152439024 Avg MEM%
 
 Analysis
 ~~~~~~~~
@@ -50,7 +63,11 @@ iOS
 Android
 -------
 
-* TODO
+The results of this experiment is surprising since we should expect Envoy to use significantly more CPU than the control.
+
+One explanation is that Envoy is running on its own native thread and the Android application is unable
+to associate the Envoy process to the Android application. However, when looking at the treads and CPU usage (via `adb shell top`),
+we are unable to observe another thread taking up CPU other than the running Envoy application.
 
 Open issues regarding battery usage
 -----------------------------------


### PR DESCRIPTION
Docs for the battery/cpu analysis

# Summary

- CPU is slightly higher for Envoy
- Battery is about the same


Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Docs for the battery/cpu analysis
Risk Level: low
Testing: local
Docs Changes: performance
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
