### PR TITLE
objc: convert EnvoyEngine into a protocol

### DIFF
--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -60,7 +60,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 @end
 
 /// Wrapper layer for calling into Envoy's C/++ API.
-@interface EnvoyEngine : NSObject
+@protocol EnvoyEngine
 
 /**
  Run the Envoy engine with the provided config and log level.
@@ -82,6 +82,11 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 /// Performs necessary setup after Envoy has initialized and started running.
 /// TODO: create a post-initialization callback from Envoy to handle this automatically.
 + (void)setupEnvoy;
+
+@end
+
+// Concrete implementation of the `EnvoyEngine` protocol.
+@interface EnvoyEngineImpl : NSObject <EnvoyEngine>
 
 @end
 

--- a/library/objective-c/EnvoyEngine.m
+++ b/library/objective-c/EnvoyEngine.m
@@ -8,7 +8,7 @@
 @implementation EnvoyObserver
 @end
 
-@implementation EnvoyEngine
+@implementation EnvoyEngineImpl
 
 #pragma mark - class methods
 + (int)runWithConfig:(NSString *)config {

--- a/library/swift/src/Envoy.swift
+++ b/library/swift/src/Envoy.swift
@@ -33,7 +33,7 @@ public final class Envoy: NSObject {
     }
 
     override func main() {
-      EnvoyEngine.run(withConfig: self.config, logLevel: self.logLevel.stringValue)
+      EnvoyEngineImpl.run(withConfig: self.config, logLevel: self.logLevel.stringValue)
     }
   }
 }


### PR DESCRIPTION
This was originally going to be done as part of https://github.com/lyft/envoy-mobile/pull/316, but we ran into build issues.

Making this change will allow us to mock `EnvoyEngine` from the Swift/Kotlin platform layers.

Signed-off-by: Michael Rebello <me@michaelrebello.com>