### PR TITLE
swift: fix RetryPolicy equatability & add tests

### DIFF
--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -45,3 +45,17 @@ public final class RetryPolicy: NSObject {
     self.perRetryTimeoutMS = perRetryTimeoutMS
   }
 }
+
+// MARK: - Equatable overrides
+
+extension RetryPolicy {
+  public override func isEqual(_ object: Any?) -> Bool {
+    guard let other = object as? RetryPolicy else {
+      return false
+    }
+
+    return self.maxRetryCount == other.maxRetryCount
+      && self.retryOn == other.retryOn
+      && self.perRetryTimeoutMS == other.perRetryTimeoutMS
+  }
+}

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -3,8 +3,8 @@ licenses(["notice"])  # Apache 2
 load("//bazel:swift_test.bzl", "envoy_mobile_swift_test")
 
 envoy_mobile_swift_test(
-    name = "sample_test",
+    name = "retry_policy_tests",
     srcs = [
-        "SampleTest.swift",
+        "RetryPolicyTests.swift",
     ],
 )

--- a/library/swift/test/RetryPolicyTests.swift
+++ b/library/swift/test/RetryPolicyTests.swift
@@ -1,0 +1,24 @@
+import Envoy
+import XCTest
+
+final class RetryPolicyTests: XCTestCase {
+  func testRetryPoliciesAreEqualWhenPropertiesAreEqual() {
+    let policy1 = RetryPolicy(maxRetryCount: 123,
+                              retryOn: [.connectFailure],
+                              perRetryTimeoutMS: 8000)
+    let policy2 = RetryPolicy(maxRetryCount: 123,
+                              retryOn: [.connectFailure],
+                              perRetryTimeoutMS: 8000)
+    XCTAssertEqual(policy1, policy2)
+  }
+
+  func testPointersAreNotEqualWhenInstancesAreDifferent() {
+    let policy1 = RetryPolicy(maxRetryCount: 123,
+                              retryOn: [.connectFailure],
+                              perRetryTimeoutMS: 8000)
+    let policy2 = RetryPolicy(maxRetryCount: 123,
+                              retryOn: [.connectFailure],
+                              perRetryTimeoutMS: 8000)
+    XCTAssert(policy1 !== policy2)
+  }
+}


### PR DESCRIPTION
Because `RetryPolicy` inherits from `NSObject` in order to be visible to Objective-C, we need to implement our own equatable comparison in order for `==` to work as intended (using property comparison instead of pointer comparison).

Adds tests to verify this.

Signed-off-by: Michael Rebello <mrebello@lyft.com>
