### PR TITLE
ci: disable Swift todo lint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -81,7 +81,6 @@ whitelist_rules:
   - switch_case_alignment
   - switch_case_on_newline
   - syntactic_sugar
-  - todo
   - toggle_bool
   - trailing_comma
   - trailing_newline


### PR DESCRIPTION
This is not enforced in any other languages in this repo, and we have TODOs in other languages and upstream Envoy.

Signed-off-by: Michael Rebello <mrebello@lyft.com>