### PR TITLE
swift: include missing library files

### DIFF
--- a/library/swift/src/BUILD
+++ b/library/swift/src/BUILD
@@ -12,6 +12,10 @@ swift_static_framework(
     srcs = [
         "Envoy.swift",
         "LogLevel.swift",
+        "Request.swift",
+        "RequestBuilder.swift",
+        "RequestMethod.swift",
+        "RetryPolicy.swift",
     ],
     module_name = "Envoy",
     objc_includes = ["//library/objective-c:EnvoyEngine.h"],


### PR DESCRIPTION
These aren't being compiled in right now.

Signed-off-by: Michael Rebello <mrebello@lyft.com>