### PR TITLE
swift: expose URL components instead of URL type

### DIFF
--- a/library/swift/src/Request.swift
+++ b/library/swift/src/Request.swift
@@ -5,8 +5,12 @@ import Foundation
 public final class Request: NSObject {
   /// Method for the request.
   public let method: RequestMethod
-  /// URL for the request.
-  public let url: URL
+  /// The URL scheme for the request (i.e., "https").
+  public let scheme: String
+  /// The URL authority for the request (i.e., "api.foo.com").
+  public let authority: String
+  /// The URL path for the request (i.e., "/foo").
+  public let path: String
   /// Headers to send with the request.
   /// Multiple values for a given name are valid, and will be sent as comma-separated values.
   public let headers: [String: [String]]
@@ -27,14 +31,18 @@ public final class Request: NSObject {
 
   /// Internal initializer called from the builder to create a new request.
   init(method: RequestMethod,
-       url: URL,
+       scheme: String,
+       authority: String,
+       path: String,
        headers: [String: [String]] = [:],
        trailers: [String: [String]] = [:],
        body: Data?,
        retryPolicy: RetryPolicy?)
   {
     self.method = method
-    self.url = url
+    self.scheme = scheme
+    self.authority = authority
+    self.path = path
     self.headers = headers
     self.trailers = trailers
     self.body = body
@@ -51,7 +59,9 @@ extension Request {
     }
 
     return self.method == other.method
-      && self.url == other.url
+      && self.scheme == other.scheme
+      && self.authority == other.authority
+      && self.path == other.path
       && self.headers == other.headers
       && self.trailers == other.trailers
       && self.body == other.body

--- a/library/swift/src/RequestBuilder.swift
+++ b/library/swift/src/RequestBuilder.swift
@@ -4,9 +4,13 @@ import Foundation
 @objcMembers
 public final class RequestBuilder: NSObject {
   /// Method for the request.
-  public private(set) var method: RequestMethod
-  /// URL for the request.
-  public private(set) var url: URL
+  public let method: RequestMethod
+  /// The URL scheme for the request (i.e., "https").
+  public let scheme: String
+  /// The URL authority for the request (i.e., "api.foo.com").
+  public let authority: String
+  /// The URL path for the request (i.e., "/foo").
+  public let path: String
   /// Headers to send with the request.
   /// Multiple values for a given name are valid, and will be sent as comma-separated values.
   public private(set) var headers: [String: [String]] = [:]
@@ -23,7 +27,9 @@ public final class RequestBuilder: NSObject {
   /// Internal initializer used for converting a request back to a builder.
   init(request: Request) {
     self.method = request.method
-    self.url = request.url
+    self.scheme = request.scheme
+    self.authority = request.authority
+    self.path = request.path
     self.headers = request.headers
     self.trailers = request.trailers
     self.body = request.body
@@ -31,9 +37,11 @@ public final class RequestBuilder: NSObject {
   }
 
   /// Public initializer.
-  public init(method: RequestMethod, url: URL) {
+  public init(method: RequestMethod, scheme: String, authority: String, path: String) {
     self.method = method
-    self.url = url
+    self.scheme = scheme
+    self.authority = authority
+    self.path = path
   }
 
   // MARK: - Builder functions
@@ -96,7 +104,9 @@ public final class RequestBuilder: NSObject {
 
   public func build() -> Request {
     return Request(method: self.method,
-                   url: self.url,
+                   scheme: self.scheme,
+                   authority: self.authority,
+                   path: self.path,
                    headers: self.headers,
                    trailers: self.trailers,
                    body: self.body,
@@ -111,16 +121,21 @@ extension Request {
   ///
   /// For example:
   ///
-  /// Request *req = [Request withMethod:RequestMethodGet url:url build:^(RequestBuilder *builder) {
+  /// Request *req = [Request withMethod:RequestMethodGet (...) build:^(RequestBuilder *builder) {
   ///   [builder addBody:bodyData];
   ///   [builder addHeaderWithName:@"x-some-header" value:@"foo"];
   ///   [builder addTrailerWithName:@"x-some-trailer" value:@"foo"];
   /// }];
   @objc
-  public static func with(method: RequestMethod, url: URL, build: (RequestBuilder) -> Void)
+  public static func with(method: RequestMethod,
+                          scheme: String,
+                          authority: String,
+                          path: String,
+                          build: (RequestBuilder) -> Void)
     -> Request
   {
-    let builder = RequestBuilder(method: method, url: url)
+    let builder = RequestBuilder(method: method, scheme: scheme,
+                                 authority: authority, path: path)
     build(builder)
     return builder.build()
   }

--- a/library/swift/test/RequestBuilderTests.swift
+++ b/library/swift/test/RequestBuilderTests.swift
@@ -2,8 +2,6 @@ import Envoy
 import Foundation
 import XCTest
 
-// swiftlint:disable:next force_unwrapping
-private let kURL = URL(string: "http://0.0.0.0:9001/api.lyft.com/demo.txt")!
 private let kBodyData = Data([1, 2, 3, 4])
 private let kRetryPolicy = RetryPolicy(maxRetryCount: 123,
                                        retryOn: [.connectFailure, .fiveXX],
@@ -13,7 +11,8 @@ final class RequestBuilderTests: XCTestCase {
   // MARK: - Method
 
   func testHasMatchingMethodPresentInRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .build()
     XCTAssertEqual(.post, request.method)
   }
@@ -21,22 +20,27 @@ final class RequestBuilderTests: XCTestCase {
   // MARK: - URL
 
   func testHasMatchingURLPresentInRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .build()
-    XCTAssertEqual(kURL.absoluteString, request.url.absoluteString)
+    XCTAssertEqual("https", request.scheme)
+    XCTAssertEqual("api.foo.com", request.authority)
+    XCTAssertEqual("/foo", request.path)
   }
 
   // MARK: - Body data
 
   func testAddingRequestDataHasBodyPresentInRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addBody(kBodyData)
       .build()
     XCTAssertEqual(kBodyData, request.body)
   }
 
   func testNotAddingRequestDataHasNilBodyInRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .build()
     XCTAssertNil(request.body)
   }
@@ -44,14 +48,16 @@ final class RequestBuilderTests: XCTestCase {
   // MARK: - Retry policy
 
   func testAddingRetryPolicyHasRetryPolicyInRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addRetryPolicy(kRetryPolicy)
       .build()
     XCTAssertEqual(kRetryPolicy, request.retryPolicy)
   }
 
   func testNotAddingRetryPolicyHasNilRetryPolicyInRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .build()
     XCTAssertNil(request.retryPolicy)
   }
@@ -59,14 +65,16 @@ final class RequestBuilderTests: XCTestCase {
   // MARK: - Headers
 
   func testAddingNewHeaderAddsToListOfHeaderKeys() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "bar")
       .build()
     XCTAssertEqual(["bar"], request.headers["foo"])
   }
 
   func testRemovingSpecificHeaderKeyRemovesAllOfItsValuesFromRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .removeHeaders(name: "foo")
@@ -75,7 +83,8 @@ final class RequestBuilderTests: XCTestCase {
   }
 
   func testRemovingSpecificHeaderKeyDoesNotRemoveOtherKeysFromRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "bar", value: "2")
       .removeHeaders(name: "foo")
@@ -84,7 +93,8 @@ final class RequestBuilderTests: XCTestCase {
   }
 
   func testRemovingSpecificHeaderValueRemovesItFromRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .addHeader(name: "foo", value: "3")
@@ -94,7 +104,8 @@ final class RequestBuilderTests: XCTestCase {
   }
 
   func testRemovingAllHeaderValuesRemovesKeyFromRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .removeHeader(name: "foo", value: "1")
@@ -106,14 +117,16 @@ final class RequestBuilderTests: XCTestCase {
   // MARK: - Trailers
 
   func testAddingNewTrailerAppendsToListOfTrailerKeys() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addTrailer(name: "foo", value: "bar")
       .build()
     XCTAssertEqual(["bar"], request.trailers["foo"])
   }
 
   func testRemovingSpecificTrailerKeyRemovesAllOfItsValuesFromRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addTrailer(name: "foo", value: "1")
       .addTrailer(name: "foo", value: "2")
       .removeTrailers(name: "foo")
@@ -122,7 +135,8 @@ final class RequestBuilderTests: XCTestCase {
   }
 
   func testRemovingSpecificTrailerKeyDoesNotRemoveOtherKeysFromRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addTrailer(name: "foo", value: "1")
       .addTrailer(name: "bar", value: "2")
       .removeTrailers(name: "foo")
@@ -131,7 +145,8 @@ final class RequestBuilderTests: XCTestCase {
   }
 
   func testRemovingSpecificTrailerValueRemovesItFromRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addTrailer(name: "foo", value: "1")
       .addTrailer(name: "foo", value: "2")
       .addTrailer(name: "foo", value: "3")
@@ -141,7 +156,8 @@ final class RequestBuilderTests: XCTestCase {
   }
 
   func testRemovingAllTrailerValuesRemovesKeyFromRequest() {
-    let request = RequestBuilder(method: .post, url: kURL)
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
       .addTrailer(name: "foo", value: "1")
       .addTrailer(name: "foo", value: "2")
       .removeTrailer(name: "foo", value: "1")
@@ -173,7 +189,7 @@ final class RequestBuilderTests: XCTestCase {
   // MARK: - Private
 
   private func newRequestBuilder() -> RequestBuilder {
-    return RequestBuilder(method: .post, url: kURL)
+    return RequestBuilder(method: .post, scheme: "https", authority: "api.foo.com", path: "/foo")
       .addBody(kBodyData)
       .addRetryPolicy(kRetryPolicy)
       .addHeader(name: "foo", value: "1")


### PR DESCRIPTION
As we bridge over the platform layers to talk to the C/C++ core, we'll need to be able to send headers such as `:method`/`:scheme`/`:authority`.

The `URL` type exposes optionals for these properties, which means we need to either handle them at initialization time or at the time when the request is executed by unwrapping them and throwing/failing.

In order to prevent throwing when deconstructing `URL` components, we are instead updating the interfaces to accept these 3 fields separately.

Signed-off-by: Michael Rebello <mrebello@lyft.com>
