### PR TITLE
core: handle stream completion

### DIFF
--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -32,17 +32,16 @@ public:
    * @return envoy_stream_t handle to the stream being created.
    */
   envoy_stream_t startStream(envoy_observer observer);
-  envoy_status_t sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_stream);
-  envoy_status_t sendData(envoy_stream_t stream, envoy_headers headers, bool end_stream);
-  envoy_status_t sendMetadata(envoy_stream_t stream, envoy_headers headers, bool end_stream);
-  envoy_status_t sendTrailers(envoy_stream_t stream, envoy_headers headers);
-  envoy_status_t locallyCloseStream(envoy_stream_t stream);
+  envoy_status_t sendHeaders(envoy_stream_t stream_id, envoy_headers headers, bool end_stream);
+  envoy_status_t sendData(envoy_stream_t stream_id, envoy_headers headers, bool end_stream);
+  envoy_status_t sendMetadata(envoy_stream_t stream_id, envoy_headers headers, bool end_stream);
+  envoy_status_t sendTrailers(envoy_stream_t stream_id, envoy_headers headers);
+  envoy_status_t locallyCloseStream(envoy_stream_t stream_id);
   // TODO: when implementing this function we have to make sure to prevent races with already
   // scheduled and potentially scheduled callbacks. In order to do so the platform callbacks need to
   // check for atomic state (boolean most likely) that will be updated here to mark the stream as
   // closed.
-  envoy_status_t resetStream(envoy_stream_t stream);
-  envoy_status_t removeStream(envoy_stream_t stream);
+  envoy_status_t resetStream(envoy_stream_t stream_id);
 
 private:
   /**
@@ -77,13 +76,11 @@ private:
    * AsyncClient::Stream and in the incoming direction via DirectStreamCallbacks.
    */
   class DirectStream {
-    // TODO: Bookkeeping for this class is insufficient to fully cover all cases necessary to
-    // track the lifecycle of the underlying_stream_. One way or another, we must fix this
-    // to prevent bugs in the future. (Enhanced internal bookkeeping is probably good enough,
-    // but other options include upstream modifications to AsyncClient and friends.
   public:
-    DirectStream(AsyncClient::Stream& underlying_stream, DirectStreamCallbacksPtr&& callbacks);
+    DirectStream(envoy_stream_t stream_id, AsyncClient::Stream& underlying_stream,
+                 DirectStreamCallbacksPtr&& callbacks);
 
+    const envoy_stream_t stream_id_;
     // Used to issue outgoing HTTP stream operations.
     AsyncClient::Stream& underlying_stream_;
     // Used to receive incoming HTTP stream operations.
@@ -95,6 +92,9 @@ private:
     // An implementation option would be to have drainable header maps, or done callbacks.
     std::vector<HeaderMapPtr> metadata_;
     HeaderMapPtr trailers_;
+
+    std::atomic<bool> local_closed_{};
+    std::atomic<bool> remote_closed_{};
   };
 
   using DirectStreamPtr = std::unique_ptr<DirectStream>;
@@ -102,6 +102,10 @@ private:
   // Everything in the below interface must only be accessed from the event_dispatcher's thread.
   // This allows us to generally avoid synchronization.
   DirectStream* getStream(envoy_stream_t stream_id);
+  void removeStream(envoy_stream_t stream_id);
+  void cleanup(DirectStream& stream);
+  void closeLocal(envoy_stream_t stream_id, bool end_stream);
+  void closeRemote(envoy_stream_t stream_id, bool end_stream);
 
   std::unordered_map<envoy_stream_t, DirectStreamPtr> streams_;
   std::atomic<envoy_stream_t> current_stream_id_;

--- a/library/objective-c/AppDelegate.h
+++ b/library/objective-c/AppDelegate.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/library/objective-c/AppDelegate.mm
+++ b/library/objective-c/AppDelegate.mm
@@ -1,0 +1,68 @@
+#import "AppDelegate.h"
+#import <UIKit/UIKit.h>
+#import "ViewController.h"
+#include "library/objective-c/EnvoyEngine.h"
+
+@interface AppDelegate () <NSURLConnectionDelegate>
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application
+    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  [NSThread detachNewThreadSelector:@selector(envoyRunner) toTarget:self withObject:nil];
+  [NSThread detachNewThreadSelector:@selector(envoyHarness) toTarget:self withObject:nil];
+
+  UIViewController *controller = [UITableViewController new];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  [self.window setRootViewController:controller];
+  [self.window makeKeyAndVisible];
+  NSLog(@"Finished launching!");
+  return YES;
+}
+
+- (void)envoyRunner {
+  // Read in and store as string
+  NSString *configFile = [[NSBundle mainBundle] pathForResource:@"config" ofType:@"yaml"];
+  NSString *configYaml = [NSString stringWithContentsOfFile:configFile
+                                                   encoding:NSUTF8StringEncoding
+                                                      error:NULL];
+  NSLog(@"Loading config: %@", configYaml);
+
+  [EnvoyEngine runWithConfig:configYaml logLevel:@"debug"];
+}
+
+- (void)envoyHarness {
+  sleep(5);
+  [EnvoyEngine setupEnvoy];
+  sleep(1);
+  while (true) {
+    [EnvoyEngine makeRequest];
+    sleep(1);
+  }
+}
+
+#pragma mark NSURLConnectionDelegate
+
+- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
+  NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+  NSLog(@"status: %ld", httpResponse.statusCode);
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
+}
+
+- (NSCachedURLResponse *)connection:(NSURLConnection *)connection
+                  willCacheResponse:(NSCachedURLResponse *)cachedResponse {
+  return nil;
+}
+
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
+  NSLog(@"response complete");
+}
+
+- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
+  NSLog(@"ut oh");
+}
+
+@end

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -1,9 +1,17 @@
 licenses(["notice"])  # Apache 2
 
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+
 exports_files([
     "EnvoyEngine.h",
     "EnvoyTypes.h",
 ])
+
+filegroup(
+    name = "envoy_engine_hdrs",
+    srcs = ["EnvoyEngine.h"],
+    visibility = ["//visibility:public"],
+)
 
 objc_library(
     name = "envoy_engine_objc_lib",
@@ -16,4 +24,29 @@ objc_library(
     copts = ["-std=c++14"],
     visibility = ["//visibility:public"],
     deps = ["//library/common:envoy_main_interface_lib"],
+)
+
+objc_library(
+    name = "appmain",
+    srcs = [
+        "AppDelegate.h",
+        "AppDelegate.mm",
+        "main.mm",
+    ],
+    copts = ["-std=c++14"],
+    data = ["config.yaml"],
+    sdk_dylibs = [
+        "resolv.9",
+        "c++",
+    ],
+    deps = ["envoy_engine_objc_lib"],
+)
+
+ios_application(
+    name = "app",
+    bundle_id = "com.foo.bar",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "11.0",
+    deps = ["appmain"],
 )

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -86,8 +86,8 @@
  */
 + (EnvoyStatus)resetStream:(EnvoyStream *)stream;
 
-/// Performs necessary setup after Envoy has initialized and started running.
-/// TODO: create a post-initialization callback from Envoy to handle this automatically.
++ (void)makeRequest;
+
 + (void)setupEnvoy;
 
 @end

--- a/library/objective-c/EnvoyEngine.mm
+++ b/library/objective-c/EnvoyEngine.mm
@@ -3,11 +3,89 @@
 #import "library/common/include/c_types.h"
 #import "library/common/main_interface.h"
 
+#include <string>
+
 @implementation EnvoyEngine
 
-#pragma mark - class methods
+static NSMutableDictionary *_callbacks = [NSMutableDictionary new];
+
+static void platform_on_headers(envoy_headers headers, bool end_stream, void *context) {
+  void (^onHeaders)(envoy_headers) = _callbacks[@"headers"];
+  onHeaders(headers);
+  if (end_stream) {
+    NSLog(@"[STREAM END]");
+  }
+}
+
+static void platform_on_data(envoy_data data, bool end_stream, void *context) {
+  void (^onData)(envoy_data) = _callbacks[@"data"];
+  onData(data);
+  if (end_stream) {
+    NSLog(@"[STREAM END]");
+  }
+}
+
+static envoy_data EnvoyString(NSString *s) { return {s.length, (uint8_t *)strdup(s.UTF8String)}; }
+
+static void printHeaders(envoy_headers headers, bool sent) {
+  for (int i = 0; i < headers.length; i++) {
+
+    NSString *key =
+        @(reinterpret_cast<char *>(const_cast<uint8_t *>(headers.headers[i].key.bytes)));
+    NSString *value =
+        @(reinterpret_cast<char *>(const_cast<uint8_t *>(headers.headers[i].value.bytes)));
+    NSString *action = sent ? @"SENT" : @"RECEIVED";
+    NSLog(@"[%@ HEADER] %@: %@", action, key, value);
+  }
+}
+
++ (void)makeRequest {
+  NSLog(@"Inside makeRequest");
+  void (^onHeaders)(envoy_headers) = ^(envoy_headers headers) {
+    printHeaders(headers, false);
+  };
+
+  void (^onData)(envoy_data) = ^(envoy_data data) {
+    NSLog(@"RECEIVED DATA: %llu", data.length);
+  };
+
+  envoy_observer observer = {
+      platform_on_headers,
+      platform_on_data,
+      nullptr,
+      nullptr,
+  };
+
+  NSLog(@"Calling start_stream");
+  envoy_stream stream_pair = start_stream(observer);
+  NSLog(@"Checking start_stream result");
+  if (stream_pair.status == ENVOY_SUCCESS) {
+    NSLog(@"[STREAM OPEN: %@]", @(stream_pair.stream));
+    _callbacks[@"headers"] = onHeaders;
+    _callbacks[@"data"] = onData;
+  } else {
+    NSLog(@"[STREAM OPEN FAILED]");
+  }
+
+  envoy_header *header_array = new envoy_header[4];
+
+  header_array[0] = {EnvoyString(@":method"), EnvoyString(@"GET")};
+  header_array[1] = {EnvoyString(@":scheme"), EnvoyString(@"https")};
+  header_array[2] = {EnvoyString(@":authority"), EnvoyString(@"api.lyft.com")};
+  header_array[3] = {EnvoyString(@":path"), EnvoyString(@"/ping")};
+
+  envoy_headers request_headers = {4, header_array};
+
+  envoy_status_t status = send_headers(stream_pair.stream, request_headers, true);
+  if (status == ENVOY_SUCCESS) {
+    printHeaders(request_headers, true);
+  } else {
+    NSLog(@"[FAILED TO SEND HEADERS]");
+  }
+}
+
 + (EnvoyStatus)runWithConfig:(NSString *)config {
-  return [self runWithConfig:config logLevel:@"info"];
+  return [self runWithConfig:config logLevel:@"debug"];
 }
 
 + (EnvoyStatus)runWithConfig:(NSString *)config logLevel:(NSString *)logLevel {

--- a/library/objective-c/Info.plist
+++ b/library/objective-c/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreenView</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
+</dict>
+</plist>

--- a/library/objective-c/ViewController.h
+++ b/library/objective-c/ViewController.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UITableViewController
+@end

--- a/library/objective-c/ViewController.mm
+++ b/library/objective-c/ViewController.mm
@@ -1,0 +1,122 @@
+#import <UIKit/UIKit.h>
+#import "ViewController.h"
+
+#pragma mark - Constants
+
+NSString *_CELL_ID = @"cell-id";
+NSString *_ENDPOINT = @"http://0.0.0.0:9001/api.lyft.com/static/demo/hello_world.txt";
+
+#pragma mark - ResponseValue
+
+@interface ResponseValue : NSObject
+@property (nonatomic, strong) NSString *body;
+@property (nonatomic, strong) NSString *serverHeader;
+@end
+
+@implementation ResponseValue
+@end
+
+#pragma mark - ViewController
+
+@interface ViewController ()
+@property (nonatomic, strong) NSMutableArray<ResponseValue *> *responses;
+@property (nonatomic, weak) NSTimer *requestTimer;
+@end
+
+@implementation ViewController
+
+#pragma mark - Lifecycle
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    self.responses = [NSMutableArray new];
+    self.tableView.allowsSelection = FALSE;
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [self.requestTimer invalidate];
+  self.requestTimer = nil;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  [self startRequests];
+}
+
+#pragma mark - Requests
+
+- (void)startRequests {
+  // Note that the first delay will give Envoy time to start up.
+  self.requestTimer = [NSTimer scheduledTimerWithTimeInterval:1.0
+                                                       target:self
+                                                     selector:@selector(performRequest)
+                                                     userInfo:nil
+                                                      repeats:true];
+}
+
+- (void)performRequest {
+  NSURLSession *session = [NSURLSession sharedSession];
+  NSURL *url = [NSURL URLWithString:_ENDPOINT];
+  NSURLRequest *request = [NSURLRequest requestWithURL:url];
+  NSLog(@"Starting request to '%@'", url.path);
+
+  __weak ViewController *weakSelf = self;
+  NSURLSessionDataTask *task =
+      [session dataTaskWithRequest:request
+                 completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                   if (error == nil) {
+                     dispatch_async(dispatch_get_main_queue(), ^{
+                       [weakSelf handleResponse:(NSHTTPURLResponse *)response data:data];
+                     });
+                   } else {
+                     NSLog(@"Received error: %@", error);
+                   }
+                 }];
+  [task resume];
+}
+
+- (void)handleResponse:(NSHTTPURLResponse *)response data:(NSData *)data {
+  NSString *body = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  if (body == nil || response == nil) {
+    NSLog(@"Failed to deserialize response string");
+    return;
+  }
+
+  ResponseValue *value = [ResponseValue new];
+  value.body = body;
+  value.serverHeader = [[response allHeaderFields] valueForKey:@"Server"];
+
+  NSLog(@"Response:\n%ld bytes\n%@\n%@", data.length, body, [response allHeaderFields]);
+  [self.responses addObject:value];
+  [self.tableView reloadData];
+}
+
+#pragma mark - UITableView
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+  return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+  return self.responses.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:_CELL_ID];
+  if (cell == nil) {
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle
+                                  reuseIdentifier:_CELL_ID];
+  }
+
+  ResponseValue *response = self.responses[indexPath.row];
+  cell.textLabel.text = [NSString stringWithFormat:@"Response: %@", response.body];
+  cell.detailTextLabel.text =
+      [NSString stringWithFormat:@"'Server' header: %@", response.serverHeader];
+  return cell;
+}
+
+@end

--- a/library/objective-c/config.yaml
+++ b/library/objective-c/config.yaml
@@ -1,0 +1,33 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address: {address: 0.0.0.0, port_value: 9001, protocol: TCP}
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          stat_prefix: client
+          route_config:
+            virtual_hosts:
+            - name: all
+              domains: ["*"]
+              routes:
+              - match: {prefix: "/"}
+                route: {cluster: egress_cluster}
+          http_filters:
+          - name: envoy.router
+  clusters:
+  - name: egress_cluster
+    connect_timeout: 30s
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: egress_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address: {address: api.lyft.com, port_value: 443}
+    tls_context:
+      sni: api.lyft.com
+    type: LOGICAL_DNS

--- a/library/objective-c/main.mm
+++ b/library/objective-c/main.mm
@@ -1,0 +1,7 @@
+#import "AppDelegate.h"
+
+int main(int argc, char *argv[]) {
+  @autoreleasepool {
+    return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+  }
+}


### PR DESCRIPTION
Description: This PR adds stream state (local and remote) bookkeeping in order to track stream completion state. Once the stream is completed (both local and remote are closed) the stream is removed from the http dispatcher's stream map.
Risk Level: medium - this PR takes into account stream state to modify the http dispatchers stream map.
Testing:
Fixes #302 

Signed-off-by: Jose Nino <jnino@lyft.com>