### PR TITLE
android: add missing minSdkVersion

### DIFF
--- a/examples/kotlin/shared/AndroidManifest.xml
+++ b/examples/kotlin/shared/AndroidManifest.xml
@@ -2,4 +2,8 @@
           package="io.envoyproxy.envoymobile.shared"
           android:versionCode="1"
           android:versionName="0.1">
+
+    <uses-sdk
+            android:minSdkVersion="21"
+            android:targetSdkVersion="27"/>
 </manifest>


### PR DESCRIPTION
Prevents warnings when building:

```
WARNING:
CONFIGURATION: bazel-out/android-x86-fastbuild/bin/examples/kotlin/shared/hello_envoy_shared_lib_base_processed_manifest/AndroidManifest.xml has no minSdkVersion. Using 1.
[204 / 242] Merging Android resources for @androidsdk//com.android.support:support-vector-drawable-25.0.0; 1s local ... (4 actions running)
INFO: From Validating Android resources for //dist:envoy_mobile_android:
Aug 12, 2019 10:21:21 PM com.google.devtools.build.android.AndroidManifest parseFrom
WARNING:
CONFIGURATION: bazel-out/android-x86-fastbuild/bin/dist/envoy_mobile_android_processed_manifest/AndroidManifest.xml has no minSdkVersion. Using 1.
```

Signed-off-by: Michael Rebello <me@michaelrebello.com>