### PR TITLE
objc: add nullability regions

### DIFF
--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -2,6 +2,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Wrapper layer to simplify calling into Envoy's C/++ API.
 @interface EnvoyEngine : NSObject
 
@@ -91,3 +93,5 @@
 + (void)setupEnvoy;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/library/objective-c/EnvoyTypes.h
+++ b/library/objective-c/EnvoyTypes.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 // MARK: - Aliases
 
 /// Handle to an outstanding Envoy HTTP stream. Valid only for the duration of the stream and not
@@ -90,3 +92,5 @@ typedef struct {
 @property (nonatomic, strong) void (^onError)(EnvoyError *error);
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Contents of these interfaces should be assumed to be nonnull.

Signed-off-by: Michael Rebello <me@michaelrebello.com>