### PR TITLE
ci: Change master job to use bazelw

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ stages:
           - script: git checkout master && git pull origin master
           - script: ./ci/linux_ci_setup.sh
             displayName: 'Install dependencies'
-          - script: bazel build //test/performance:test_binary_size --config=sizeopt
+          - script: ./bazelw build //test/performance:test_binary_size --config=sizeopt
             displayName: 'Build test binary'
           - task: PublishPipelineArtifact@0
             displayName: 'Publish master test binary'

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -3,6 +3,8 @@
 set -e
 
 # Set up basic requirements and install them.
+# workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
+sudo rm -rf /var/lib/apt/lists/*
 sudo apt-get update
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y wget software-properties-common make cmake git \

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -5,6 +5,7 @@ set -e
 # Set up basic requirements and install them.
 # workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
 sudo rm -rf /var/lib/apt/lists/*
+sudo apt-get clean
 sudo apt-get update
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y wget software-properties-common make cmake git \


### PR DESCRIPTION
I couldn't do this in the same PR since it checks out master and the
wrapper wasn't there yet.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>