### PR TITLE
ci: temporarily disable mac_swift_helloworld

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -353,14 +353,18 @@ stages:
           # First start the iOS simulator.
           # Interestingly bazel run does not start the simulator in CI.
           # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
-          - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
-            displayName: 'Start the iOS simulator'
-          # Run the app in the background and redirect logs.
-          - script: ./bazelw run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
-            displayName: 'Run swift app'
-          # Wait for the app to start and get some requests/responses.
-          - script: sleep 60
-            displayName: 'Sleep'
-          # Check for the sentinel value that shows the app is alive and well.
-          - script: cat /tmp/envoy.log | grep 'Hello, world!'
-            displayName: 'Check liveliness'
+          #
+          # Temporarily disabled due to flakiness. Tracking in this issue:
+          # https://github.com/lyft/envoy-mobile/issues/271
+          #
+          # - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
+          #   displayName: 'Start the iOS simulator'
+          # # Run the app in the background and redirect logs.
+          # - script: ./bazelw run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
+          #   displayName: 'Run swift app'
+          # # Wait for the app to start and get some requests/responses.
+          # - script: sleep 60
+          #   displayName: 'Sleep'
+          # # Check for the sentinel value that shows the app is alive and well.
+          # - script: cat /tmp/envoy.log | grep 'Hello, world!'
+          #   displayName: 'Check liveliness'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -329,38 +329,38 @@ stages:
       #    # Check for the sentinel value that shows the app is alive and well.
       #    - script: cat /tmp/envoy.log | grep 'Hello, world!'
       #      displayName: 'Check liveliness'
-      - job: mac_swift_helloworld
-        dependsOn: mac_dist
-        timeoutInMinutes: 60
-        pool:
-          vmImage: 'macos-10.14'
-        steps:
-          - checkout: self
-            submodules: true
-          - script: ./ci/mac_ci_setup.sh
-            displayName: 'Install dependencies'
-          - script: mkdir -p dist/Envoy.framework
-            displayName: 'Create directory for distributable'
-          - task: DownloadPipelineArtifact@0
-            displayName: 'Download Envoy.framework distributable'
-            inputs:
-              artifactName: Envoy.framework
-              targetPath: dist/Envoy.framework
-          - script: ./bazelw build --config=ios //examples/swift/hello_world:app
-            displayName: 'Build swift app'
-          # Now check that the app actually runs on the simulator.
-          # This is a non-ideal way to check for liveliness, but works for now.
-          # First start the iOS simulator.
-          # Interestingly bazel run does not start the simulator in CI.
-          # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
-          - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
-            displayName: 'Start the iOS simulator'
-          # Run the app in the background and redirect logs.
-          - script: ./bazelw run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
-            displayName: 'Run swift app'
-          # Wait for the app to start and get some requests/responses.
-          - script: sleep 60
-            displayName: 'Sleep'
-          # Check for the sentinel value that shows the app is alive and well.
-          - script: cat /tmp/envoy.log | grep 'Hello, world!'
-            displayName: 'Check liveliness'
+      # - job: mac_swift_helloworld
+      #   dependsOn: mac_dist
+      #   timeoutInMinutes: 60
+      #   pool:
+      #     vmImage: 'macos-10.14'
+      #   steps:
+      #     - checkout: self
+      #       submodules: true
+      #     - script: ./ci/mac_ci_setup.sh
+      #       displayName: 'Install dependencies'
+      #     - script: mkdir -p dist/Envoy.framework
+      #       displayName: 'Create directory for distributable'
+      #     - task: DownloadPipelineArtifact@0
+      #       displayName: 'Download Envoy.framework distributable'
+      #       inputs:
+      #         artifactName: Envoy.framework
+      #         targetPath: dist/Envoy.framework
+      #     - script: ./bazelw build --config=ios //examples/swift/hello_world:app
+      #       displayName: 'Build swift app'
+      #     # Now check that the app actually runs on the simulator.
+      #     # This is a non-ideal way to check for liveliness, but works for now.
+      #     # First start the iOS simulator.
+      #     # Interestingly bazel run does not start the simulator in CI.
+      #     # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
+      #     - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
+      #       displayName: 'Start the iOS simulator'
+      #     # Run the app in the background and redirect logs.
+      #     - script: ./bazelw run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
+      #       displayName: 'Run swift app'
+      #     # Wait for the app to start and get some requests/responses.
+      #     - script: sleep 60
+      #       displayName: 'Sleep'
+      #     # Check for the sentinel value that shows the app is alive and well.
+      #     - script: cat /tmp/envoy.log | grep 'Hello, world!'
+      #       displayName: 'Check liveliness'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -329,38 +329,38 @@ stages:
       #    # Check for the sentinel value that shows the app is alive and well.
       #    - script: cat /tmp/envoy.log | grep 'Hello, world!'
       #      displayName: 'Check liveliness'
-      # - job: mac_swift_helloworld
-      #   dependsOn: mac_dist
-      #   timeoutInMinutes: 60
-      #   pool:
-      #     vmImage: 'macos-10.14'
-      #   steps:
-      #     - checkout: self
-      #       submodules: true
-      #     - script: ./ci/mac_ci_setup.sh
-      #       displayName: 'Install dependencies'
-      #     - script: mkdir -p dist/Envoy.framework
-      #       displayName: 'Create directory for distributable'
-      #     - task: DownloadPipelineArtifact@0
-      #       displayName: 'Download Envoy.framework distributable'
-      #       inputs:
-      #         artifactName: Envoy.framework
-      #         targetPath: dist/Envoy.framework
-      #     - script: ./bazelw build --config=ios //examples/swift/hello_world:app
-      #       displayName: 'Build swift app'
-      #     # Now check that the app actually runs on the simulator.
-      #     # This is a non-ideal way to check for liveliness, but works for now.
-      #     # First start the iOS simulator.
-      #     # Interestingly bazel run does not start the simulator in CI.
-      #     # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
-      #     - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
-      #       displayName: 'Start the iOS simulator'
-      #     # Run the app in the background and redirect logs.
-      #     - script: ./bazelw run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
-      #       displayName: 'Run swift app'
-      #     # Wait for the app to start and get some requests/responses.
-      #     - script: sleep 60
-      #       displayName: 'Sleep'
-      #     # Check for the sentinel value that shows the app is alive and well.
-      #     - script: cat /tmp/envoy.log | grep 'Hello, world!'
-      #       displayName: 'Check liveliness'
+      - job: mac_swift_helloworld
+        dependsOn: mac_dist
+        timeoutInMinutes: 60
+        pool:
+          vmImage: 'macos-10.14'
+        steps:
+          - checkout: self
+            submodules: true
+          - script: ./ci/mac_ci_setup.sh
+            displayName: 'Install dependencies'
+          - script: mkdir -p dist/Envoy.framework
+            displayName: 'Create directory for distributable'
+          - task: DownloadPipelineArtifact@0
+            displayName: 'Download Envoy.framework distributable'
+            inputs:
+              artifactName: Envoy.framework
+              targetPath: dist/Envoy.framework
+          - script: ./bazelw build --config=ios //examples/swift/hello_world:app
+            displayName: 'Build swift app'
+          # # Now check that the app actually runs on the simulator.
+          # # This is a non-ideal way to check for liveliness, but works for now.
+          # # First start the iOS simulator.
+          # # Interestingly bazel run does not start the simulator in CI.
+          # # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
+          # - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
+          #   displayName: 'Start the iOS simulator'
+          # # Run the app in the background and redirect logs.
+          # - script: ./bazelw run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
+          #   displayName: 'Run swift app'
+          # # Wait for the app to start and get some requests/responses.
+          # - script: sleep 60
+          #   displayName: 'Sleep'
+          # # Check for the sentinel value that shows the app is alive and well.
+          # - script: cat /tmp/envoy.log | grep 'Hello, world!'
+          #   displayName: 'Check liveliness'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -348,19 +348,19 @@ stages:
               targetPath: dist/Envoy.framework
           - script: ./bazelw build --config=ios //examples/swift/hello_world:app
             displayName: 'Build swift app'
-          # # Now check that the app actually runs on the simulator.
-          # # This is a non-ideal way to check for liveliness, but works for now.
-          # # First start the iOS simulator.
-          # # Interestingly bazel run does not start the simulator in CI.
-          # # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
-          # - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
-          #   displayName: 'Start the iOS simulator'
-          # # Run the app in the background and redirect logs.
-          # - script: ./bazelw run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
-          #   displayName: 'Run swift app'
-          # # Wait for the app to start and get some requests/responses.
-          # - script: sleep 60
-          #   displayName: 'Sleep'
-          # # Check for the sentinel value that shows the app is alive and well.
-          # - script: cat /tmp/envoy.log | grep 'Hello, world!'
-          #   displayName: 'Check liveliness'
+          # Now check that the app actually runs on the simulator.
+          # This is a non-ideal way to check for liveliness, but works for now.
+          # First start the iOS simulator.
+          # Interestingly bazel run does not start the simulator in CI.
+          # https://github.com/lyft/envoy-mobile/issues/201 for further investigation.
+          - script: npm install -g ios-sim && ios-sim start --devicetypeid "iPhone-X, 12.2"
+            displayName: 'Start the iOS simulator'
+          # Run the app in the background and redirect logs.
+          - script: ./bazelw run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
+            displayName: 'Run swift app'
+          # Wait for the app to start and get some requests/responses.
+          - script: sleep 60
+            displayName: 'Sleep'
+          # Check for the sentinel value that shows the app is alive and well.
+          - script: cat /tmp/envoy.log | grep 'Hello, world!'
+            displayName: 'Check liveliness'


### PR DESCRIPTION
This has proven to be super flaky, failing on almost every PR once or twice. Disabling for now until we're able to debug.

Issue for re-enabling: https://github.com/lyft/envoy-mobile/issues/271

Signed-off-by: Michael Rebello <mrebello@lyft.com>