### PR TITLE
swift: add tests for request builders

### DIFF
--- a/library/swift/src/Request.swift
+++ b/library/swift/src/Request.swift
@@ -41,3 +41,20 @@ public final class Request: NSObject {
     self.retryPolicy = retryPolicy
   }
 }
+
+// MARK: - Equatable overrides
+
+extension Request {
+  public override func isEqual(_ object: Any?) -> Bool {
+    guard let other = object as? Request else {
+      return false
+    }
+
+    return self.method == other.method
+      && self.url == other.url
+      && self.headers == other.headers
+      && self.trailers == other.trailers
+      && self.body == other.body
+      && self.retryPolicy == other.retryPolicy
+  }
+}

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -3,6 +3,13 @@ licenses(["notice"])  # Apache 2
 load("//bazel:swift_test.bzl", "envoy_mobile_swift_test")
 
 envoy_mobile_swift_test(
+    name = "request_builder_tests",
+    srcs = [
+        "RequestBuilderTests.swift",
+    ],
+)
+
+envoy_mobile_swift_test(
     name = "retry_policy_tests",
     srcs = [
         "RetryPolicyTests.swift",

--- a/library/swift/test/RequestBuilderTests.swift
+++ b/library/swift/test/RequestBuilderTests.swift
@@ -1,0 +1,189 @@
+import Envoy
+import Foundation
+import XCTest
+
+// swiftlint:disable:next force_unwrapping
+private let kURL = URL(string: "http://0.0.0.0:9001/api.lyft.com/demo.txt")!
+private let kBodyData = Data([1, 2, 3, 4])
+
+private let kRetryPolicy1 = RetryPolicy(maxRetryCount: 123,
+                                        retryOn: [.connectFailure, .fiveXX],
+                                        perRetryTimeoutMS: 9000)
+
+private let kRetryPolicy2 = RetryPolicy(maxRetryCount: 123,
+                                        retryOn: [.connectFailure, .fiveXX],
+                                        perRetryTimeoutMS: 9000)
+
+private let kRequestBuilder1 = RequestBuilder(method: .post, url: kURL)
+  .addBody(kBodyData)
+  .addRetryPolicy(kRetryPolicy1)
+  .addHeader(name: "foo", value: "1")
+  .addHeader(name: "foo", value: "2")
+  .addHeader(name: "bar", value: "3")
+  .addTrailer(name: "baz", value: "4")
+  .addTrailer(name: "baz", value: "5")
+
+private let kRequestBuilder2 = RequestBuilder(method: .post, url: kURL)
+  .addBody(kBodyData)
+  .addRetryPolicy(kRetryPolicy2)
+  .addHeader(name: "foo", value: "1")
+  .addHeader(name: "foo", value: "2")
+  .addHeader(name: "bar", value: "3")
+  .addTrailer(name: "baz", value: "4")
+  .addTrailer(name: "baz", value: "5")
+
+final class RequestBuilderTests: XCTestCase {
+  // MARK: - Method
+
+  func testHasMatchingMethodPresentInRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .build()
+    XCTAssertEqual(.post, request.method)
+  }
+
+  // MARK: - URL
+
+  func testHasMatchingURLPresentInRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .build()
+    XCTAssertEqual(kURL.absoluteString, request.url.absoluteString)
+  }
+
+  // MARK: - Body data
+
+  func testAddingRequestDataHasBodyPresentInRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addBody(kBodyData)
+      .build()
+    XCTAssertEqual(kBodyData, request.body)
+  }
+
+  func testNotAddingRequestDataHasNilBodyInRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .build()
+    XCTAssertNil(request.body)
+  }
+
+  // MARK: - Retry policy
+
+  func testAddingRetryPolicyHasRetryPolicyInRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addRetryPolicy(kRetryPolicy1)
+      .build()
+    XCTAssertEqual(kRetryPolicy1, request.retryPolicy)
+  }
+
+  func testNotAddingRetryPolicyHasNilRetryPolicyInRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .build()
+    XCTAssertNil(request.retryPolicy)
+  }
+
+  // MARK: - Headers
+
+  func testAddingNewHeaderAddsToListOfHeaderKeys() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addHeader(name: "foo", value: "bar")
+      .build()
+    XCTAssertEqual(["bar"], request.headers["foo"])
+  }
+
+  func testRemovingSpecificHeaderKeyRemovesAllOfItsValuesFromRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addHeader(name: "foo", value: "1")
+      .addHeader(name: "foo", value: "2")
+      .removeHeaders(name: "foo")
+      .build()
+    XCTAssertNil(request.headers["foo"])
+  }
+
+  func testRemovingSpecificHeaderKeyDoesNotRemoveOtherKeysFromRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addHeader(name: "foo", value: "1")
+      .addHeader(name: "bar", value: "2")
+      .removeHeaders(name: "foo")
+      .build()
+    XCTAssertEqual(["bar": ["2"]], request.headers)
+  }
+
+  func testRemovingSpecificHeaderValueRemovesItFromRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addHeader(name: "foo", value: "1")
+      .addHeader(name: "foo", value: "2")
+      .addHeader(name: "foo", value: "3")
+      .removeHeader(name: "foo", value: "2")
+      .build()
+    XCTAssertEqual(["1", "3"], request.headers["foo"])
+  }
+
+  func testRemovingAllHeaderValuesRemovesKeyFromRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addHeader(name: "foo", value: "1")
+      .addHeader(name: "foo", value: "2")
+      .removeHeader(name: "foo", value: "1")
+      .removeHeader(name: "foo", value: "2")
+      .build()
+    XCTAssertNil(request.headers["foo"])
+  }
+
+  // MARK: - Trailers
+
+  func testAddingNewTrailerAppendsToListOfTrailerKeys() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addTrailer(name: "foo", value: "bar")
+      .build()
+    XCTAssertEqual(["bar"], request.trailers["foo"])
+  }
+
+  func testRemovingSpecificTrailerKeyRemovesAllOfItsValuesFromRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addTrailer(name: "foo", value: "1")
+      .addTrailer(name: "foo", value: "2")
+      .removeTrailers(name: "foo")
+      .build()
+    XCTAssertNil(request.trailers["foo"])
+  }
+
+  func testRemovingSpecificTrailerKeyDoesNotRemoveOtherKeysFromRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addTrailer(name: "foo", value: "1")
+      .addTrailer(name: "bar", value: "2")
+      .removeTrailers(name: "foo")
+      .build()
+    XCTAssertEqual(["bar": ["2"]], request.trailers)
+  }
+
+  func testRemovingSpecificTrailerValueRemovesItFromRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addTrailer(name: "foo", value: "1")
+      .addTrailer(name: "foo", value: "2")
+      .addTrailer(name: "foo", value: "3")
+      .removeTrailer(name: "foo", value: "2")
+      .build()
+    XCTAssertEqual(["1", "3"], request.trailers["foo"])
+  }
+
+  func testRemovingAllTrailerValuesRemovesKeyFromRequest() {
+    let request = RequestBuilder(method: .post, url: kURL)
+      .addTrailer(name: "foo", value: "1")
+      .addTrailer(name: "foo", value: "2")
+      .removeTrailer(name: "foo", value: "1")
+      .removeTrailer(name: "foo", value: "2")
+      .build()
+    XCTAssertNil(request.trailers["foo"])
+  }
+
+  // MARK: - Request conversion
+
+  func testRequestsAreEqualWhenPropertiesAreEqual() {
+    let request1 = kRequestBuilder1.build()
+    let request2 = kRequestBuilder2.build()
+    XCTAssertEqual(request1, request2)
+  }
+
+  func testPointersAreNotEqualWhenInstancesAreDifferent() {
+    let request1 = kRequestBuilder1.build()
+    let request2 = request1.newBuilder().build()
+    XCTAssertEqual(request1, request2)
+  }
+}

--- a/library/swift/test/RequestBuilderTests.swift
+++ b/library/swift/test/RequestBuilderTests.swift
@@ -5,32 +5,9 @@ import XCTest
 // swiftlint:disable:next force_unwrapping
 private let kURL = URL(string: "http://0.0.0.0:9001/api.lyft.com/demo.txt")!
 private let kBodyData = Data([1, 2, 3, 4])
-
-private let kRetryPolicy1 = RetryPolicy(maxRetryCount: 123,
-                                        retryOn: [.connectFailure, .fiveXX],
-                                        perRetryTimeoutMS: 9000)
-
-private let kRetryPolicy2 = RetryPolicy(maxRetryCount: 123,
-                                        retryOn: [.connectFailure, .fiveXX],
-                                        perRetryTimeoutMS: 9000)
-
-private let kRequestBuilder1 = RequestBuilder(method: .post, url: kURL)
-  .addBody(kBodyData)
-  .addRetryPolicy(kRetryPolicy1)
-  .addHeader(name: "foo", value: "1")
-  .addHeader(name: "foo", value: "2")
-  .addHeader(name: "bar", value: "3")
-  .addTrailer(name: "baz", value: "4")
-  .addTrailer(name: "baz", value: "5")
-
-private let kRequestBuilder2 = RequestBuilder(method: .post, url: kURL)
-  .addBody(kBodyData)
-  .addRetryPolicy(kRetryPolicy2)
-  .addHeader(name: "foo", value: "1")
-  .addHeader(name: "foo", value: "2")
-  .addHeader(name: "bar", value: "3")
-  .addTrailer(name: "baz", value: "4")
-  .addTrailer(name: "baz", value: "5")
+private let kRetryPolicy = RetryPolicy(maxRetryCount: 123,
+                                       retryOn: [.connectFailure, .fiveXX],
+                                       perRetryTimeoutMS: 9000)
 
 final class RequestBuilderTests: XCTestCase {
   // MARK: - Method
@@ -68,9 +45,9 @@ final class RequestBuilderTests: XCTestCase {
 
   func testAddingRetryPolicyHasRetryPolicyInRequest() {
     let request = RequestBuilder(method: .post, url: kURL)
-      .addRetryPolicy(kRetryPolicy1)
+      .addRetryPolicy(kRetryPolicy)
       .build()
-    XCTAssertEqual(kRetryPolicy1, request.retryPolicy)
+    XCTAssertEqual(kRetryPolicy, request.retryPolicy)
   }
 
   func testNotAddingRetryPolicyHasNilRetryPolicyInRequest() {
@@ -176,14 +153,33 @@ final class RequestBuilderTests: XCTestCase {
   // MARK: - Request conversion
 
   func testRequestsAreEqualWhenPropertiesAreEqual() {
-    let request1 = kRequestBuilder1.build()
-    let request2 = kRequestBuilder2.build()
+    let request1 = self.newRequestBuilder().build()
+    let request2 = self.newRequestBuilder().build()
     XCTAssertEqual(request1, request2)
   }
 
   func testPointersAreNotEqualWhenInstancesAreDifferent() {
-    let request1 = kRequestBuilder1.build()
+    let request1 = self.newRequestBuilder().build()
+    let request2 = self.newRequestBuilder().build()
+    XCTAssert(request1 !== request2)
+  }
+
+  func testConvertingToBuilderAndBackMaintainsEquality() {
+    let request1 = self.newRequestBuilder().build()
     let request2 = request1.newBuilder().build()
     XCTAssertEqual(request1, request2)
+  }
+
+  // MARK: - Private
+
+  private func newRequestBuilder() -> RequestBuilder {
+    return RequestBuilder(method: .post, url: kURL)
+      .addBody(kBodyData)
+      .addRetryPolicy(kRetryPolicy)
+      .addHeader(name: "foo", value: "1")
+      .addHeader(name: "foo", value: "2")
+      .addHeader(name: "bar", value: "3")
+      .addTrailer(name: "baz", value: "4")
+      .addTrailer(name: "baz", value: "5")
   }
 }

--- a/library/swift/test/SampleTest.swift
+++ b/library/swift/test/SampleTest.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-final class SampleTest: XCTestCase {
-    func testExample() {
-        print("Test succeeds")
-    }
-}


### PR DESCRIPTION
Adds tests for the request builders similar to the ones available on master for Kotlin.

Also fixes the `Equatable` comparison of `Request` by overriding `isEqual`. This is required since this type subclasses `NSObject` to be visible to Objective-C, and we want property comparison instead of pointer comparison here.

Resolves https://github.com/lyft/envoy-mobile/issues/252

Signed-off-by: Michael Rebello <mrebello@lyft.com>