### PR TITLE
configs: slow down certain refreshes

### DIFF
--- a/examples/common/config.yaml
+++ b/examples/common/config.yaml
@@ -23,6 +23,7 @@ static_resources:
     - name: hello_world_api
       connect_timeout: 30s
       dns_lookup_family: V4_ONLY
+      dns_refresh_rate: 60s
       lb_policy: ROUND_ROBIN
       load_assignment:
         cluster_name: hello_world_api
@@ -34,3 +35,7 @@ static_resources:
       tls_context:
         sni: s3.amazonaws.com
       type: LOGICAL_DNS
+stats_flush_interval: 60s
+watchdog:
+  megamiss_timeout: 60s
+  miss_timeout: 60s


### PR DESCRIPTION
There is a set of configurations that we can slow down on mobile from their defaults upstream because they aren't as relevant to mobile clients.

This change updates our example configurations to use new values based on [this discussion](https://github.com/lyft/envoy-mobile/issues/113#issuecomment-507421778).

When we switch to typed configurations, these should also be set automatically for production clients: https://github.com/lyft/envoy-mobile/issues/169

Risk Level: Low
Testing: CI and locally
Docs Changes: None
Release Notes: N/A