### PR TITLE
swift: add Foundation import

### DIFF
--- a/library/swift/src/Client.swift
+++ b/library/swift/src/Client.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Client that is able to send and receive requests through Envoy.
 @objc
 public protocol Client {


### PR DESCRIPTION
Xcode 10.3 complains that this file uses `@objc` without importing `Foundation`.