### PR TITLE
kotlin: expose URL components instead of URL type

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
@@ -4,7 +4,7 @@ package io.envoyproxy.envoymobile
  * Represents an Envoy HTTP request. Use `RequestBuilder` to construct new instances.
  *
  * @param method Method for the request.
- * @param scheme /// The URL scheme for the request (i.e., "https").
+ * @param scheme The URL scheme for the request (i.e., "https").
  * @param authority The URL authority for the request (i.e., "api.foo.com").
  * @param path The URL path for the request (i.e., "/foo").
  */
@@ -65,6 +65,4 @@ class Request internal constructor(
     result = 31 * result + (retryPolicy?.hashCode() ?: 0)
     return result
   }
-
-
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
@@ -5,7 +5,7 @@ package io.envoyproxy.envoymobile
  *
  * @param method Method for the request.
  * @param scheme /// The URL scheme for the request (i.e., "https").
- * @param authority The URL authority for the request (i.e., "api.envoyproxy.io"). # TODO
+ * @param authority The URL authority for the request (i.e., "api.foo.com").
  * @param path The URL path for the request (i.e., "/foo").
  */
 class Request internal constructor(

--- a/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
@@ -1,10 +1,18 @@
 package io.envoyproxy.envoymobile
 
-import java.net.URL
-
+/**
+ * Represents an Envoy HTTP request. Use `RequestBuilder` to construct new instances.
+ *
+ * @param method Method for the request.
+ * @param scheme /// The URL scheme for the request (i.e., "https").
+ * @param authority The URL authority for the request (i.e., "api.envoyproxy.io"). # TODO
+ * @param path The URL path for the request (i.e., "/foo").
+ */
 class Request internal constructor(
     val method: RequestMethod,
-    val url: URL,
+    val scheme: String,
+    val authority: String,
+    val path: String,
     val headers: Map<String, List<String>>,
     val trailers: Map<String, List<String>>,
     val body: ByteArray?,
@@ -18,7 +26,7 @@ class Request internal constructor(
    * @return the builder.
    */
   fun toBuilder(): RequestBuilder {
-    return RequestBuilder(url, method)
+    return RequestBuilder(method, scheme, authority, path)
         .setHeaders(headers)
         .setTrailers(trailers)
         .addBody(body)
@@ -32,7 +40,9 @@ class Request internal constructor(
     other as Request
 
     if (method != other.method) return false
-    if (url != other.url) return false
+    if (scheme != other.scheme) return false
+    if (authority != other.authority) return false
+    if (path != other.path) return false
     if (headers != other.headers) return false
     if (trailers != other.trailers) return false
     if (body != null) {
@@ -46,11 +56,15 @@ class Request internal constructor(
 
   override fun hashCode(): Int {
     var result = method.hashCode()
-    result = 31 * result + url.hashCode()
+    result = 31 * result + scheme.hashCode()
+    result = 31 * result + authority.hashCode()
+    result = 31 * result + path.hashCode()
     result = 31 * result + headers.hashCode()
     result = 31 * result + trailers.hashCode()
     result = 31 * result + (body?.contentHashCode() ?: 0)
     result = 31 * result + (retryPolicy?.hashCode() ?: 0)
     return result
   }
+
+
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
@@ -6,7 +6,7 @@ package io.envoyproxy.envoymobile
  *
  * @param method Method for the request.
  * @param scheme /// The URL scheme for the request (i.e., "https").
- * @param authority The URL authority for the request (i.e., "api.envoyproxy.io"). # TODO
+ * @param authority The URL authority for the request (i.e., "api.foo.com").
  * @param path The URL path for the request (i.e., "/foo").
  */
 class RequestBuilder(

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
@@ -5,7 +5,7 @@ package io.envoyproxy.envoymobile
  * Builder used for constructing instances of `Request` types.
  *
  * @param method Method for the request.
- * @param scheme /// The URL scheme for the request (i.e., "https").
+ * @param scheme The URL scheme for the request (i.e., "https").
  * @param authority The URL authority for the request (i.e., "api.foo.com").
  * @param path The URL path for the request (i.e., "/foo").
  */

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
@@ -146,7 +146,9 @@ class RequestBuilder(
   fun build(): Request {
     return Request(
         method,
-        url,
+        scheme,
+        authority,
+        path,
         headers,
         trailers,
         body,

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
@@ -1,17 +1,19 @@
 package io.envoyproxy.envoymobile
 
-import java.net.URL
-
 
 /**
  * Builder used for constructing instances of `Request` types.
  *
- * @param url URL for the request.
  * @param method Method for the request.
+ * @param scheme /// The URL scheme for the request (i.e., "https").
+ * @param authority The URL authority for the request (i.e., "api.envoyproxy.io"). # TODO
+ * @param path The URL path for the request (i.e., "/foo").
  */
 class RequestBuilder(
-    val url: URL,
-    val method: RequestMethod
+    val method: RequestMethod,
+    val scheme: String,
+    val authority: String,
+    val path: String
 ) {
   // Headers to send with the request.
   // Multiple values for a given name are valid, and will be sent as comma-separated values.

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
@@ -9,7 +9,7 @@ class RequestBuilderTest {
   fun `adding request data should have body present in request`() {
     val body = "data".toByteArray()
 
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addBody(body)
         .build()
     assertThat(request.body).isEqualTo(body)
@@ -17,7 +17,7 @@ class RequestBuilderTest {
 
   @Test
   fun `not adding request data should have null body in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .build()
 
     assertThat(request.body).isNull()
@@ -27,7 +27,7 @@ class RequestBuilderTest {
   fun `adding retry policy should have policy present in request`() {
 
     val retryPolicy = RetryPolicy(23, listOf(RetryRule.FIVE_XX, RetryRule.CONNECT_FAILURE), 1234)
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addRetryPolicy(retryPolicy)
         .build()
 
@@ -36,7 +36,7 @@ class RequestBuilderTest {
 
   @Test
   fun `not adding retry policy should have null body in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .build()
 
     assertThat(request.retryPolicy).isNull()
@@ -44,7 +44,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding new headers should append to the list of header keys`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .build()
 
@@ -53,7 +53,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding new trailers should append to the list of trailers keys`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addTrailer("trailer_a", "value_a1")
         .build()
 
@@ -62,7 +62,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing headers should clear headers in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .removeHeaders("header_a")
         .build()
@@ -72,7 +72,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific header value should not be in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -83,7 +83,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific header value should keep the other header values in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -94,7 +94,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding a specific header value should keep the other header values in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .build()
@@ -104,7 +104,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing all header values should remove header list in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .removeHeader("header_a", "value_a1")
         .build()
@@ -114,7 +114,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing trailers should clear trailers in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addTrailer("trailer_a", "value_a1")
         .removeTrailers("trailer_a")
         .build()
@@ -124,7 +124,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific trailer value should not be in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addTrailer("trailer_a", "value_a1")
         .addTrailer("trailer_a", "value_a2")
         .removeTrailer("trailer_a", "value_a1")
@@ -135,7 +135,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific trailer value should keep the other trailer values in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addTrailer("trailer_a", "value_a1")
         .addTrailer("trailer_a", "value_a2")
         .removeTrailer("trailer_a", "value_a1")
@@ -146,7 +146,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding a specific trailer value should keep the other trailer values in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addTrailer("trailer_a", "value_a1")
         .addTrailer("trailer_a", "value_a2")
         .build()
@@ -156,7 +156,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing all trailer values should remove trailer list in request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addTrailer("trailer_a", "value_a1")
         .removeTrailer("trailer_a", "value_a1")
         .build()

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
@@ -2,7 +2,6 @@ package io.envoyproxy.envoymobile
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import java.net.URL
 
 class RequestBuilderTest {
 
@@ -10,7 +9,7 @@ class RequestBuilderTest {
   fun `adding request data should have body present in request`() {
     val body = "data".toByteArray()
 
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addBody(body)
         .build()
     assertThat(request.body).isEqualTo(body)
@@ -18,7 +17,7 @@ class RequestBuilderTest {
 
   @Test
   fun `not adding request data should have null body in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .build()
 
     assertThat(request.body).isNull()
@@ -28,7 +27,7 @@ class RequestBuilderTest {
   fun `adding retry policy should have policy present in request`() {
 
     val retryPolicy = RetryPolicy(23, listOf(RetryRule.FIVE_XX, RetryRule.CONNECT_FAILURE), 1234)
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addRetryPolicy(retryPolicy)
         .build()
 
@@ -37,7 +36,7 @@ class RequestBuilderTest {
 
   @Test
   fun `not adding retry policy should have null body in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .build()
 
     assertThat(request.retryPolicy).isNull()
@@ -45,7 +44,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding new headers should append to the list of header keys`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addHeader("header_a", "value_a1")
         .build()
 
@@ -54,7 +53,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding new trailers should append to the list of trailers keys`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addTrailer("trailer_a", "value_a1")
         .build()
 
@@ -63,7 +62,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing headers should clear headers in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addHeader("header_a", "value_a1")
         .removeHeaders("header_a")
         .build()
@@ -73,7 +72,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific header value should not be in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -84,7 +83,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific header value should keep the other header values in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -95,7 +94,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding a specific header value should keep the other header values in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .build()
@@ -105,7 +104,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing all header values should remove header list in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addHeader("header_a", "value_a1")
         .removeHeader("header_a", "value_a1")
         .build()
@@ -115,7 +114,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing trailers should clear trailers in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addTrailer("trailer_a", "value_a1")
         .removeTrailers("trailer_a")
         .build()
@@ -125,7 +124,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific trailer value should not be in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addTrailer("trailer_a", "value_a1")
         .addTrailer("trailer_a", "value_a2")
         .removeTrailer("trailer_a", "value_a1")
@@ -136,7 +135,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific trailer value should keep the other trailer values in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addTrailer("trailer_a", "value_a1")
         .addTrailer("trailer_a", "value_a2")
         .removeTrailer("trailer_a", "value_a1")
@@ -147,7 +146,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding a specific trailer value should keep the other trailer values in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addTrailer("trailer_a", "value_a1")
         .addTrailer("trailer_a", "value_a2")
         .build()
@@ -157,7 +156,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing all trailer values should remove trailer list in request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addTrailer("trailer_a", "value_a1")
         .removeTrailer("trailer_a", "value_a1")
         .build()

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
@@ -8,7 +8,7 @@ class RequestTest {
 
   @Test
   fun `requests with the same properties should be equal`() {
-    val request1 = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request1 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addBody("data".toByteArray())
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
@@ -18,7 +18,7 @@ class RequestTest {
         .addTrailer("trailer_b", "value_b1")
         .build()
 
-    val request2 = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request2 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addBody("data".toByteArray())
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
@@ -33,7 +33,7 @@ class RequestTest {
 
   @Test
   fun `requests converted to a builder should build to the same request`() {
-    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addBody("data".toByteArray())
         .addRetryPolicy(RetryPolicy(23, listOf(RetryRule.FIVE_XX, RetryRule.CONNECT_FAILURE), 1234))
         .addHeader("header_a", "value_a1")

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
@@ -2,14 +2,13 @@ package io.envoyproxy.envoymobile
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import java.net.URL
 
 
 class RequestTest {
 
   @Test
   fun `requests with the same properties should be equal`() {
-    val request1 = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request1 = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addBody("data".toByteArray())
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
@@ -19,7 +18,7 @@ class RequestTest {
         .addTrailer("trailer_b", "value_b1")
         .build()
 
-    val request2 = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request2 = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addBody("data".toByteArray())
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
@@ -34,7 +33,7 @@ class RequestTest {
 
   @Test
   fun `requests converted to a builder should build to the same request`() {
-    val request = RequestBuilder(URL("http://0.0.0.0:9001/api.lyft.com/demo.txt"), RequestMethod.GET)
+    val request = RequestBuilder(RequestMethod.POST, "https", "api.foo.com", "foo")
         .addBody("data".toByteArray())
         .addRetryPolicy(RetryPolicy(23, listOf(RetryRule.FIVE_XX, RetryRule.CONNECT_FAILURE), 1234))
         .addHeader("header_a", "value_a1")


### PR DESCRIPTION
To mirror: https://github.com/lyft/envoy-mobile/pull/277

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: expose URL components instead of URL type
Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
