### PR TITLE
swift: add library request interfaces

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,4 @@ repos:
   rev: v1.15.0
   hooks:
     - id: codespell
+      args: [-L uint]

--- a/library/swift/Request.swift
+++ b/library/swift/Request.swift
@@ -3,41 +3,41 @@ import Foundation
 /// Represents an Envoy HTTP request. Use `RequestBuilder` to construct new instances.
 @objcMembers
 public final class Request: NSObject {
-    /// Method for the request.
-    public let method: RequestMethod
-    /// URL for the request.
-    public let url: URL
-    /// Headers to send with the request.
-    /// Multiple values for a given name are valid, and will be sent as comma-separated values.
-    public let headers: [String: [String]]
-    /// Trailers to send with the request.
-    /// Multiple values for a given name are valid, and will be sent as comma-separated values.
-    public let trailers: [String: [String]]
-    // Serialized data to send as the body of the request.
-    public let body: Data?
-    // Retry policy to use for this request.
-    public let retryPolicy: RetryPolicy?
+  /// Method for the request.
+  public let method: RequestMethod
+  /// URL for the request.
+  public let url: URL
+  /// Headers to send with the request.
+  /// Multiple values for a given name are valid, and will be sent as comma-separated values.
+  public let headers: [String: [String]]
+  /// Trailers to send with the request.
+  /// Multiple values for a given name are valid, and will be sent as comma-separated values.
+  public let trailers: [String: [String]]
+  // Serialized data to send as the body of the request.
+  public let body: Data?
+  // Retry policy to use for this request.
+  public let retryPolicy: RetryPolicy?
 
-    /// Converts the request back to a builder so that it can be modified (i.e., by a filter).
-    ///
-    /// - returns: A new builder including all the properties of this request.
-    public func newBuilder() -> RequestBuilder {
-        return RequestBuilder(request: self)
-    }
+  /// Converts the request back to a builder so that it can be modified (i.e., by a filter).
+  ///
+  /// - returns: A new builder including all the properties of this request.
+  public func newBuilder() -> RequestBuilder {
+    return RequestBuilder(request: self)
+  }
 
-    /// Internal initializer called from the builder to create a new request.
-    init(method: RequestMethod,
-         url: URL,
-         headers: [String: [String]] = [:],
-         trailers: [String: [String]] = [:],
-         body: Data?,
-         retryPolicy: RetryPolicy?)
-    {
-        self.method = method
-        self.url = url
-        self.headers = headers
-        self.trailers = trailers
-        self.body = body
-        self.retryPolicy = retryPolicy
-    }
+  /// Internal initializer called from the builder to create a new request.
+  init(method: RequestMethod,
+       url: URL,
+       headers: [String: [String]] = [:],
+       trailers: [String: [String]] = [:],
+       body: Data?,
+       retryPolicy: RetryPolicy?)
+  {
+    self.method = method
+    self.url = url
+    self.headers = headers
+    self.trailers = trailers
+    self.body = body
+    self.retryPolicy = retryPolicy
+  }
 }

--- a/library/swift/Request.swift
+++ b/library/swift/Request.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Represents an Envoy HTTP request. Use `RequestBuilder` to construct new instances.
+@objcMembers
+public final class Request: NSObject {
+    /// Method for the request.
+    public let method: RequestMethod
+    /// URL for the request.
+    public let url: URL
+    /// Headers to send with the request.
+    /// Multiple values for a given name are valid, and will be sent as comma-separated values.
+    public let headers: [String: [String]]
+    /// Trailers to send with the request.
+    /// Multiple values for a given name are valid, and will be sent as comma-separated values.
+    public let trailers: [String: [String]]
+    // Serialized data to send as the body of the request.
+    public let body: Data?
+    // Retry policy to use for this request.
+    public let retryPolicy: RetryPolicy?
+
+    /// Converts the request back to a builder so that it can be modified (i.e., by a filter).
+    ///
+    /// - returns: A new builder including all the properties of this request.
+    public func newBuilder() -> RequestBuilder {
+        return RequestBuilder(request: self)
+    }
+
+    /// Internal initializer called from the builder to create a new request.
+    init(method: RequestMethod,
+         url: URL,
+         headers: [String: [String]] = [:],
+         trailers: [String: [String]] = [:],
+         body: Data?,
+         retryPolicy: RetryPolicy?)
+    {
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.trailers = trailers
+        self.body = body
+        self.retryPolicy = retryPolicy
+    }
+}

--- a/library/swift/RequestBuilder.swift
+++ b/library/swift/RequestBuilder.swift
@@ -39,14 +39,23 @@ public final class RequestBuilder: NSObject {
   // MARK: - Builder functions
 
   @discardableResult
-  public func addHeader(name: String, value: String) -> RequestBuilder {
+  public func addHeader(named name: String, value: String) -> RequestBuilder {
     self.headers[name, default: []].append(value)
     return self
   }
 
   @discardableResult
-  public func removeHeader(name: String) -> RequestBuilder {
+  public func removeHeaders(named name: String) -> RequestBuilder {
     self.headers.removeValue(forKey: name)
+    return self
+  }
+
+  public func removeHeader(named name: String, value: String) -> RequestBuilder {
+    self.headers[name]?.removeAll(where: { $0 == value })
+    if self.headers[name]?.isEmpty == true {
+      self.headers.removeValue(forKey: name)
+    }
+
     return self
   }
 

--- a/library/swift/RequestBuilder.swift
+++ b/library/swift/RequestBuilder.swift
@@ -36,20 +36,6 @@ public final class RequestBuilder: NSObject {
     self.method = method
   }
 
-  /// Convenience initializer accepting individual URL components.
-  public convenience init?(scheme: String, host: String, path: String, method: RequestMethod) {
-    var components = URLComponents()
-    components.scheme = scheme
-    components.host = host
-    components.path = path
-
-    guard let url = components.url else {
-      return nil
-    }
-
-    self.init(url: url, method: method)
-  }
-
   // MARK: - Builder functions
 
   @discardableResult

--- a/library/swift/RequestBuilder.swift
+++ b/library/swift/RequestBuilder.swift
@@ -64,6 +64,7 @@ public final class RequestBuilder: NSObject {
     return self
   }
 
+  @discardableResult
   public func removeHeader(named name: String, value: String) -> RequestBuilder {
     self.headers[name]?.removeAll(where: { $0 == value })
     if self.headers[name]?.isEmpty == true {
@@ -74,14 +75,24 @@ public final class RequestBuilder: NSObject {
   }
 
   @discardableResult
-  public func addTrailer(name: String, value: String) -> RequestBuilder {
+  public func addTrailer(named name: String, value: String) -> RequestBuilder {
     self.trailers[name, default: []].append(value)
     return self
   }
 
   @discardableResult
-  public func removeTrailer(name: String) -> RequestBuilder {
+  public func removeTrailer(named name: String) -> RequestBuilder {
     self.trailers.removeValue(forKey: name)
+    return self
+  }
+
+  @discardableResult
+  public func removeTrailers(named name: String, value: String) -> RequestBuilder {
+    self.trailers[name]?.removeAll(where: { $0 == value })
+    if self.trailers[name]?.isEmpty == true {
+      self.trailers.removeValue(forKey: name)
+    }
+
     return self
   }
 

--- a/library/swift/RequestBuilder.swift
+++ b/library/swift/RequestBuilder.swift
@@ -3,10 +3,10 @@ import Foundation
 /// Builder used for constructing instances of `Request` types.
 @objcMembers
 public final class RequestBuilder: NSObject {
-  /// URL for the request.
-  public private(set) var url: URL
   /// Method for the request.
   public private(set) var method: RequestMethod
+  /// URL for the request.
+  public private(set) var url: URL
   /// Headers to send with the request.
   /// Multiple values for a given name are valid, and will be sent as comma-separated values.
   public private(set) var headers: [String: [String]] = [:]
@@ -22,8 +22,8 @@ public final class RequestBuilder: NSObject {
 
   /// Internal initializer used for converting a request back to a builder.
   init(request: Request) {
-    self.url = request.url
     self.method = request.method
+    self.url = request.url
     self.headers = request.headers
     self.trailers = request.trailers
     self.body = request.body
@@ -31,27 +31,27 @@ public final class RequestBuilder: NSObject {
   }
 
   /// Public initializer.
-  public init(url: URL, method: RequestMethod) {
-    self.url = url
+  public init(method: RequestMethod, url: URL) {
     self.method = method
+    self.url = url
   }
 
   // MARK: - Builder functions
 
   @discardableResult
-  public func addHeader(named name: String, value: String) -> RequestBuilder {
+  public func addHeader(name: String, value: String) -> RequestBuilder {
     self.headers[name, default: []].append(value)
     return self
   }
 
   @discardableResult
-  public func removeHeaders(named name: String) -> RequestBuilder {
+  public func removeHeaders(name: String) -> RequestBuilder {
     self.headers.removeValue(forKey: name)
     return self
   }
 
   @discardableResult
-  public func removeHeader(named name: String, value: String) -> RequestBuilder {
+  public func removeHeader(name: String, value: String) -> RequestBuilder {
     self.headers[name]?.removeAll(where: { $0 == value })
     if self.headers[name]?.isEmpty == true {
       self.headers.removeValue(forKey: name)
@@ -61,13 +61,13 @@ public final class RequestBuilder: NSObject {
   }
 
   @discardableResult
-  public func addTrailer(named name: String, value: String) -> RequestBuilder {
+  public func addTrailer(name: String, value: String) -> RequestBuilder {
     self.trailers[name, default: []].append(value)
     return self
   }
 
   @discardableResult
-  public func removeTrailer(named name: String) -> RequestBuilder {
+  public func removeTrailer(name: String) -> RequestBuilder {
     self.trailers.removeValue(forKey: name)
     return self
   }
@@ -111,15 +111,16 @@ extension Request {
   ///
   /// For example:
   ///
-  /// Request *req = [Request withUrl:url method:RequestMethodGet build:^(RequestBuilder *builder) {
+  /// Request *req = [Request withMethod:RequestMethodGet url:url build:^(RequestBuilder *builder) {
   ///   [builder addBody:bodyData];
-  ///   [builder addRetryPolicy:retryPolicy];
+  ///   [builder addHeaderWithName:@"x-some-header" value:@"foo"];
+  ///   [builder addTrailerWithName:@"x-some-trailer" value:@"foo"];
   /// }];
   @objc
-  public static func with(url: URL, method: RequestMethod, build: (RequestBuilder) -> Void)
+  public static func with(method: RequestMethod, url: URL, build: (RequestBuilder) -> Void)
     -> Request
   {
-    let builder = RequestBuilder(url: url, method: method)
+    let builder = RequestBuilder(method: method, url: url)
     build(builder)
     return builder.build()
   }

--- a/library/swift/RequestBuilder.swift
+++ b/library/swift/RequestBuilder.swift
@@ -91,12 +91,14 @@ extension Request {
   ///
   /// For example:
   ///
-  /// Request *request = [Request withUrl:url method:RequestMethodGet build:^(RequestBuilder *builder) {
+  /// Request *req = [Request withUrl:url method:RequestMethodGet build:^(RequestBuilder *builder) {
   ///   [builder addBody:bodyData];
   ///   [builder addRetryPolicy:retryPolicy];
   /// }];
   @objc
-  public static func with(url: URL, method: RequestMethod, build: (RequestBuilder) -> Void) -> Request {
+  public static func with(url: URL, method: RequestMethod, build: (RequestBuilder) -> Void)
+    -> Request
+  {
     let builder = RequestBuilder(url: url, method: method)
     build(builder)
     return builder.build()

--- a/library/swift/RequestBuilder.swift
+++ b/library/swift/RequestBuilder.swift
@@ -36,6 +36,20 @@ public final class RequestBuilder: NSObject {
     self.method = method
   }
 
+  /// Convenience initializer accepting individual URL components.
+  public convenience init?(scheme: String, host: String, path: String, method: RequestMethod) {
+    var components = URLComponents()
+    components.scheme = scheme
+    components.host = host
+    components.path = path
+
+    guard let url = components.url else {
+      return nil
+    }
+
+    self.init(url: url, method: method)
+  }
+
   // MARK: - Builder functions
 
   @discardableResult

--- a/library/swift/RequestBuilder.swift
+++ b/library/swift/RequestBuilder.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+@objcMembers
+public final class RequestBuilder: NSObject {
+    /// URL for the request.
+    public private(set) var url: URL
+    /// Method for the request.
+    public private(set) var method: RequestMethod
+    /// Headers to send with the request.
+    /// Multiple values for a given name are valid, and will be sent as comma-separated values.
+    public private(set) var headers: [String: [String]] = [:]
+    /// Trailers to send with the request.
+    /// Multiple values for a given name are valid, and will be sent as comma-separated values.
+    public private(set) var trailers: [String: [String]] = [:]
+    // Serialized data to send as the body of the request.
+    public private(set) var body: Data?
+    // Retry policy to use for this request.
+    public private(set) var retryPolicy: RetryPolicy?
+
+    // MARK: - Initializers
+
+    /// Internal initializer used for converting a request back to a builder.
+    init(request: Request) {
+        self.url = request.url
+        self.method = request.method
+        self.headers = request.headers
+        self.trailers = request.trailers
+        self.body = request.body
+        self.retryPolicy = request.retryPolicy
+    }
+
+    /// Public initializer.
+    public init(url: URL, method: RequestMethod) {
+        self.url = url
+        self.method = method
+    }
+
+    // MARK: - Builder functions
+
+    @discardableResult
+    public func addHeader(name: String, value: String) -> RequestBuilder {
+        self.headers[name, default: []].append(value)
+        return self
+    }
+
+    @discardableResult
+    public func removeHeader(name: String) -> RequestBuilder {
+        self.headers.removeValue(forKey: name)
+        return self
+    }
+
+    @discardableResult
+    public func addTrailer(name: String, value: String) -> RequestBuilder {
+        self.trailers[name, default: []].append(value)
+        return self
+    }
+
+    @discardableResult
+    public func removeTrailer(name: String) -> RequestBuilder {
+        self.trailers.removeValue(forKey: name)
+        return self
+    }
+
+    @discardableResult
+    public func addBody(_ body: Data?) -> RequestBuilder {
+        self.body = body
+        return self
+    }
+
+    @discardableResult
+    public func addRetryPolicy(_ retryPolicy: RetryPolicy) -> RequestBuilder {
+        self.retryPolicy = retryPolicy
+        return self
+    }
+
+    public func build() -> Request {
+        return Request(method: self.method,
+                       url: self.url,
+                       headers: self.headers,
+                       trailers: self.trailers,
+                       body: self.body,
+                       retryPolicy: self.retryPolicy)
+    }
+}
+
+// MARK: - Objective-C helpers
+
+extension Request {
+    /// Convenience builder function to allow for cleaner Objective-C syntax.
+    ///
+    /// For example:
+    ///
+    /// Request *request = [Request withUrl:url method:RequestMethodGet build:^(RequestBuilder *builder) {
+    ///   [builder addBody:bodyData];
+    ///   [builder addRetryPolicy:retryPolicy];
+    /// }];
+    @objc
+    public static func with(url: URL, method: RequestMethod, build: (RequestBuilder) -> Void) -> Request {
+        let builder = RequestBuilder(url: url, method: method)
+        build(builder)
+        return builder.build()
+    }
+}

--- a/library/swift/RequestBuilder.swift
+++ b/library/swift/RequestBuilder.swift
@@ -1,103 +1,104 @@
 import Foundation
 
+/// Builder used for constructing instances of `Request` types.
 @objcMembers
 public final class RequestBuilder: NSObject {
-    /// URL for the request.
-    public private(set) var url: URL
-    /// Method for the request.
-    public private(set) var method: RequestMethod
-    /// Headers to send with the request.
-    /// Multiple values for a given name are valid, and will be sent as comma-separated values.
-    public private(set) var headers: [String: [String]] = [:]
-    /// Trailers to send with the request.
-    /// Multiple values for a given name are valid, and will be sent as comma-separated values.
-    public private(set) var trailers: [String: [String]] = [:]
-    // Serialized data to send as the body of the request.
-    public private(set) var body: Data?
-    // Retry policy to use for this request.
-    public private(set) var retryPolicy: RetryPolicy?
+  /// URL for the request.
+  public private(set) var url: URL
+  /// Method for the request.
+  public private(set) var method: RequestMethod
+  /// Headers to send with the request.
+  /// Multiple values for a given name are valid, and will be sent as comma-separated values.
+  public private(set) var headers: [String: [String]] = [:]
+  /// Trailers to send with the request.
+  /// Multiple values for a given name are valid, and will be sent as comma-separated values.
+  public private(set) var trailers: [String: [String]] = [:]
+  // Serialized data to send as the body of the request.
+  public private(set) var body: Data?
+  // Retry policy to use for this request.
+  public private(set) var retryPolicy: RetryPolicy?
 
-    // MARK: - Initializers
+  // MARK: - Initializers
 
-    /// Internal initializer used for converting a request back to a builder.
-    init(request: Request) {
-        self.url = request.url
-        self.method = request.method
-        self.headers = request.headers
-        self.trailers = request.trailers
-        self.body = request.body
-        self.retryPolicy = request.retryPolicy
-    }
+  /// Internal initializer used for converting a request back to a builder.
+  init(request: Request) {
+    self.url = request.url
+    self.method = request.method
+    self.headers = request.headers
+    self.trailers = request.trailers
+    self.body = request.body
+    self.retryPolicy = request.retryPolicy
+  }
 
-    /// Public initializer.
-    public init(url: URL, method: RequestMethod) {
-        self.url = url
-        self.method = method
-    }
+  /// Public initializer.
+  public init(url: URL, method: RequestMethod) {
+    self.url = url
+    self.method = method
+  }
 
-    // MARK: - Builder functions
+  // MARK: - Builder functions
 
-    @discardableResult
-    public func addHeader(name: String, value: String) -> RequestBuilder {
-        self.headers[name, default: []].append(value)
-        return self
-    }
+  @discardableResult
+  public func addHeader(name: String, value: String) -> RequestBuilder {
+    self.headers[name, default: []].append(value)
+    return self
+  }
 
-    @discardableResult
-    public func removeHeader(name: String) -> RequestBuilder {
-        self.headers.removeValue(forKey: name)
-        return self
-    }
+  @discardableResult
+  public func removeHeader(name: String) -> RequestBuilder {
+    self.headers.removeValue(forKey: name)
+    return self
+  }
 
-    @discardableResult
-    public func addTrailer(name: String, value: String) -> RequestBuilder {
-        self.trailers[name, default: []].append(value)
-        return self
-    }
+  @discardableResult
+  public func addTrailer(name: String, value: String) -> RequestBuilder {
+    self.trailers[name, default: []].append(value)
+    return self
+  }
 
-    @discardableResult
-    public func removeTrailer(name: String) -> RequestBuilder {
-        self.trailers.removeValue(forKey: name)
-        return self
-    }
+  @discardableResult
+  public func removeTrailer(name: String) -> RequestBuilder {
+    self.trailers.removeValue(forKey: name)
+    return self
+  }
 
-    @discardableResult
-    public func addBody(_ body: Data?) -> RequestBuilder {
-        self.body = body
-        return self
-    }
+  @discardableResult
+  public func addBody(_ body: Data?) -> RequestBuilder {
+    self.body = body
+    return self
+  }
 
-    @discardableResult
-    public func addRetryPolicy(_ retryPolicy: RetryPolicy) -> RequestBuilder {
-        self.retryPolicy = retryPolicy
-        return self
-    }
+  @discardableResult
+  public func addRetryPolicy(_ retryPolicy: RetryPolicy) -> RequestBuilder {
+    self.retryPolicy = retryPolicy
+    return self
+  }
 
-    public func build() -> Request {
-        return Request(method: self.method,
-                       url: self.url,
-                       headers: self.headers,
-                       trailers: self.trailers,
-                       body: self.body,
-                       retryPolicy: self.retryPolicy)
-    }
+  public func build() -> Request {
+    return Request(method: self.method,
+                   url: self.url,
+                   headers: self.headers,
+                   trailers: self.trailers,
+                   body: self.body,
+                   retryPolicy: self.retryPolicy)
+  }
 }
 
 // MARK: - Objective-C helpers
 
 extension Request {
-    /// Convenience builder function to allow for cleaner Objective-C syntax.
-    ///
-    /// For example:
-    ///
-    /// Request *request = [Request withUrl:url method:RequestMethodGet build:^(RequestBuilder *builder) {
-    ///   [builder addBody:bodyData];
-    ///   [builder addRetryPolicy:retryPolicy];
-    /// }];
-    @objc
-    public static func with(url: URL, method: RequestMethod, build: (RequestBuilder) -> Void) -> Request {
-        let builder = RequestBuilder(url: url, method: method)
-        build(builder)
-        return builder.build()
-    }
+  /// Convenience builder function to allow for cleaner Objective-C syntax.
+  ///
+  /// For example:
+  ///
+  /// Request *request = [Request withUrl:url method:RequestMethodGet build:^(RequestBuilder *builder) {
+  ///   [builder addBody:bodyData];
+  ///   [builder addRetryPolicy:retryPolicy];
+  /// }];
+  @objc
+  public static func with(url: URL, method: RequestMethod, build: (RequestBuilder) -> Void) -> Request {
+    let builder = RequestBuilder(url: url, method: method)
+    build(builder)
+    return builder.build()
+  }
 }

--- a/library/swift/RequestMethod.swift
+++ b/library/swift/RequestMethod.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Represents an HTTP request method.
+@objc
+public enum RequestMethod: Int {
+    case delete
+    case get
+    case head
+    case options
+    case patch
+    case post
+    case put
+    case trace
+
+    /// String representation of this method.
+    var stringValue: String {
+        switch self {
+        case .delete:
+            return "DELETE"
+        case .get:
+            return "GET"
+        case .head:
+            return "HEAD"
+        case .options:
+            return "OPTIONS"
+        case .patch:
+            return "PATCH"
+        case .post:
+            return "POST"
+        case .put:
+            return "PUT"
+        case .trace:
+            return "TRACE"
+        }
+    }
+}

--- a/library/swift/RequestMethod.swift
+++ b/library/swift/RequestMethod.swift
@@ -3,34 +3,34 @@ import Foundation
 /// Represents an HTTP request method.
 @objc
 public enum RequestMethod: Int {
-    case delete
-    case get
-    case head
-    case options
-    case patch
-    case post
-    case put
-    case trace
+  case delete
+  case get
+  case head
+  case options
+  case patch
+  case post
+  case put
+  case trace
 
-    /// String representation of this method.
-    var stringValue: String {
-        switch self {
-        case .delete:
-            return "DELETE"
-        case .get:
-            return "GET"
-        case .head:
-            return "HEAD"
-        case .options:
-            return "OPTIONS"
-        case .patch:
-            return "PATCH"
-        case .post:
-            return "POST"
-        case .put:
-            return "PUT"
-        case .trace:
-            return "TRACE"
-        }
+  /// String representation of this method.
+  var stringValue: String {
+    switch self {
+    case .delete:
+      return "DELETE"
+    case .get:
+      return "GET"
+    case .head:
+      return "HEAD"
+    case .options:
+      return "OPTIONS"
+    case .patch:
+      return "PATCH"
+    case .post:
+      return "POST"
+    case .put:
+      return "PUT"
+    case .trace:
+      return "TRACE"
     }
+  }
 }

--- a/library/swift/RetryPolicy.swift
+++ b/library/swift/RetryPolicy.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Rules that may be used for retry policies.
+/// Rules that may be used with `RetryPolicy`.
 /// See the `x-envoy-retry-on` Envoy header for documentation.
 @objc
 public enum RetryRule: Int {
@@ -27,6 +27,7 @@ public enum RetryRule: Int {
   }
 }
 
+/// Specifies how a request may be retried, containing one or more rules.
 @objcMembers
 public final class RetryPolicy: NSObject {
   /// Maximum number of retries that a request may be performed.

--- a/library/swift/RetryPolicy.swift
+++ b/library/swift/RetryPolicy.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Rules that may be used for retry policies.
+/// See the `x-envoy-retry-on` Envoy header for documentation.
+@objc
+public enum RetryRule: Int {
+    case fiveXX
+    case gatewayError
+    case connectFailure
+    case retriableFourXX
+    case refusedUpstream
+
+    /// String representation of this rule.
+    var stringValue: String {
+        switch self {
+        case .fiveXX:
+            return "5xx"
+        case .gatewayError:
+            return "gateway-error"
+        case .connectFailure:
+            return "connect-failure"
+        case .retriableFourXX:
+            return "retriable-4xx"
+        case .refusedUpstream:
+            return "refused-upstream"
+        }
+    }
+}
+
+@objcMembers
+public final class RetryPolicy: NSObject {
+    /// Maximum number of retries that a request may be performed.
+    public let maxRetryCount: UInt
+    /// Whitelist of rules used for retrying.
+    public let retryOn: [RetryRule]
+    /// Timeout (in seconds) to apply to each retry.
+    public let perRetryTimeoutSeconds: UInt?
+
+    /// Public initializer.
+    public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutSeconds: UInt?) {
+        self.maxRetryCount = maxRetryCount
+        self.retryOn = retryOn
+        self.perRetryTimeoutSeconds = perRetryTimeoutSeconds
+    }
+}

--- a/library/swift/RetryPolicy.swift
+++ b/library/swift/RetryPolicy.swift
@@ -4,42 +4,42 @@ import Foundation
 /// See the `x-envoy-retry-on` Envoy header for documentation.
 @objc
 public enum RetryRule: Int {
-    case fiveXX
-    case gatewayError
-    case connectFailure
-    case retriableFourXX
-    case refusedUpstream
+  case fiveXX
+  case gatewayError
+  case connectFailure
+  case retriableFourXX
+  case refusedUpstream
 
-    /// String representation of this rule.
-    var stringValue: String {
-        switch self {
-        case .fiveXX:
-            return "5xx"
-        case .gatewayError:
-            return "gateway-error"
-        case .connectFailure:
-            return "connect-failure"
-        case .retriableFourXX:
-            return "retriable-4xx"
-        case .refusedUpstream:
-            return "refused-upstream"
-        }
+  /// String representation of this rule.
+  var stringValue: String {
+    switch self {
+    case .fiveXX:
+      return "5xx"
+    case .gatewayError:
+      return "gateway-error"
+    case .connectFailure:
+      return "connect-failure"
+    case .retriableFourXX:
+      return "retriable-4xx"
+    case .refusedUpstream:
+      return "refused-upstream"
     }
+  }
 }
 
 @objcMembers
 public final class RetryPolicy: NSObject {
-    /// Maximum number of retries that a request may be performed.
-    public let maxRetryCount: UInt
-    /// Whitelist of rules used for retrying.
-    public let retryOn: [RetryRule]
-    /// Timeout (in seconds) to apply to each retry.
-    public let perRetryTimeoutSeconds: UInt?
+  /// Maximum number of retries that a request may be performed.
+  public let maxRetryCount: UInt
+  /// Whitelist of rules used for retrying.
+  public let retryOn: [RetryRule]
+  /// Timeout (in seconds) to apply to each retry.
+  public let perRetryTimeoutSeconds: UInt?
 
-    /// Public initializer.
-    public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutSeconds: UInt?) {
-        self.maxRetryCount = maxRetryCount
-        self.retryOn = retryOn
-        self.perRetryTimeoutSeconds = perRetryTimeoutSeconds
-    }
+  /// Public initializer.
+  public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutSeconds: UInt?) {
+    self.maxRetryCount = maxRetryCount
+    self.retryOn = retryOn
+    self.perRetryTimeoutSeconds = perRetryTimeoutSeconds
+  }
 }

--- a/library/swift/RetryPolicy.swift
+++ b/library/swift/RetryPolicy.swift
@@ -34,13 +34,13 @@ public final class RetryPolicy: NSObject {
   public let maxRetryCount: UInt
   /// Whitelist of rules used for retrying.
   public let retryOn: [RetryRule]
-  /// Timeout (in seconds) to apply to each retry.
-  public let perRetryTimeoutSeconds: UInt?
+  /// Timeout (in milliseconds) to apply to each retry.
+  public let perRetryTimeoutMS: UInt?
 
   /// Public initializer.
-  public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutSeconds: UInt?) {
+  public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutMS: UInt?) {
     self.maxRetryCount = maxRetryCount
     self.retryOn = retryOn
-    self.perRetryTimeoutSeconds = perRetryTimeoutSeconds
+    self.perRetryTimeoutMS = perRetryTimeoutMS
   }
 }

--- a/library/swift/RetryPolicy.swift
+++ b/library/swift/RetryPolicy.swift
@@ -28,6 +28,7 @@ public enum RetryRule: Int {
 }
 
 /// Specifies how a request may be retried, containing one or more rules.
+/// https://www.envoyproxy.io/learn/automatic-retries
 @objcMembers
 public final class RetryPolicy: NSObject {
   /// Maximum number of retries that a request may be performed.


### PR DESCRIPTION
Introduces request interfaces for the Swift library.

**Builder pattern**

We elected to use a builder pattern for the following reasons:
- Allows us to avoid making all properties mutable (such as those on `Request`). This is especially valuable because these types are classes instead of structs due to the fact that they need to be visible to Objective-C from Swift
- Provides a clear separation between mutable/immutable states of these types since only builders can be modified
- Allows consumers to easily convert between builders and the models, which will become particularly useful when we introduce features such as runtime filters in the future:

```swift
func filter(request: Request) -> Request {
    return request
        .newBuilder()
        .addHeader(name: "x-new-header", value: "foo")
        .build()
}
```

**Swift example**

```swift
let request = RequestBuilder(method: .post, url: url)
    .addBody(data)
    .addHeader(name: "x-some-header", value: "foo")
    .addTrailer(name: "x-some-trailer", value: "foo")
    .build()
```

**Objective-C example**

```objc
Request *request = [Request withMethod:RequestMethodGet url:url build:^(RequestBuilder *builder) {
    [builder addBody:bodyData];
    [builder addHeaderWithName:@"x-some-header" value:@"foo"];
    [builder addTrailerWithName:@"x-some-trailer" value:@"foo"];
}];
```

**Notes**

- `NSObject` and `@objc` classes had to be used in order for these types to be visible to Objective-C
- Enums had to inherit from `Int` to be visible to Objective-C

Resolves https://github.com/lyft/envoy-mobile/issues/122

Signed-off-by: Michael Rebello <mrebello@lyft.com>