### PR TITLE
build: Remove an architecture for Android builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,7 +20,7 @@ build \
 # https://github.com/envoyproxy/envoy/tree/master/bazel#enabling-optional-features
 build:ios --define=manual_stamp=manual_stamp
 
-build:android --fat_apk_cpu=x86,x86_64
+build:android --fat_apk_cpu=x86_64
 
 build:device --ios_multi_cpus=armv7,arm64 --fat_apk_cpu=armeabi-v7a,arm64-v8a
 


### PR DESCRIPTION
When creating release builds we should pass `--config=fat`, when
iterating on the Android library we don't need to build multiple
architectures since this just doubles build times.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>