### PR TITLE
kotlin: Adding bazel macro for more convenient test target declaration

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -111,9 +111,8 @@ maven_install(
         "junit:junit:4.12"
     ],
     repositories = [
-        "https://jcenter.bintray.com/",
-        "https://maven.google.com",
         "https://repo1.maven.org/maven2",
+        "https://jcenter.bintray.com/",
     ]
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,6 +102,21 @@ git_repository(
     shallow_since = "1552938175 -0400",
 )
 
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+maven_install(
+    artifacts = [
+        # Test artifacts
+        "org.assertj:assertj-core:3.9.0",
+        "junit:junit:4.12"
+    ],
+    repositories = [
+        "https://jcenter.bintray.com/",
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ]
+)
+
 # Bazel Kotlin 1.3 patch: https://github.com/bazelbuild/rules_kotlin/issues/159
 # bazelbuild/rules_kotlin currently doesn't work with Kotlin 1.3
 # TODO: https://github.com/lyft/envoy-mobile/issues/68

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,6 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-load("//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 
 envoy_package()

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,1 +1,17 @@
 licenses(["notice"])  # Apache 2
+
+load("//bazel:envoy_build_system.bzl", "envoy_package")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+envoy_package()
+
+kt_jvm_library(
+    name = "envoy_mobile_test_suite",
+    srcs = [
+        "EnvoyMobileTestSuite.kt",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@maven//:junit_junit",
+    ],
+)

--- a/bazel/EnvoyMobileTestSuite.kt
+++ b/bazel/EnvoyMobileTestSuite.kt
@@ -1,0 +1,55 @@
+package io.envoyproxy.envoymobile.bazel
+
+import junit.framework.JUnit4TestAdapter
+import junit.framework.TestSuite
+import org.junit.runner.RunWith
+import java.io.File
+import java.net.URLClassLoader
+import java.util.*
+import java.util.zip.ZipFile
+
+/**
+ * This is class is taken from https://stackoverflow.com/questions/46365464/how-to-run-all-tests-in-bazel-from-a-single-java-test-rule
+ *
+ * Translated to Kotlin and slightly modified
+ *
+ */
+@RunWith(org.junit.runners.AllTests::class)
+object EnvoyMobileTestSuite {
+  private const val CLASS_SUFFIX = ".class"
+
+  @JvmStatic
+  fun suite(): TestSuite {
+    val suite = TestSuite()
+    val classLoader = Thread.currentThread().contextClassLoader as URLClassLoader
+
+    // The first entry on the classpath contains the srcs from java_test
+    val classesInJar = findClassesInJar(File(classLoader.urLs[0].path))
+    for (clazz in classesInJar) {
+      val name = Class.forName(clazz)
+      if (name != EnvoyMobileTestSuite::class.java) {
+        suite.addTest(JUnit4TestAdapter(name))
+      }
+    }
+
+    return suite
+  }
+
+  private fun findClassesInJar(jarFile: File): Set<String> {
+    val classNames = mutableSetOf<String>()
+
+    ZipFile(jarFile).use { zipFile ->
+      val entries = zipFile.entries()
+      for (entry in entries) {
+        val entryName = entry.name
+
+        if (entryName.endsWith(CLASS_SUFFIX)) {
+          val classNameEnd = entryName.length - CLASS_SUFFIX.length
+          classNames.add(entryName.substring(0, classNameEnd).replace('/', '.'))
+        }
+      }
+    }
+
+    return classNames
+  }
+}

--- a/bazel/EnvoyMobileTestSuite.kt
+++ b/bazel/EnvoyMobileTestSuite.kt
@@ -5,7 +5,6 @@ import junit.framework.TestSuite
 import org.junit.runner.RunWith
 import java.io.File
 import java.net.URLClassLoader
-import java.util.*
 import java.util.zip.ZipFile
 
 /**

--- a/bazel/EnvoyMobileTestSuite.kt
+++ b/bazel/EnvoyMobileTestSuite.kt
@@ -26,9 +26,7 @@ object EnvoyMobileTestSuite {
     val classesInJar = findClassesInJar(File(classLoader.urLs[0].path))
     for (clazz in classesInJar) {
       val name = Class.forName(clazz)
-      if (name != EnvoyMobileTestSuite::class.java) {
-        suite.addTest(JUnit4TestAdapter(name))
-      }
+      suite.addTest(JUnit4TestAdapter(name))
     }
 
     return suite

--- a/bazel/EnvoyMobileTestSuite.kt
+++ b/bazel/EnvoyMobileTestSuite.kt
@@ -4,6 +4,7 @@ import junit.framework.JUnit4TestAdapter
 import junit.framework.TestSuite
 import org.junit.runner.RunWith
 import java.io.File
+import java.lang.RuntimeException
 import java.net.URLClassLoader
 import java.util.zip.ZipFile
 
@@ -12,23 +13,36 @@ import java.util.zip.ZipFile
  *
  * Translated to Kotlin and slightly modified
  *
+ * Requirements:
+ * 1. This only allows tests to be run if the package is within `io.envoyproxy.envoymobile`
+ * 2. This requires at least one test to be defined in the test target
  */
 @RunWith(org.junit.runners.AllTests::class)
 object EnvoyMobileTestSuite {
   private const val CLASS_SUFFIX = ".class"
+  private const val ENVOY_MOBILE_PACKAGE = "io.envoyproxy.envoymobile"
 
   @JvmStatic
   fun suite(): TestSuite {
     val suite = TestSuite()
     val classLoader = Thread.currentThread().contextClassLoader as URLClassLoader
 
+    val testAdapters = mutableListOf<JUnit4TestAdapter>()
     // The first entry on the classpath contains the srcs from java_test
     val classesInJar = findClassesInJar(File(classLoader.urLs[0].path))
     for (clazz in classesInJar) {
       val name = Class.forName(clazz)
-      suite.addTest(JUnit4TestAdapter(name))
+      val testAdapter = JUnit4TestAdapter(name)
+      testAdapters.add(testAdapter)
     }
 
+    if (testAdapters.isEmpty()) {
+      throw RuntimeException("Unable to find any tests in test target")
+    }
+
+    for (testAdapter in testAdapters) {
+      suite.addTest(testAdapter)
+    }
     return suite
   }
 
@@ -42,7 +56,10 @@ object EnvoyMobileTestSuite {
 
         if (entryName.endsWith(CLASS_SUFFIX)) {
           val classNameEnd = entryName.length - CLASS_SUFFIX.length
-          classNames.add(entryName.substring(0, classNameEnd).replace('/', '.'))
+          val resolvedClass = entryName.substring(0, classNameEnd).replace('/', '.')
+          if (resolvedClass.contains(ENVOY_MOBILE_PACKAGE)) {
+            classNames.add(resolvedClass)
+          }
         }
       }
     }

--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+# A basic macro to make it easier to declare and run kotlin tests
+#
+# Ergonomic improvements include:
+# 1. Avoiding the need to declare the test_class which requires a fully qualified class name (example below)
+# 2. Avoiding the need to redeclare common unit testing dependencies like JUnit
+# 3. Ability to run more than one test file per target
+#
+# Usage example:
+# load("//bazel:kotlin_test.bzl", "envoy_mobile_kt_test)
+#
+# envoy_mobile_kt_test(
+#     name = "example_kotlin_test",
+#     srcs = [
+#         "ExampleTest.kt",
+#     ],
+# )
+#
+def envoy_mobile_kt_test(name, srcs, deps = []):
+    kt_jvm_test(
+        name = name,
+        test_class = "io.envoyproxy.envoymobile.bazel.EnvoyMobileTestSuite",
+        srcs = srcs,
+        deps = deps + [
+            "//bazel:envoy_mobile_test_suite",
+            "@maven//:org_assertj_assertj_core",
+            "@maven//:junit_junit",
+        ],
+    )

--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -18,7 +18,6 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
 # )
 #
 def envoy_mobile_kt_test(name, srcs, deps = []):
-
     kt_jvm_test(
         name = name,
         test_class = "io.envoyproxy.envoymobile.bazel.EnvoyMobileTestSuite",

--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -18,6 +18,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
 # )
 #
 def envoy_mobile_kt_test(name, srcs, deps = []):
+
     kt_jvm_test(
         name = name,
         test_class = "io.envoyproxy.envoymobile.bazel.EnvoyMobileTestSuite",

--- a/library/kotlin/test/SampleTest.kt
+++ b/library/kotlin/test/SampleTest.kt
@@ -1,8 +1,0 @@
-package io.envoyproxy.envoymobile
-
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
-
-class SampleTest {
-
-}

--- a/library/kotlin/test/SampleTest.kt
+++ b/library/kotlin/test/SampleTest.kt
@@ -1,0 +1,8 @@
+package io.envoyproxy.envoymobile
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SampleTest {
+
+}


### PR DESCRIPTION
Creating test targets for Kotlin is a bit tedious. This change is to help alleviate that.

Some callouts:
1. This will *only* run tests within the `io.envoyproxy.envoymobile` package space
2. This will fail if there are no tests in the provided test target

I feel these are reasonable requirements for this project and can rely on this for the near future (we can revisit when we there is a solution which is more official).

Bazel out of the box:
```
load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")

kt_jvm_test(
    name = "example_kotlin_test",
    test_target = "com.example.myproject.mymodule.ExampleTest"
    srcs = [
        "ExampleTest.kt",
    ],
    deps = [
        "//:another_target",
        "@maven//:org_assertj_assertj_core",
        "@maven//:junit_junit",
    ]
)
```

With this change:
```
load("//bazel:kotlin_test.bzl", "envoy_mobile_kt_test)

envoy_mobile_kt_test(
    name = "example_kotlin_test",
    srcs = [
        "ExampleTest.kt",
    ],
    deps = [
        "//:another_target",
    ]
)
```

Took this solution from: https://stackoverflow.com/questions/46365464/how-to-run-all-tests-in-bazel-from-a-single-java-test-rule

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Adding bazel macro for more convenient test target declaration
Risk Level: low
Testing: locally
Docs Changes: n/a
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
