### PR TITLE
perf: update test binary size target

### DIFF
--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -22,11 +22,3 @@ cc_library(
     ],
     deps = [":envoy_main_interface_lib"],
 )
-
-envoy_cc_binary(
-    name = "test_binary_size",
-    srcs = ["test_binary_size.cc"],
-    repository = "@envoy",
-    stamped = True,
-    deps = ["envoy_main_interface_lib"],
-)

--- a/test/performance/test_binary_size.cc
+++ b/test/performance/test_binary_size.cc
@@ -1,8 +1,8 @@
-#include "main_interface.h"
+#include "library/common/main_interface.h"
 
 // NOLINT(namespace-envoy)
 
 // This binary is used to perform stripped down binary size investigations of the Envoy codebase.
 // Please refer to the development docs for more information:
 // https://envoy-mobile.github.io/docs/envoy-mobile/latest/development/performance/binary_size.html
-int main() { return run_envoy(nullptr); }
+int main() { return run_envoy(nullptr, nullptr); }


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

Description: after #173 landed this target broke due to the breaking API change. This target will be added to CI once #181 closes, so breakages like this will not go undected.
Risk Level: low - updating API, deleting old build rules.