### PR TITLE
ci: Remove libtool from macOS

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -20,7 +20,7 @@ if ! brew update; then
     exit 1
 fi
 
-DEPS="automake cmake coreutils go libtool wget ninja"
+DEPS="automake cmake coreutils go wget ninja"
 for DEP in ${DEPS}
 do
     is_installed "${DEP}" || install "${DEP}"


### PR DESCRIPTION
On macOS with brew installing libtool installs `glibtool` which isn't
ever referenced. Whatever this is for must work fine with the default
`libtool` vendored with Xcode.

Upstream PR: https://github.com/envoyproxy/envoy/pull/7499

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>