### PR TITLE
objc: move EnvoyEngine streaming calls to protocol

### DIFF
--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -4,25 +4,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Wrapper layer to simplify calling into Envoy's C/++ API.
-@interface EnvoyEngine : NSObject
-
-/**
- Run the Envoy engine with the provided config and log level.
-
- @param config The configuration file with which to start Envoy.
- @return A status indicating if the action was successful.
- */
-+ (EnvoyStatus)runWithConfig:(NSString *)config;
-
-/**
- Run the Envoy engine with the provided config and log level.
-
- @param config The configuration file with which to start Envoy.
- @param logLevel The log level to use when starting Envoy.
- @return A status indicating if the action was successful.
- */
-+ (EnvoyStatus)runWithConfig:(NSString *)config logLevel:(NSString *)logLevel;
+/// Protocol interface for streaming with the Envoy engine.
+@protocol EnvoyEngineStreamInterface
 
 /**
  Open an underlying HTTP stream.
@@ -87,6 +70,28 @@ NS_ASSUME_NONNULL_BEGIN
  @return A status indicating if the action was successful.
  */
 + (EnvoyStatus)resetStream:(EnvoyStream *)stream;
+
+@end
+
+/// Wrapper layer for calling into Envoy's C/++ API.
+@interface EnvoyEngine : NSObject <EnvoyEngineStreamInterface>
+
+/**
+ Run the Envoy engine with the provided config and log level.
+
+ @param config The configuration file with which to start Envoy.
+ @return A status indicating if the action was successful.
+ */
++ (EnvoyStatus)runWithConfig:(NSString *)config;
+
+/**
+ Run the Envoy engine with the provided config and log level.
+
+ @param config The configuration file with which to start Envoy.
+ @param logLevel The log level to use when starting Envoy.
+ @return A status indicating if the action was successful.
+ */
++ (EnvoyStatus)runWithConfig:(NSString *)config logLevel:(NSString *)logLevel;
 
 /// Performs necessary setup after Envoy has initialized and started running.
 /// TODO: create a post-initialization callback from Envoy to handle this automatically.


### PR DESCRIPTION
Moves the streaming method requirements out of the `EnvoyEngine` class and into a protocol interface. Swift will then take a conformer to this protocol instead of calling directly into `EnvoyEngine`, which will allow us to inject mock conformers for better testing. We'll do this on Android as well.

Signed-off-by: Michael Rebello <me@michaelrebello.com>
