### PR TITLE
kotlin: add bazel macros for easier kt target declaration

### DIFF
--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -1,0 +1,56 @@
+licenses(["notice"])  # Apache 2
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_jvm_library")
+
+# Android library drops exported dependencies from dependent rules. The kt_android_library
+#  internally is just a macro which wraps two rules into one:
+#  https://github.com/bazelbuild/rules_kotlin/blob/326661e7e705d14e754abc2765837aa61bddf205/kotlin/internal/jvm/android.bzl#L28.
+#  This causes the sources to be exported and dropped due to it being a transitive dependency.
+#  To get around this, we have to redeclare the sources from envoy_engine_lib here in order to be pulled into the
+#  kotlin jar.
+def envoy_mobile_kt_aar_android_library(name, custom_package, manifest, srcs = [], deps = []):
+    filegroups = []
+    for dep in deps:
+        filegroups.append(dep + "_srcs")
+
+    kt_android_library(
+        name = name,
+        srcs = srcs + filegroups,
+        custom_package = custom_package,
+        manifest = manifest,
+        visibility = ["//visibility:public"],
+        deps = deps,
+    )
+
+def envoy_mobile_android_library(name,  custom_package, manifest,srcs=[], deps=[]):
+    # These source files must be re-exported to the kotlin custom library rule to ensure their
+    # inclusion.
+    native.filegroup(
+        name = name + "_srcs",
+        srcs = srcs,
+        visibility = ["//visibility:public"],
+    )
+
+    native.android_library(
+        name = name,
+        srcs = srcs,
+        custom_package = custom_package,
+        manifest = manifest,
+        visibility = ["//visibility:public"],
+        deps = deps,
+    )
+
+def envoy_mobile_kt_library(name, srcs=[], deps=[]):
+    # These source files must be re-exported to the kotlin custom library rule to ensure their
+    # inclusion.
+    native.filegroup(
+        name = name + "_srcs",
+        srcs = srcs,
+        visibility = ["//visibility:public"],
+    )
+
+    kt_jvm_library(
+        name = name,
+        srcs = srcs,
+        deps = deps,
+    )

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -22,7 +22,7 @@ def envoy_mobile_kt_aar_android_library(name, custom_package, manifest, srcs = [
         deps = deps,
     )
 
-def envoy_mobile_android_library(name,  custom_package, manifest,srcs=[], deps=[]):
+def envoy_mobile_android_library(name, custom_package, manifest, srcs = [], deps = []):
     # These source files must be re-exported to the kotlin custom library rule to ensure their
     # inclusion.
     native.filegroup(
@@ -40,7 +40,7 @@ def envoy_mobile_android_library(name,  custom_package, manifest,srcs=[], deps=[
         deps = deps,
     )
 
-def envoy_mobile_kt_library(name, srcs=[], deps=[]):
+def envoy_mobile_kt_library(name, srcs = [], deps = []):
     # These source files must be re-exported to the kotlin custom library rule to ensure their
     # inclusion.
     native.filegroup(

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -20,7 +20,7 @@ def envoy_mobile_kt_aar_android_library(name, custom_package, manifest, visibili
         deps = deps,
     )
 
-def envoy_mobile_android_library(name, custom_package, visibility = None, manifest, srcs = [], deps = []):
+def envoy_mobile_android_library(name, custom_package, manifest, visibility = None, srcs = [], deps = []):
     # These source files must be re-exported to the kotlin custom library rule to ensure their
     # inclusion.
     native.filegroup(

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -1,5 +1,3 @@
-licenses(["notice"])  # Apache 2
-
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_jvm_library")
 
 # Android library drops exported dependencies from dependent rules. The kt_android_library

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -51,5 +51,5 @@ def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = []):
         name = name,
         srcs = srcs,
         deps = deps,
-        visibility = visibility
+        visibility = visibility,
     )

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -6,7 +6,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_jvm_
 #  This causes the sources to be exported and dropped due to it being a transitive dependency.
 #  To get around this, we have to redeclare the sources from envoy_engine_lib here in order to be pulled into the
 #  kotlin jar.
-def envoy_mobile_kt_aar_android_library(name, custom_package, manifest, srcs = [], deps = []):
+def envoy_mobile_kt_aar_android_library(name, custom_package, manifest, visibility = None, srcs = [], deps = []):
     filegroups = []
     for dep in deps:
         filegroups.append(dep + "_srcs")
@@ -20,13 +20,13 @@ def envoy_mobile_kt_aar_android_library(name, custom_package, manifest, srcs = [
         deps = deps,
     )
 
-def envoy_mobile_android_library(name, custom_package, manifest, srcs = [], deps = []):
+def envoy_mobile_android_library(name, custom_package, visibility = None, manifest, srcs = [], deps = []):
     # These source files must be re-exported to the kotlin custom library rule to ensure their
     # inclusion.
     native.filegroup(
         name = name + "_srcs",
         srcs = srcs,
-        visibility = ["//visibility:public"],
+        visibility = visibility,
     )
 
     native.android_library(
@@ -34,21 +34,22 @@ def envoy_mobile_android_library(name, custom_package, manifest, srcs = [], deps
         srcs = srcs,
         custom_package = custom_package,
         manifest = manifest,
-        visibility = ["//visibility:public"],
+        visibility = visibility,
         deps = deps,
     )
 
-def envoy_mobile_kt_library(name, srcs = [], deps = []):
+def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = []):
     # These source files must be re-exported to the kotlin custom library rule to ensure their
     # inclusion.
     native.filegroup(
         name = name + "_srcs",
         srcs = srcs,
-        visibility = ["//visibility:public"],
+        visibility = visibility,
     )
 
     kt_jvm_library(
         name = name,
         srcs = srcs,
         deps = deps,
+        visibility = visibility
     )

--- a/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -1,6 +1,9 @@
 licenses(["notice"])  # Apache 2
 
 load("//bazel:kotlin_lib.bzl", "envoy_mobile_android_library")
+load("//bazel:envoy_build_system.bzl", "envoy_package")
+
+envoy_package()
 
 envoy_mobile_android_library(
     name = "envoy_engine_lib",

--- a/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -8,4 +8,5 @@ envoy_mobile_android_library(
     custom_package = "io.envoyproxy.envoymobile.engine",
     manifest = "EnvoyEngineManifest.xml",
     deps = ["//library/common:envoy_jni_interface_lib"],
+    visibility = ["//visibility:public"],
 )

--- a/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -1,18 +1,11 @@
 licenses(["notice"])  # Apache 2
 
-# These source files must be re-exported to the kotlin custom library rule to ensure their
-# inclusion.
-filegroup(
-    name = "envoy_engine_srcs",
-    srcs = ["EnvoyEngine.java"],
-    visibility = ["//visibility:public"],
-)
+load("//bazel:kotlin_lib.bzl", "envoy_mobile_android_library")
 
-android_library(
+envoy_mobile_android_library(
     name = "envoy_engine_lib",
-    srcs = [":envoy_engine_srcs"],
+    srcs = ["EnvoyEngine.java"],
     custom_package = "io.envoyproxy.envoymobile.engine",
     manifest = "EnvoyEngineManifest.xml",
-    visibility = ["//visibility:public"],
     deps = ["//library/common:envoy_jni_interface_lib"],
 )

--- a/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -7,6 +7,6 @@ envoy_mobile_android_library(
     srcs = ["EnvoyEngine.java"],
     custom_package = "io.envoyproxy.envoymobile.engine",
     manifest = "EnvoyEngineManifest.xml",
-    deps = ["//library/common:envoy_jni_interface_lib"],
     visibility = ["//visibility:public"],
+    deps = ["//library/common:envoy_jni_interface_lib"],
 )

--- a/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -1,9 +1,6 @@
 licenses(["notice"])  # Apache 2
 
 load("//bazel:kotlin_lib.bzl", "envoy_mobile_android_library")
-load("//bazel:envoy_build_system.bzl", "envoy_package")
-
-envoy_package()
 
 envoy_mobile_android_library(
     name = "envoy_engine_lib",

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -1,7 +1,7 @@
 licenses(["notice"])  # Apache 2
 
 load("//bazel:aar_with_jni.bzl", "aar_with_jni")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_jvm_library")
+load("//bazel:kotlin_lib.bzl", "envoy_mobile_kt_aar_android_library", "envoy_mobile_kt_library")
 
 aar_with_jni(
     name = "android_aar",
@@ -10,25 +10,17 @@ aar_with_jni(
     visibility = ["//visibility:public"],
 )
 
-# Android library drops exported dependencies from dependent rules. The kt_android_library
-#  internally is just a macro which wraps two rules into one:
-#  https://github.com/bazelbuild/rules_kotlin/blob/326661e7e705d14e754abc2765837aa61bddf205/kotlin/internal/jvm/android.bzl#L28.
-#  This causes the sources to be exported and dropped due to it being a transitive dependency.
-#  To get around this, we have to redeclare the sources from envoy_engine_lib here in order to be pulled into the
-#  kotlin jar.
-kt_android_library(
+envoy_mobile_kt_aar_android_library(
     name = "envoy_lib",
     srcs = [
         "Envoy.kt",
-        "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_srcs",
     ],
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "EnvoyManifest.xml",
-    visibility = ["//visibility:public"],
     deps = ["//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib"],
 )
 
-kt_jvm_library(
+envoy_mobile_kt_library(
     name = "envoy_interfaces_lib",
     srcs = [
         "Request.kt",

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -28,5 +28,4 @@ envoy_mobile_kt_library(
         "RequestMethod.kt",
         "RetryPolicy.kt",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -17,8 +17,8 @@ envoy_mobile_kt_aar_android_library(
     ],
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "EnvoyManifest.xml",
-    deps = ["//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib"],
     visibility = ["//visibility:public"],
+    deps = ["//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib"],
 )
 
 envoy_mobile_kt_library(

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -18,6 +18,7 @@ envoy_mobile_kt_aar_android_library(
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "EnvoyManifest.xml",
     deps = ["//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib"],
+    visibility = ["//visibility:public"],
 )
 
 envoy_mobile_kt_library(
@@ -28,4 +29,5 @@ envoy_mobile_kt_library(
         "RequestMethod.kt",
         "RetryPolicy.kt",
     ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
We currently have to redeclare our sources in the `srcs` argument for the top level library consumed by the `aar_with_jni` macro. The reason is because the `aar_with_jni` doesn't get visibility onto the transitive dependencies of the provided library. Since we are using `kt_jvm_library`, which internally creates two rules and encloses the dependencies within them, the library we provide does not expose any dependencies for the `aar_with_jni` target.

This makes it very complicated to create new libraries because for every new library, we have to create a `filegroup` which the top level `envoy_lib` needs to depend on directly in the `srcs`.

This is a total bazel macro hack to hide away this detail for us. The limitation here is that the top level `envoy_lib` needs to directly depend on the targets.

Alternative solution is to write a rule which traverses the dependencies and takes out the appropriate `srcs` from each dependency and transitive dependency using an `envoy_mobile_kt_library`.

Before:
```
aar_with_jni(
    name = "android_aar",
    android_library = "envoy_lib",
    archive_name = "envoy",
    visibility = ["//visibility:public"],
)
kt_android_library(
    name = "envoy_lib",
    srcs = [
        "Envoy.kt",
        "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_srcs", # Redundancy
    ],
    custom_package = "io.envoyproxy.envoymobile",
    manifest = "EnvoyManifest.xml",
    visibility = ["//visibility:public"],
    deps = ["//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib"],
)
# Redundancy
filegroup(
    name = "envoy_engine_srcs",
    srcs = ["EnvoyEngine.java"],
    visibility = ["//visibility:public"],
)
android_library(
    name = "envoy_engine_lib",
    srcs = [":envoy_engine_srcs"], # Redundancy
    custom_package = "io.envoyproxy.envoymobile.engine",
    manifest = "EnvoyEngineManifest.xml",
    visibility = ["//visibility:public"],
    deps = ["//library/common:envoy_jni_interface_lib"],
)
```
Now:
```

aar_with_jni(
    name = "android_aar",
    android_library = "envoy_lib",
    archive_name = "envoy",
    visibility = ["//visibility:public"],
)
envoy_mobile_kt_aar_android_library(
    name = "envoy_lib",
    srcs = [
        "Envoy.kt",
    ],
    custom_package = "io.envoyproxy.envoymobile",
    manifest = "EnvoyManifest.xml",
    deps = ["//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib"],
)
envoy_mobile_android_library(
    name = "envoy_engine_lib",
    srcs = ["EnvoyEngine.java"],
    custom_package = "io.envoyproxy.envoymobile.engine",
    manifest = "EnvoyEngineManifest.xml",
    deps = ["//library/common:envoy_jni_interface_lib"],
)
```
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: add bazel macros for easier kt target declaration
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
