### PR TITLE
build: remove extraneous inclusion of envoy_package

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,10 +1,7 @@
 licenses(["notice"])  # Apache 2
 
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_framework", "ios_static_framework")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
-
-envoy_package()
 
 alias(
     name = "ios_framework",

--- a/dist/BUILD
+++ b/dist/BUILD
@@ -1,9 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_framework_import")
-
-envoy_package()
 
 # NOTE: You must first build the top-level targets //:ios_dist and //:android_dist to use the
 # artifacts referenced here.

--- a/examples/kotlin/hello_world/BUILD
+++ b/examples/kotlin/hello_world/BUILD
@@ -1,9 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
-
-envoy_package()
 
 android_binary(
     name = "hello_envoy_kt",

--- a/examples/kotlin/shared/BUILD
+++ b/examples/kotlin/shared/BUILD
@@ -16,8 +16,8 @@ kt_android_library(
         "res/values/colors.xml",
         "res/values/strings.xml",
     ]),
+    visibility = ["//visibility:public"],
     deps = [
         "@androidsdk//com.android.support:recyclerview-v7-25.0.0",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/examples/kotlin/shared/BUILD
+++ b/examples/kotlin/shared/BUILD
@@ -19,4 +19,5 @@ kt_android_library(
     deps = [
         "@androidsdk//com.android.support:recyclerview-v7-25.0.0",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/examples/kotlin/shared/BUILD
+++ b/examples/kotlin/shared/BUILD
@@ -1,9 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
-
-envoy_package()
 
 kt_android_library(
     name = "hello_envoy_shared_lib",

--- a/examples/objective-c/hello_world/BUILD
+++ b/examples/objective-c/hello_world/BUILD
@@ -1,9 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_framework", "ios_static_framework")
-
-envoy_package()
 
 objc_library(
     name = "appmain",

--- a/examples/swift/hello_world/BUILD
+++ b/examples/swift/hello_world/BUILD
@@ -1,10 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
-
-envoy_package()
-
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -36,4 +36,5 @@ kt_jvm_library(
         "RequestMethod.kt",
         "RetryPolicy.kt",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -1,10 +1,7 @@
 licenses(["notice"])  # Apache 2
 
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("//bazel:aar_with_jni.bzl", "aar_with_jni")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_jvm_library")
-
-envoy_package()
 
 aar_with_jni(
     name = "android_aar",

--- a/library/swift/src/BUILD
+++ b/library/swift/src/BUILD
@@ -1,9 +1,5 @@
 licenses(["notice"])  # Apache 2
 
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
-
-envoy_package()
-
 load("//bazel:swift_static_framework.bzl", "swift_static_framework")
 
 swift_static_framework(

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -14,5 +14,5 @@ envoy/tools/check_format.py \
     --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./dist/Envoy.framework/ \
     --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" \
     --namespace_check_excluded_paths ./examples/ ./library/java/ ./library/kotlin ./library/objective-c \
-    --build_fixer_check_excluded_paths ./BUILD ./dist ./examples ./library/java ./library/kotlin ./library/objective-c
+    --build_fixer_check_excluded_paths ./BUILD ./dist ./examples ./library/java ./library/kotlin ./library/objective-c ./library/swift
 envoy/tools/format_python_tools.sh check

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -10,10 +10,9 @@ fi
 
 # TODO(mattklein123): WORKSPACE is excluded due to warning about @bazel_tools reference. Fix here
 #                     or in the upstream checker.
-# TODO(mattklein123): We don't need envoy_package() in various files. Somehow fix in upstream
-#                     checker.
 envoy/tools/check_format.py \
     --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./dist/Envoy.framework/ \
     --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" \
-    --namespace_check_excluded_paths ./examples/ ./library/java/ ./library/kotlin ./library/objective-c
+    --namespace_check_excluded_paths ./examples/ ./library/java/ ./library/kotlin ./library/objective-c \
+    --build_fixer_check_excluded_paths ./BUILD ./dist ./examples ./library/java ./library/kotlin ./library/objective-c
 envoy/tools/format_python_tools.sh check


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>

Description: These were originally inserted by the upstream check_format.py script. They're really only relevant to the core Envoy build tree. Cleaning them up now that we're able to selectively exclude paths from this check.
Risk Level: Low
Testing: CI