### PR TITLE
build: Add bazel wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.pyc
 tags
 .vscode
+/tmp/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ stages:
           - script: git checkout master && git pull origin master
           - script: ./ci/linux_ci_setup.sh
             displayName: 'Install dependencies'
-          - script: ./bazelw build //test/performance:test_binary_size --config=sizeopt
+          - script: bazel build //test/performance:test_binary_size --config=sizeopt
             displayName: 'Build test binary'
           - task: PublishPipelineArtifact@0
             displayName: 'Publish master test binary'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ stages:
             submodules: true
           - script: ./ci/linux_ci_setup.sh
             displayName: 'Install dependencies'
-          - script: bazel build //test/performance:test_binary_size --config=sizeopt
+          - script: ./bazelw build //test/performance:test_binary_size --config=sizeopt
             displayName: 'Build test binary'
           - task: PublishPipelineArtifact@0
             displayName: 'Publish current test binary'
@@ -89,7 +89,7 @@ stages:
           - script: git checkout master && git pull origin master
           - script: ./ci/linux_ci_setup.sh
             displayName: 'Install dependencies'
-          - script: bazel build //test/performance:test_binary_size --config=sizeopt
+          - script: ./bazelw build //test/performance:test_binary_size --config=sizeopt
             displayName: 'Build test binary'
           - task: PublishPipelineArtifact@0
             displayName: 'Publish master test binary'
@@ -145,7 +145,7 @@ stages:
               export CXX=clang++
             displayName: 'Set up clang toolchain'
           - script: |
-              bazel build --fat_apk_cpu=x86 //:android_dist
+              ./bazelw build --fat_apk_cpu=x86 //:android_dist
             displayName: 'Build envoy.aar distributable'
           - task: PublishPipelineArtifact@0
             displayName: 'Publish envoy.aar distributable'
@@ -169,7 +169,7 @@ stages:
             inputs:
               artifactName: 'envoy-linux.aar'
               targetPath: dist
-          - script: bazel build --fat_apk_cpu=x86 //examples/java/hello_world:hello_envoy
+          - script: ./bazelw build --fat_apk_cpu=x86 //examples/java/hello_world:hello_envoy
             displayName: 'Build java app'
       - job: linux_kotlin_helloworld
         dependsOn: linux_dist
@@ -188,7 +188,7 @@ stages:
             inputs:
               artifactName: 'envoy-linux.aar'
               targetPath: dist
-          - script: bazel build --fat_apk_cpu=x86 //examples/kotlin/hello_world:hello_envoy_kt
+          - script: ./bazelw build --fat_apk_cpu=x86 //examples/kotlin/hello_world:hello_envoy_kt
             displayName: 'Build kotlin app'
       - job: mac_dist
         timeoutInMinutes: 60
@@ -199,7 +199,7 @@ stages:
             submodules: true
           - script: ./ci/mac_ci_setup.sh
             displayName: 'Install dependencies'
-          - script: bazel build --fat_apk_cpu=x86 //:android_dist
+          - script: ./bazelw build --fat_apk_cpu=x86 //:android_dist
             displayName: 'Build envoy.aar distributable'
           - task: PublishPipelineArtifact@0
             displayName: 'Publish envoy.aar distributable'
@@ -222,7 +222,7 @@ stages:
               artifactName: 'envoy-mac.aar'
               targetPath: dist
           - template: ci/templates/start_android_emulator.yaml
-          - script: bazel mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
+          - script: ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
             displayName: 'Start java app'
           - script: adb logcat -e "successful response!" -m 1
             displayName: 'Check liveliness'
@@ -242,7 +242,7 @@ stages:
               artifactName: 'envoy-mac.aar'
               targetPath: dist
           - template: ci/templates/start_android_emulator.yaml
-          - script: bazel mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
+          - script: ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
             displayName: 'Start kotlin app'
           - script: adb logcat -e "successful response!" -m 1
             displayName: 'Check liveliness'
@@ -258,7 +258,7 @@ stages:
             submodules: true
           - script: ./ci/mac_ci_setup.sh
             displayName: 'Install dependencies'
-          - script: bazel build --config=ios //:ios_dist
+          - script: ./bazelw build --config=ios //:ios_dist
             displayName: 'Build Envoy.framework distributable'
           - task: PublishPipelineArtifact@0
             displayName: 'Publish Envoy.framework distributable'
@@ -282,7 +282,7 @@ stages:
       #      inputs:
       #        artifactName: Envoy.framework
       #        targetPath: dist/Envoy.framework
-      #    - script: bazel build --config=ios //examples/objective-c/hello_world:app
+      #    - script: ./bazelw build --config=ios //examples/objective-c/hello_world:app
       #      displayName: 'Build objective-c app'
       #    # Now check that the app actually runs on the simulator.
       #    # This is a non-ideal way to check for liveliness, but works for now.
@@ -292,7 +292,7 @@ stages:
       #    - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
       #      displayName: 'Start the iOS simulator'
       #    # Run the app in the background and redirect logs.
-      #    - script: bazel run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+      #    - script: ./bazelw run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
       #      displayName: 'Run objective-c app'
       #    # Wait for the app to start and get some requests/responses.
       #    - script: sleep 60
@@ -317,7 +317,7 @@ stages:
             inputs:
               artifactName: Envoy.framework
               targetPath: dist/Envoy.framework
-          - script: bazel build --config=ios //examples/swift/hello_world:app
+          - script: ./bazelw build --config=ios //examples/swift/hello_world:app
             displayName: 'Build swift app'
           # Now check that the app actually runs on the simulator.
           # This is a non-ideal way to check for liveliness, but works for now.
@@ -327,7 +327,7 @@ stages:
           - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
             displayName: 'Start the iOS simulator'
           # Run the app in the background and redirect logs.
-          - script: bazel run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
+          - script: ./bazelw run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
             displayName: 'Run swift app'
           # Wait for the app to start and get some requests/responses.
           - script: sleep 60

--- a/bazelw
+++ b/bazelw
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly bazel_version="0.26.1"
+if [[ $OSTYPE == darwin* ]]; then
+  readonly bazel_platform="darwin"
+  readonly bazel_version_sha="9b416e0c9bde5fd59264eacc35d518d2465b5591fbaf3656e386970c045d4747"
+else
+  readonly bazel_platform="linux"
+  readonly bazel_version_sha="6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f"
+fi
+
+readonly bazel_version_url="https://github.com/bazelbuild/bazel/releases/download/$bazel_version/bazel-$bazel_version-$bazel_platform-x86_64"
+readonly script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly bazel_root="$script_root/tmp/bazel/versions/$bazel_version-$bazel_platform"
+readonly bazel_executable="$bazel_root/bin/bazel"
+
+if [[ ! -x "$bazel_executable" ]]; then
+  echo "Installing bazel..." >&2
+  mkdir -p "$(dirname "$bazel_executable")"
+  extra_curl_args=""
+  if [[ -n "${JOB_IS_RUNNING_ON_CI:-}" ]]; then
+    extra_curl_args="--silent"
+  fi
+
+  curl \
+    --show-error \
+    $extra_curl_args \
+    --progress-bar \
+    --retry 3 \
+    --retry-connrefused \
+    --fail \
+    --location \
+    --output "$bazel_executable" \
+    "$bazel_version_url"
+
+  if echo "$bazel_version_sha  $bazel_executable" | shasum --check --status; then
+    chmod +x "$bazel_executable"
+  else
+    echo "Bazel installer sha mismatch" >&2
+    rm -f "$bazel_executable"
+    exit 1
+  fi
+fi
+
+exec "$bazel_executable" "$@"

--- a/bazelw
+++ b/bazelw
@@ -29,7 +29,6 @@ if [[ ! -x "$bazel_executable" ]]; then
     $extra_curl_args \
     --progress-bar \
     --retry 3 \
-    --retry-connrefused \
     --fail \
     --location \
     --output "$bazel_executable" \

--- a/bazelw
+++ b/bazelw
@@ -20,7 +20,7 @@ if [[ ! -x "$bazel_executable" ]]; then
   echo "Installing bazel..." >&2
   mkdir -p "$(dirname "$bazel_executable")"
   extra_curl_args=""
-  if [[ -n "${JOB_IS_RUNNING_ON_CI:-}" ]]; then
+  if [[ -n "${BUILD_BUILDID:-}" ]]; then
     extra_curl_args="--silent"
   fi
 

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -19,8 +19,3 @@ sudo update-alternatives --remove-all clang
 sudo update-alternatives --remove-all clang++
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 100
-
-# Bazel.
-wget -c https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-installer-linux-x86_64.sh
-chmod +x bazel-0.26.1-installer-linux-x86_64.sh
-sudo ./bazel-0.26.1-installer-linux-x86_64.sh

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -25,10 +25,3 @@ for DEP in ${DEPS}
 do
     is_installed "${DEP}" || install "${DEP}"
 done
-
-# Install bazel manually until https://github.com/bazelbuild/continuous-integration/issues/128 is fixed.
-# Otherwise we always pull the latest release automatically.
-wget -c https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-installer-darwin-x86_64.sh
-chmod +x bazel-0.26.1-installer-darwin-x86_64.sh
-sudo ./bazel-0.26.1-installer-darwin-x86_64.sh
-bazel version


### PR DESCRIPTION
This wrapper is a simple shell script that handles downloading bazel.
This ensures that all developers are using the same supported version of
bazel, as well as keeping it in lockstep with CI. This also means
developers who aren't already using bazel don't have to figure out how
to install it on their system globally.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>