### PR TITLE
swift: add conversion from RetryPolicy to headers

### DIFF
--- a/library/swift/src/BUILD
+++ b/library/swift/src/BUILD
@@ -14,6 +14,7 @@ swift_static_framework(
         "RequestMethod.swift",
         "ResponseHandler.swift",
         "RetryPolicy.swift",
+        "RetryPolicyMapper.swift",
         "StreamEmitter.swift",
     ],
     module_name = "Envoy",

--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -4,22 +4,22 @@ import Foundation
 /// See the `x-envoy-retry-on` Envoy header for documentation.
 @objc
 public enum RetryRule: Int, CaseIterable {
-  case fiveXX
+  case status5xx
   case gatewayError
   case connectFailure
-  case retriableFourXX
+  case retriable4xx
   case refusedUpstream
 
   /// String representation of this rule.
   var stringValue: String {
     switch self {
-    case .fiveXX:
+    case .status5xx:
       return "5xx"
     case .gatewayError:
       return "gateway-error"
     case .connectFailure:
       return "connect-failure"
-    case .retriableFourXX:
+    case .retriable4xx:
       return "retriable-4xx"
     case .refusedUpstream:
       return "refused-upstream"

--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -44,25 +44,6 @@ public final class RetryPolicy: NSObject {
     self.retryOn = retryOn
     self.perRetryTimeoutMS = perRetryTimeoutMS
   }
-
-  /// Converts the retry policy to a set of headers recognized by Envoy.
-  ///
-  /// - returns: The header representation of the retry policy.
-  func toHeaders() -> [String: String] {
-    var headers = [
-      "x-envoy-max-retries": "\(self.maxRetryCount)",
-      "x-envoy-retry-on": self.retryOn
-        .lazy
-        .map { $0.stringValue }
-        .joined(separator: ","),
-    ]
-
-    if let perRetryTimeoutMS = self.perRetryTimeoutMS {
-      headers["x-envoy-upstream-rq-per-try-timeout-ms"] = "\(perRetryTimeoutMS)"
-    }
-
-    return headers
-  }
 }
 
 // MARK: - Equatable overrides

--- a/library/swift/src/RetryPolicyMapper.swift
+++ b/library/swift/src/RetryPolicyMapper.swift
@@ -1,0 +1,20 @@
+extension RetryPolicy {
+  /// Converts the retry policy to a set of headers recognized by Envoy.
+  ///
+  /// - returns: The header representation of the retry policy.
+  func toHeaders() -> [String: String] {
+    var headers = [
+      "x-envoy-max-retries": "\(self.maxRetryCount)",
+      "x-envoy-retry-on": self.retryOn
+        .lazy
+        .map { $0.stringValue }
+        .joined(separator: ","),
+    ]
+
+    if let perRetryTimeoutMS = self.perRetryTimeoutMS {
+      headers["x-envoy-upstream-rq-per-try-timeout-ms"] = "\(perRetryTimeoutMS)"
+    }
+
+    return headers
+  }
+}

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -15,3 +15,10 @@ envoy_mobile_swift_test(
         "RetryPolicyTests.swift",
     ],
 )
+
+envoy_mobile_swift_test(
+    name = "retry_policy_mapper_tests",
+    srcs = [
+        "RetryPolicyMapperTests.swift",
+    ],
+)

--- a/library/swift/test/RequestBuilderTests.swift
+++ b/library/swift/test/RequestBuilderTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 private let kBodyData = Data([1, 2, 3, 4])
 private let kRetryPolicy = RetryPolicy(maxRetryCount: 123,
-                                       retryOn: [.connectFailure, .fiveXX],
+                                       retryOn: [.connectFailure, .status5xx],
                                        perRetryTimeoutMS: 9000)
 
 final class RequestBuilderTests: XCTestCase {

--- a/library/swift/test/RetryPolicyMapperTests.swift
+++ b/library/swift/test/RetryPolicyMapperTests.swift
@@ -1,0 +1,29 @@
+@testable import Envoy
+import XCTest
+
+final class RetryPolicyMapperTests: XCTestCase {
+  func testConvertingToHeadersWithPerRetryTimeoutIncludesAllHeaders() {
+    let policy = RetryPolicy(maxRetryCount: 123,
+                             retryOn: RetryRule.allCases,
+                             perRetryTimeoutMS: 9001)
+    let expectedHeaders = [
+      "x-envoy-max-retries": "123",
+      "x-envoy-retry-on": "5xx,gateway-error,connect-failure,retriable-4xx,refused-upstream",
+      "x-envoy-upstream-rq-per-try-timeout-ms": "9001",
+    ]
+
+    XCTAssertEqual(expectedHeaders, policy.toHeaders())
+  }
+
+  func testConvertingToHeadersWithoutRetryTimeoutExcludesPerRetryTimeoutHeader() {
+    let policy = RetryPolicy(maxRetryCount: 123,
+                             retryOn: RetryRule.allCases,
+                             perRetryTimeoutMS: nil)
+    let expectedHeaders = [
+      "x-envoy-max-retries": "123",
+      "x-envoy-retry-on": "5xx,gateway-error,connect-failure,retriable-4xx,refused-upstream",
+    ]
+
+    XCTAssertEqual(expectedHeaders, policy.toHeaders())
+  }
+}

--- a/library/swift/test/RetryPolicyTests.swift
+++ b/library/swift/test/RetryPolicyTests.swift
@@ -1,36 +1,7 @@
-@testable import Envoy
+import Envoy
 import XCTest
 
 final class RetryPolicyTests: XCTestCase {
-  // MARK: - Conversions
-
-  func testConvertingToHeadersWithPerRetryTimeoutIncludesAllHeaders() {
-    let policy = RetryPolicy(maxRetryCount: 123,
-                             retryOn: RetryRule.allCases,
-                             perRetryTimeoutMS: 9001)
-    let expectedHeaders = [
-      "x-envoy-max-retries": "123",
-      "x-envoy-retry-on": "5xx,gateway-error,connect-failure,retriable-4xx,refused-upstream",
-      "x-envoy-upstream-rq-per-try-timeout-ms": "9001",
-    ]
-
-    XCTAssertEqual(expectedHeaders, policy.toHeaders())
-  }
-
-  func testConvertingToHeadersWithoutRetryTimeoutExcludesPerRetryTimeoutHeader() {
-    let policy = RetryPolicy(maxRetryCount: 123,
-                             retryOn: RetryRule.allCases,
-                             perRetryTimeoutMS: nil)
-    let expectedHeaders = [
-      "x-envoy-max-retries": "123",
-      "x-envoy-retry-on": "5xx,gateway-error,connect-failure,retriable-4xx,refused-upstream",
-    ]
-
-    XCTAssertEqual(expectedHeaders, policy.toHeaders())
-  }
-
-  // MARK: - Equatability
-
   func testRetryPoliciesAreEqualWhenPropertiesAreEqual() {
     let policy1 = RetryPolicy(maxRetryCount: 123,
                               retryOn: [.connectFailure],

--- a/library/swift/test/RetryPolicyTests.swift
+++ b/library/swift/test/RetryPolicyTests.swift
@@ -10,9 +10,7 @@ final class RetryPolicyTests: XCTestCase {
                              perRetryTimeoutMS: 9001)
     let expectedHeaders = [
       "x-envoy-max-retries": "123",
-      "x-envoy-retry-on": RetryRule.allCases
-        .map { $0.stringValue }
-        .joined(separator: ","),
+      "x-envoy-retry-on": "5xx,gateway-error,connect-failure,retriable-4xx,refused-upstream",
       "x-envoy-upstream-rq-per-try-timeout-ms": "9001",
     ]
 
@@ -25,9 +23,7 @@ final class RetryPolicyTests: XCTestCase {
                              perRetryTimeoutMS: nil)
     let expectedHeaders = [
       "x-envoy-max-retries": "123",
-      "x-envoy-retry-on": RetryRule.allCases
-        .map { $0.stringValue }
-        .joined(separator: ","),
+      "x-envoy-retry-on": "5xx,gateway-error,connect-failure,retriable-4xx,refused-upstream",
     ]
 
     XCTAssertEqual(expectedHeaders, policy.toHeaders())


### PR DESCRIPTION
Adds converters to go from `RetryPolicy` to a set of headers that upstream Envoy understands.

This will be utilized by the request logic in the `Envoy` class.

Signed-off-by: Michael Rebello <mrebello@lyft.com>