### PR TITLE
ios: refactor LogLevel to Swift layer

### DIFF
--- a/library/objective-c/Envoy.h
+++ b/library/objective-c/Envoy.h
@@ -1,16 +1,5 @@
 #import <Foundation/Foundation.h>
 
-/// Available logging levels for an Envoy instance. Note some levels may be compiled out.
-typedef NS_ENUM(NSInteger, EnvoyLogLevel) {
-  EnvoyLogLevelTrace,
-  EnvoyLogLevelDebug,
-  EnvoyLogLevelInfo,
-  EnvoyLogLevelWarn,
-  EnvoyLogLevelError,
-  EnvoyLogLevelCritical,
-  EnvoyLogLevelOff
-};
-
 @interface Envoy : NSObject
 
 /// Indicates whether this Envoy instance is currently active and running.
@@ -25,6 +14,6 @@ typedef NS_ENUM(NSInteger, EnvoyLogLevel) {
 
 /// Create a new Envoy instance. The Envoy runner NSThread is started as part of instance
 /// initialization with the configuration provided.
-- (instancetype)initWithConfig:(NSString *)config logLevel:(EnvoyLogLevel)logLevel;
+- (instancetype)initWithConfig:(NSString *)config logLevel:(NSString *)logLevel;
 
 @end

--- a/library/objective-c/Envoy.mm
+++ b/library/objective-c/Envoy.mm
@@ -4,12 +4,7 @@
 
 static NSString *const kConfig = @"config";
 static NSString *const kLogLevel = @"logLevel";
-
-static NSString *const kLogLevelToString[] = {
-    [EnvoyLogLevelTrace] = @"trace", [EnvoyLogLevelDebug] = @"debug",
-    [EnvoyLogLevelInfo] = @"info",   [EnvoyLogLevelWarn] = @"warn",
-    [EnvoyLogLevelError] = @"error", [EnvoyLogLevelCritical] = @"critical",
-    [EnvoyLogLevelOff] = @"off"};
+static NSString *const kDefaultLogLevel = @"info";
 
 @interface Envoy ()
 @property (nonatomic, strong) NSThread *runner;
@@ -20,16 +15,16 @@ static NSString *const kLogLevelToString[] = {
 @synthesize runner;
 
 - (instancetype)initWithConfig:(NSString *)config {
-  self = [self initWithConfig:config logLevel:EnvoyLogLevelInfo];
+  self = [self initWithConfig:config logLevel:kDefaultLogLevel];
   return self;
 }
 
-- (instancetype)initWithConfig:(NSString *)config logLevel:(EnvoyLogLevel)logLevel {
+- (instancetype)initWithConfig:(NSString *)config logLevel:(NSString *)logLevel {
   self = [super init];
   if (self) {
     NSDictionary *args = @{
       kConfig : config,
-      kLogLevel : kLogLevelToString[logLevel],
+      kLogLevel : logLevel,
     };
     self.runner = [[NSThread alloc] initWithTarget:self selector:@selector(run:) object:args];
     [self.runner start];

--- a/library/swift/BUILD
+++ b/library/swift/BUILD
@@ -20,6 +20,7 @@ swift_library(
     name = "envoy_swift_lib",
     srcs = [
         "Envoy.swift",
+        "LogLevel.swift",
     ],
     module_name = "Envoy",
     visibility = ["//visibility:public"],

--- a/library/swift/BUILD
+++ b/library/swift/BUILD
@@ -9,7 +9,10 @@ load("//bazel:swift_static_framework.bzl", "swift_static_framework")
 
 swift_static_framework(
     name = "ios_framework",
-    srcs = ["Envoy.swift"],
+    srcs = [
+        "Envoy.swift",
+        "LogLevel.swift",
+    ],
     module_name = "Envoy",
     objc_includes = ["//library/objective-c:EnvoyEngine.h"],
     visibility = ["//visibility:public"],

--- a/library/swift/Envoy.swift
+++ b/library/swift/Envoy.swift
@@ -5,11 +5,11 @@ public final class Envoy: NSObject {
   private let runner: EnvoyRunner
 
   public var isRunning: Bool {
-    return runner.isExecuting
+    return self.runner.isExecuting
   }
 
   public var isTerminated: Bool {
-    return runner.isFinished
+    return self.runner.isFinished
   }
 
   public init(config: String, logLevel: LogLevel = .info) {

--- a/library/swift/Envoy.swift
+++ b/library/swift/Envoy.swift
@@ -12,26 +12,22 @@ public final class Envoy: NSObject {
     return runner.isFinished
   }
 
-  public init(config: String, logLevel: String) {
-    runner = EnvoyRunner(config: config, logLevel: logLevel)
-    runner.start()
-  }
-
-  public convenience init(config: String) {
-    self.init(config: config, logLevel: "info")
+  public init(config: String, logLevel: LogLevel = .info) {
+    self.runner = EnvoyRunner(config: config, logLevel: logLevel)
+    self.runner.start()
   }
 
   private final class EnvoyRunner: Thread {
     private let config: String
-    private let logLevel: String
+    private let logLevel: LogLevel
 
-    init(config: String, logLevel: String) {
+    init(config: String, logLevel: LogLevel) {
       self.config = config
       self.logLevel = logLevel
     }
 
     override func main() {
-      EnvoyEngine.run(withConfig: config, logLevel: logLevel)
+      EnvoyEngine.run(withConfig: self.config, logLevel: self.logLevel.stringValue)
     }
   }
 }

--- a/library/swift/LogLevel.swift
+++ b/library/swift/LogLevel.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Available logging levels for an Envoy instance.
+/// Note that some levels may be compiled out.
+@objc
+public enum LogLevel: Int {
+  case trace
+  case debug
+  case info
+  case warn
+  case error
+  case critical
+  case off
+
+  /// String representation of the log level.
+  var stringValue: String {
+    switch self {
+    case .trace:
+      return "trace"
+    case .debug:
+      return "debug"
+    case .info:
+      return "info"
+    case .warn:
+      return "warn"
+    case .error:
+      return "error"
+    case .critical:
+      return "critical"
+    case .off:
+      return "off"
+    }
+  }
+}


### PR DESCRIPTION
This is implemented in Kotlin right now, and should be present in the Swift layer as well. Move the Objective-C logging types to Swift.

Resolves https://github.com/lyft/envoy-mobile/issues/244

Signed-off-by: Michael Rebello <mrebello@lyft.com>