### PR TITLE
swift: add macro for unit testing

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 # Patch upstream Abseil to prevent Foundation dependency from leaking into Android builds.
 # Workaround for https://github.com/abseil/abseil-cpp/issues/326.
@@ -21,6 +21,14 @@ local_repository(
 local_repository(
     name = "envoy_build_config",
     path = "envoy_build_config",
+)
+
+# TODO: Remove once rules_apple > 0.17.2 is released
+http_file(
+    name = "xctestrunner",
+    executable = 1,
+    sha256 = "a3ff412deed453ebe4dc67a98db6ae388b58bd04974d0e862b951089efd26975",
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.8/ios_test_runner.par"],
 )
 
 git_repository(

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -292,7 +292,7 @@ stages:
             submodules: true
           - script: ./ci/mac_ci_setup.sh
             displayName: 'Install dependencies'
-          - script: ./bazelw test --test_output=all --build_tests_only //library/swift/test/...
+          - script: ./bazelw test --test_output=all --build_tests_only --config=ios //library/swift/test/...
             displayName: 'Run Swift library tests'
       #- job: mac_objc_helloworld
       #  dependsOn: mac_dist

--- a/bazel/swift_test.bzl
+++ b/bazel/swift_test.bzl
@@ -31,6 +31,5 @@ def envoy_mobile_swift_test(name, srcs):
 
     ios_unit_test(
         name = name,
-        minimum_os_version = "11.0",
         deps = [test_lib_name],
     )

--- a/bazel/swift_test.bzl
+++ b/bazel/swift_test.bzl
@@ -32,4 +32,5 @@ def envoy_mobile_swift_test(name, srcs):
     ios_unit_test(
         name = name,
         deps = [test_lib_name],
+        minimum_os_version = "10.0",
     )

--- a/bazel/swift_test.bzl
+++ b/bazel/swift_test.bzl
@@ -1,0 +1,36 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+# Macro providing a way to easily/consistently define Swift unit test targets.
+#
+# - Prevents consumers from having to define both swift_library and ios_unit_test targets
+# - Provides a set of linker options that is required to properly run tests
+# - Sets default visibility and OS requirements
+#
+# Usage example:
+# load("//bazel:kotlin_test.bzl", "envoy_mobile_kt_test)
+#
+# envoy_mobile_swift_test(
+#     name = "sample_test",
+#     srcs = [
+#         "SampleTest.swift",
+#     ],
+# )
+#
+def envoy_mobile_swift_test(name, srcs):
+    test_lib_name = name + "_lib"
+    swift_library(
+        name = test_lib_name,
+        srcs = srcs,
+        deps = [
+            "//library/swift/src:ios_framework_archive",
+        ],
+        linkopts = ["-lresolv.9"],
+        visibility = ["//visibility:private"],
+    )
+
+    ios_unit_test(
+        name = name,
+        minimum_os_version = "11.0",
+        deps = [test_lib_name],
+    )

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -1,11 +1,11 @@
 licenses(["notice"])  # Apache 2
 
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
+load("//bazel:swift_test.bzl", "envoy_mobile_swift_test")
 
 envoy_package()
 
-swift_test(
+envoy_mobile_swift_test(
     name = "sample_test",
     srcs = [
         "SampleTest.swift",


### PR DESCRIPTION
Conceptually similar to the macro added in https://github.com/lyft/envoy-mobile/pull/221 for Kotlin testing, this PR adds a `envoy_mobile_swift_test` macro for Swift unit testing.

- Prevents consumers from having to define both swift_library and ios_unit_test targets
- Provides a set of linker options that is required to properly run tests
- Sets default visibility and OS requirements

Signed-off-by: Michael Rebello <mrebello@lyft.com>
