### PR TITLE
swift: add conversion from Request to headers

### DIFF
--- a/library/swift/src/BUILD
+++ b/library/swift/src/BUILD
@@ -11,6 +11,7 @@ swift_static_framework(
         "LogLevel.swift",
         "Request.swift",
         "RequestBuilder.swift",
+        "RequestMapper.swift",
         "RequestMethod.swift",
         "ResponseHandler.swift",
         "RetryPolicy.swift",

--- a/library/swift/src/RequestMapper.swift
+++ b/library/swift/src/RequestMapper.swift
@@ -1,0 +1,25 @@
+private let kRestrictedHeaderPrefix = ":"
+
+extension Request {
+  /// Returns a set of outbound headers that include HTTP
+  /// information on the URL, method, and additional headers.
+  ///
+  /// - returns: Outbound headers to send with an HTTP request.
+  func makeOutboundHeaders() -> [String: String] {
+    var headers = self.headers
+      .filter { !$0.key.hasPrefix(kRestrictedHeaderPrefix) }
+      .mapValues { $0.joined(separator: ",") }
+      .reduce(into: [
+        ":method": self.method.stringValue,
+        ":scheme": self.scheme,
+        ":authority": self.authority,
+        ":path": self.path,
+      ]) { $0[$1.key] = $1.value }
+
+    if let retryPolicy = self.retryPolicy {
+      headers = headers.merging(retryPolicy.makeOutboundHeaders()) { _, retryHeader in retryHeader }
+    }
+
+    return headers
+  }
+}

--- a/library/swift/src/RequestMapper.swift
+++ b/library/swift/src/RequestMapper.swift
@@ -5,7 +5,7 @@ extension Request {
   /// information on the URL, method, and additional headers.
   ///
   /// - returns: Outbound headers to send with an HTTP request.
-  func makeOutboundHeaders() -> [String: String] {
+  func outboundHeaders() -> [String: String] {
     var headers = self.headers
       .filter { !$0.key.hasPrefix(kRestrictedHeaderPrefix) }
       .mapValues { $0.joined(separator: ",") }
@@ -17,7 +17,7 @@ extension Request {
       ]) { $0[$1.key] = $1.value }
 
     if let retryPolicy = self.retryPolicy {
-      headers = headers.merging(retryPolicy.makeOutboundHeaders()) { _, retryHeader in retryHeader }
+      headers = headers.merging(retryPolicy.outboundHeaders()) { _, retryHeader in retryHeader }
     }
 
     return headers

--- a/library/swift/src/RetryPolicyMapper.swift
+++ b/library/swift/src/RetryPolicyMapper.swift
@@ -2,7 +2,7 @@ extension RetryPolicy {
   /// Converts the retry policy to a set of headers recognized by Envoy.
   ///
   /// - returns: The header representation of the retry policy.
-  func toHeaders() -> [String: String] {
+  func makeOutboundHeaders() -> [String: String] {
     var headers = [
       "x-envoy-max-retries": "\(self.maxRetryCount)",
       "x-envoy-retry-on": self.retryOn

--- a/library/swift/src/RetryPolicyMapper.swift
+++ b/library/swift/src/RetryPolicyMapper.swift
@@ -2,7 +2,7 @@ extension RetryPolicy {
   /// Converts the retry policy to a set of headers recognized by Envoy.
   ///
   /// - returns: The header representation of the retry policy.
-  func makeOutboundHeaders() -> [String: String] {
+  func outboundHeaders() -> [String: String] {
     var headers = [
       "x-envoy-max-retries": "\(self.maxRetryCount)",
       "x-envoy-retry-on": self.retryOn

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -10,6 +10,13 @@ envoy_mobile_swift_test(
 )
 
 envoy_mobile_swift_test(
+    name = "request_mapper_tests",
+    srcs = [
+        "RequestMapperTests.swift",
+    ],
+)
+
+envoy_mobile_swift_test(
     name = "retry_policy_tests",
     srcs = [
         "RetryPolicyTests.swift",

--- a/library/swift/test/RequestMapperTests.swift
+++ b/library/swift/test/RequestMapperTests.swift
@@ -5,28 +5,28 @@ final class RequestMapperTests: XCTestCase {
   func testAddsMethodToHeaders() {
     let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .build()
-      .makeOutboundHeaders()
+      .outboundHeaders()
     XCTAssertEqual("POST", headers[":method"])
   }
 
   func testAddsSchemeToHeaders() {
     let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .build()
-      .makeOutboundHeaders()
+      .outboundHeaders()
     XCTAssertEqual("https", headers[":scheme"])
   }
 
   func testAddsAuthorityToHeaders() {
     let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .build()
-      .makeOutboundHeaders()
+      .outboundHeaders()
     XCTAssertEqual("x.y.z", headers[":authority"])
   }
 
   func testAddsPathToHeaders() {
     let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .build()
-      .makeOutboundHeaders()
+      .outboundHeaders()
     XCTAssertEqual("/foo", headers[":path"])
   }
 
@@ -35,7 +35,7 @@ final class RequestMapperTests: XCTestCase {
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .build()
-      .makeOutboundHeaders()
+      .outboundHeaders()
     XCTAssertEqual("1,2", headers["foo"])
   }
 
@@ -43,7 +43,7 @@ final class RequestMapperTests: XCTestCase {
     let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .addHeader(name: ":restricted", value: "someValue")
       .build()
-      .makeOutboundHeaders()
+      .outboundHeaders()
     XCTAssertNil(headers[":restricted"])
   }
 
@@ -53,7 +53,7 @@ final class RequestMapperTests: XCTestCase {
       .addHeader(name: ":authority", value: "override")
       .addHeader(name: ":path", value: "override")
       .build()
-      .makeOutboundHeaders()
+      .outboundHeaders()
 
     XCTAssertEqual("https", headers[":scheme"])
     XCTAssertEqual("x.y.z", headers[":authority"])
@@ -63,13 +63,13 @@ final class RequestMapperTests: XCTestCase {
   func testIncludesRetryPolicyHeaders() {
     let retryPolicy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases,
                                   perRetryTimeoutMS: 9001)
-    let retryHeaders = retryPolicy.makeOutboundHeaders()
+    let retryHeaders = retryPolicy.outboundHeaders()
     let requestHeaders = RequestBuilder(method: .post, scheme: "https",
                                         authority: "x.y.z", path: "/foo")
       .addHeader(name: "foo", value: "bar")
       .addRetryPolicy(retryPolicy)
       .build()
-      .makeOutboundHeaders()
+      .outboundHeaders()
 
     XCTAssertEqual("bar", requestHeaders["foo"])
     XCTAssertFalse(retryHeaders.isEmpty)
@@ -86,7 +86,7 @@ final class RequestMapperTests: XCTestCase {
       .addHeader(name: "x-envoy-max-retries", value: "override")
       .addRetryPolicy(retryPolicy)
       .build()
-      .makeOutboundHeaders()
+      .outboundHeaders()
 
     XCTAssertEqual("123", requestHeaders["x-envoy-max-retries"])
   }

--- a/library/swift/test/RequestMapperTests.swift
+++ b/library/swift/test/RequestMapperTests.swift
@@ -1,0 +1,93 @@
+@testable import Envoy
+import XCTest
+
+final class RequestMapperTests: XCTestCase {
+  func testAddsMethodToHeaders() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .build()
+      .makeOutboundHeaders()
+    XCTAssertEqual("POST", headers[":method"])
+  }
+
+  func testAddsSchemeToHeaders() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .build()
+      .makeOutboundHeaders()
+    XCTAssertEqual("https", headers[":scheme"])
+  }
+
+  func testAddsAuthorityToHeaders() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .build()
+      .makeOutboundHeaders()
+    XCTAssertEqual("x.y.z", headers[":authority"])
+  }
+
+  func testAddsPathToHeaders() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .build()
+      .makeOutboundHeaders()
+    XCTAssertEqual("/foo", headers[":path"])
+  }
+
+  func testJoinsHeaderValuesWithTheSameKey() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .addHeader(name: "foo", value: "1")
+      .addHeader(name: "foo", value: "2")
+      .build()
+      .makeOutboundHeaders()
+    XCTAssertEqual("1,2", headers["foo"])
+  }
+
+  func testStripsHeadersWithSemicolonPrefix() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .addHeader(name: ":restricted", value: "someValue")
+      .build()
+      .makeOutboundHeaders()
+    XCTAssertNil(headers[":restricted"])
+  }
+
+  func testCannotOverrideStandardRestrictedHeaders() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .addHeader(name: ":scheme", value: "override")
+      .addHeader(name: ":authority", value: "override")
+      .addHeader(name: ":path", value: "override")
+      .build()
+      .makeOutboundHeaders()
+
+    XCTAssertEqual("https", headers[":scheme"])
+    XCTAssertEqual("x.y.z", headers[":authority"])
+    XCTAssertEqual("/foo", headers[":path"])
+  }
+
+  func testIncludesRetryPolicyHeaders() {
+    let retryPolicy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases,
+                                  perRetryTimeoutMS: 9001)
+    let retryHeaders = retryPolicy.makeOutboundHeaders()
+    let requestHeaders = RequestBuilder(method: .post, scheme: "https",
+                                        authority: "x.y.z", path: "/foo")
+      .addHeader(name: "foo", value: "bar")
+      .addRetryPolicy(retryPolicy)
+      .build()
+      .makeOutboundHeaders()
+
+    XCTAssertEqual("bar", requestHeaders["foo"])
+    XCTAssertFalse(retryHeaders.isEmpty)
+    for (retryHeader, expectedValue) in retryHeaders {
+      XCTAssertEqual(expectedValue, requestHeaders[retryHeader])
+    }
+  }
+
+  func testRetryPolicyTakesPrecedenceOverManuallySetRetryHeaders() {
+    let retryPolicy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases,
+                                  perRetryTimeoutMS: 9001)
+    let requestHeaders = RequestBuilder(method: .post, scheme: "https",
+                                        authority: "x.y.z", path: "/foo")
+      .addHeader(name: "x-envoy-max-retries", value: "override")
+      .addRetryPolicy(retryPolicy)
+      .build()
+      .makeOutboundHeaders()
+
+    XCTAssertEqual("123", requestHeaders["x-envoy-max-retries"])
+  }
+}

--- a/library/swift/test/RetryPolicyMapperTests.swift
+++ b/library/swift/test/RetryPolicyMapperTests.swift
@@ -12,7 +12,7 @@ final class RetryPolicyMapperTests: XCTestCase {
       "x-envoy-upstream-rq-per-try-timeout-ms": "9001",
     ]
 
-    XCTAssertEqual(expectedHeaders, policy.toHeaders())
+    XCTAssertEqual(expectedHeaders, policy.makeOutboundHeaders())
   }
 
   func testConvertingToHeadersWithoutRetryTimeoutExcludesPerRetryTimeoutHeader() {
@@ -24,6 +24,6 @@ final class RetryPolicyMapperTests: XCTestCase {
       "x-envoy-retry-on": "5xx,gateway-error,connect-failure,retriable-4xx,refused-upstream",
     ]
 
-    XCTAssertEqual(expectedHeaders, policy.toHeaders())
+    XCTAssertEqual(expectedHeaders, policy.makeOutboundHeaders())
   }
 }

--- a/library/swift/test/RetryPolicyMapperTests.swift
+++ b/library/swift/test/RetryPolicyMapperTests.swift
@@ -12,7 +12,7 @@ final class RetryPolicyMapperTests: XCTestCase {
       "x-envoy-upstream-rq-per-try-timeout-ms": "9001",
     ]
 
-    XCTAssertEqual(expectedHeaders, policy.makeOutboundHeaders())
+    XCTAssertEqual(expectedHeaders, policy.outboundHeaders())
   }
 
   func testConvertingToHeadersWithoutRetryTimeoutExcludesPerRetryTimeoutHeader() {
@@ -24,6 +24,6 @@ final class RetryPolicyMapperTests: XCTestCase {
       "x-envoy-retry-on": "5xx,gateway-error,connect-failure,retriable-4xx,refused-upstream",
     ]
 
-    XCTAssertEqual(expectedHeaders, policy.makeOutboundHeaders())
+    XCTAssertEqual(expectedHeaders, policy.outboundHeaders())
   }
 }


### PR DESCRIPTION
Adds converters to go from `Request` to a set of headers that upstream Envoy understands.

This will be utilized by the request logic in the `Envoy` class.

Previous consideration: https://github.com/lyft/envoy-mobile/pull/275

Signed-off-by: Michael Rebello <me@michaelrebello.com>