### PR TITLE
ios: update EnvoyStatus to be more Swift-friendly

### DIFF
--- a/library/objective-c/EnvoyEngine.mm
+++ b/library/objective-c/EnvoyEngine.mm
@@ -19,45 +19,45 @@
     [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyException"
                                                       object:self
                                                     userInfo:userInfo];
-    return Failure;
+    return FAILURE;
   }
 }
 
 + (EnvoyStream)startStreamWithObserver:(EnvoyObserver *)observer {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
   EnvoyStream stream;
-  stream.status = Failure;
+  stream.status = FAILURE;
   return stream;
 }
 
 + (EnvoyStatus)sendHeaders:(EnvoyHeaders *)headers to:(EnvoyStream *)stream close:(BOOL)close {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return Failure;
+  return FAILURE;
 }
 
 + (EnvoyStatus)sendData:(NSData *)data to:(EnvoyStream *)stream close:(BOOL)close {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return Failure;
+  return FAILURE;
 }
 
 + (EnvoyStatus)sendMetadata:(EnvoyHeaders *)metadata to:(EnvoyStream *)stream close:(BOOL)close {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return Failure;
+  return FAILURE;
 }
 
 + (EnvoyStatus)sendTrailers:(EnvoyHeaders *)trailers to:(EnvoyStream *)stream close:(BOOL)close {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return Failure;
+  return FAILURE;
 }
 
 + (EnvoyStatus)locallyCloseStream:(EnvoyStream *)stream {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return Failure;
+  return FAILURE;
 }
 
 + (EnvoyStatus)resetStream:(EnvoyStream *)stream {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return Failure;
+  return FAILURE;
 }
 
 + (void)setupEnvoy {

--- a/library/objective-c/EnvoyEngine.mm
+++ b/library/objective-c/EnvoyEngine.mm
@@ -19,45 +19,45 @@
     [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyException"
                                                       object:self
                                                     userInfo:userInfo];
-    return FAILURE;
+    return EnvoyStatusFailure;
   }
 }
 
 + (EnvoyStream)startStreamWithObserver:(EnvoyObserver *)observer {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
   EnvoyStream stream;
-  stream.status = FAILURE;
+  stream.status = EnvoyStatusFailure;
   return stream;
 }
 
 + (EnvoyStatus)sendHeaders:(EnvoyHeaders *)headers to:(EnvoyStream *)stream close:(BOOL)close {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return FAILURE;
+  return EnvoyStatusFailure;
 }
 
 + (EnvoyStatus)sendData:(NSData *)data to:(EnvoyStream *)stream close:(BOOL)close {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return FAILURE;
+  return EnvoyStatusFailure;
 }
 
 + (EnvoyStatus)sendMetadata:(EnvoyHeaders *)metadata to:(EnvoyStream *)stream close:(BOOL)close {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return FAILURE;
+  return EnvoyStatusFailure;
 }
 
 + (EnvoyStatus)sendTrailers:(EnvoyHeaders *)trailers to:(EnvoyStream *)stream close:(BOOL)close {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return FAILURE;
+  return EnvoyStatusFailure;
 }
 
 + (EnvoyStatus)locallyCloseStream:(EnvoyStream *)stream {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return FAILURE;
+  return EnvoyStatusFailure;
 }
 
 + (EnvoyStatus)resetStream:(EnvoyStream *)stream {
   NSLog(@"%@ not implemented, returning failure", NSStringFromSelector((SEL) __func__));
-  return FAILURE;
+  return EnvoyStatusFailure;
 }
 
 + (void)setupEnvoy {

--- a/library/objective-c/EnvoyTypes.h
+++ b/library/objective-c/EnvoyTypes.h
@@ -32,9 +32,9 @@ typedef NS_ENUM(NSUInteger, EnvoyErrorCode) {
 // MARK: - EnvoyStatus
 
 /// Result codes returned by all calls made to this interface.
-typedef NS_CLOSED_ENUM(NSUInteger, EnvoyStatus) {
-  EnvoyStatusSuccess = 0,
-  EnvoyStatusFailure = 1,
+typedef NS_CLOSED_ENUM(NSUInteger, EnvoyStatus){
+    EnvoyStatusSuccess = 0,
+    EnvoyStatusFailure = 1,
 };
 
 // MARK: - EnvoyStream

--- a/library/objective-c/EnvoyTypes.h
+++ b/library/objective-c/EnvoyTypes.h
@@ -13,7 +13,7 @@ typedef NSArray<NSDictionary<NSString *, NSString *> *> EnvoyHeaders;
 
 /// Error code associated with terminal status of a HTTP stream.
 typedef NS_ENUM(NSUInteger, EnvoyErrorCode) {
-  StreamReset = 0,
+  EnvoyErrorCodeStreamReset = 0,
 };
 
 // MARK: - EnvoyError
@@ -32,9 +32,9 @@ typedef NS_ENUM(NSUInteger, EnvoyErrorCode) {
 // MARK: - EnvoyStatus
 
 /// Result codes returned by all calls made to this interface.
-typedef NS_ENUM(NSUInteger, EnvoyStatus) {
-  SUCCESS = 0,
-  FAILURE = 1,
+typedef NS_CLOSED_ENUM(NSUInteger, EnvoyStatus) {
+  EnvoyStatusSuccess = 0,
+  EnvoyStatusFailure = 1,
 };
 
 // MARK: - EnvoyStream

--- a/library/objective-c/EnvoyTypes.h
+++ b/library/objective-c/EnvoyTypes.h
@@ -33,8 +33,8 @@ typedef NS_ENUM(NSUInteger, EnvoyErrorCode) {
 
 /// Result codes returned by all calls made to this interface.
 typedef NS_ENUM(NSUInteger, EnvoyStatus) {
-  Success = 0,
-  Failure = 1,
+  SUCCESS = 0,
+  FAILURE = 1,
 };
 
 // MARK: - EnvoyStream


### PR DESCRIPTION
- Makes `EnvoyStatus` a closed enum, since we guarantee a limited set of values
- Renames the enum cases to be more consistent with Apple's [guidelines](https://developer.apple.com/library/archive/releasenotes/ObjectiveC/ModernizationObjC/AdoptingModernObjective-C/AdoptingModernObjective-C.html#//apple_ref/doc/uid/TP40014150-CH1-SW6)

This has the effect of improving their usability in Swift.

```swift
let result = ... // EnvoyStatus

if result == .Success // Before change
if result == .success // After change
```

Signed-off-by: Michael Rebello <me@michaelrebello.com>