### PR TITLE
Create an AndroidJniLibrary and move specific loader logic into the respective JniLibrary classes

### DIFF
--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -10,6 +10,8 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import io.envoyproxy.envoymobile.Envoy;
+import io.envoyproxy.envoymobile.engine.AndroidEngineImpl;
+import io.envoyproxy.envoymobile.engine.EnvoyEngine;
 import io.envoyproxy.envoymobile.shared.Failure;
 import io.envoyproxy.envoymobile.shared.Response;
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter;
@@ -43,7 +45,6 @@ public class MainActivity extends Activity {
     setContentView(R.layout.activity_main);
 
     Context context = getBaseContext();
-    Envoy.load(context);
 
     // Create envoy instance with config.
     String config;
@@ -53,7 +54,9 @@ public class MainActivity extends Activity {
       Log.d("MainActivity", "exception getting config.", e);
       throw new RuntimeException("Can't get config to run envoy.");
     }
-    envoy = new Envoy(context, config);
+
+    EnvoyEngine envoyEngine = new AndroidEngineImpl(context);
+    envoy = new Envoy(envoyEngine, config);
 
     recyclerView = (RecyclerView)findViewById(R.id.recycler_view);
     recyclerView.setLayoutManager(new LinearLayoutManager(this));

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -10,6 +10,7 @@ import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.util.Log
 import io.envoyproxy.envoymobile.Envoy
+import io.envoyproxy.envoymobile.engine.AndroidEngineImpl
 import io.envoyproxy.envoymobile.shared.Failure
 import io.envoyproxy.envoymobile.shared.Response
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter
@@ -33,10 +34,9 @@ class MainActivity : Activity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
 
-    Envoy.load(baseContext)
-
     // Create Envoy instance with config.
-    envoy = Envoy(baseContext, loadEnvoyConfig(baseContext, R.raw.config))
+    val envoyEngine = AndroidEngineImpl(baseContext)
+    envoy = Envoy(envoyEngine, loadEnvoyConfig(baseContext, R.raw.config))
 
     recyclerView = findViewById(R.id.recycler_view) as RecyclerView
     recyclerView.layoutManager = LinearLayoutManager(this)

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -20,9 +20,9 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
   return JNI_VERSION_1_6;
 }
 
-extern "C" JNIEXPORT jlong JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(JNIEnv* env,
-jclass // class
+extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
+    JNIEnv* env,
+    jclass // class
 ) {
   return init_engine();
 }

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -29,16 +29,16 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(JNIEnv* env,
 }
 
 extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_AndroidEngine_initialize(JNIEnv* env,
-                                                               jclass, // class
-                                                               jobject connectivity_manager) {
+Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
+                                                                   jclass, // class
+                                                                   jobject connectivity_manager) {
   // See note above about c-ares.
   return ares_library_init_android(connectivity_manager);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_io_envoyproxy_envoymobile_engine_AndroidEngine_isAresInitialized(JNIEnv* env,
-                                                                      jclass // class
+Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_isAresInitialized(JNIEnv* env,
+                                                                          jclass // class
 ) {
   return ares_library_android_initialized() == ARES_SUCCESS;
 }

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -20,6 +20,13 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
   return JNI_VERSION_1_6;
 }
 
+extern "C" JNIEXPORT jlong JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(JNIEnv* env,
+jclass // class
+) {
+  return init_engine();
+}
+
 extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(JNIEnv* env,
                                                            jobject, // this

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -15,7 +15,7 @@ public class AndroidEngineImpl implements EnvoyEngine {
   // Private helper class used by the load method to ensure the native library and its
   // dependencies are loaded and initialized at most once.
   public AndroidEngineImpl(Context context) {
-    initialize((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
+    initialize((ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE));
     envoyEngine = new EnvoyEngineImpl();
   }
 

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -4,5 +4,8 @@ import android.content.Context;
 
 public class AndroidEngineImpl extends EnvoyEngineImpl {
 
-  public AndroidEngineImpl(Context context) { AndroidJniLibrary.load(context); }
+  public AndroidEngineImpl(Context context) {
+    super();
+    AndroidJniLibrary.load(context);
+  }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -2,8 +2,9 @@ package io.envoyproxy.envoymobile.engine;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
+import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
 
-public class AndroidEngineImpl {
+public class AndroidEngineImpl implements EnvoyEngine {
 
   // Internal reference to helper object used to load and initialize the native library.
   // Volatile to ensure double-checked locking works correctly.
@@ -13,9 +14,8 @@ public class AndroidEngineImpl {
 
   // Private helper class used by the load method to ensure the native library and its
   // dependencies are loaded and initialized at most once.
-  private AndroidEngineImpl(Context context) {
-    System.loadLibrary("envoy_jni");
-    initialize((ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE));
+  public AndroidEngineImpl(Context context) {
+    initialize((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
     envoyEngine = new EnvoyEngineImpl();
   }
 
@@ -34,12 +34,26 @@ public class AndroidEngineImpl {
     }
   }
 
-  public static int run(String config, String logLevel) {
-    // TODO: Resolve the static loader instance
-    return loader.envoyEngine.runWithConfig(config, logLevel);
+  @Override
+  public EnvoyStream startStream(EnvoyObserver observer) {
+    return envoyEngine.startStream(observer);
   }
 
-  private static native int initialize(ConnectivityManager connectivityManager);
+  @Override
+  public int runWithConfig(String config) {
+    return envoyEngine.runWithConfig(config);
+  }
 
-  private static native boolean isAresInitialized();
+  @Override
+  public int runWithConfig(String config, String logLevel) {
+    return envoyEngine.runWithConfig(config, logLevel);
+  }
+
+  /**
+   * Native binding to register the ConnectivityManager to C-Ares
+   *
+   * @param connectivityManager Android's ConnectivityManager
+   * @return int for successful initialization
+   */
+  private static native int initialize(ConnectivityManager connectivityManager);
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -1,48 +1,8 @@
 package io.envoyproxy.envoymobile.engine;
 
 import android.content.Context;
-import android.net.ConnectivityManager;
 
 public class AndroidEngineImpl extends EnvoyEngineImpl {
 
-  // Internal reference to helper object used to load and initialize the native library.
-  // Volatile to ensure double-checked locking works correctly.
-  private static volatile AndroidLoader loader = null;
-
-  // Private helper class used by the load method to ensure the native library and its
-  // dependencies are loaded and initialized at most once.
-  public AndroidEngineImpl(Context context) {
-    load(context);
-  }
-
-  protected void load(Context context) {
-    EnvoyEngineImpl.load();
-
-    if (loader != null) {
-      return;
-    }
-
-    synchronized (AndroidLoader.class) {
-      if (loader != null) {
-        return;
-      }
-
-      loader = new AndroidLoader(context);
-    }
-  }
-
-  private static class AndroidLoader {
-    private AndroidLoader(Context context) {
-      initialize((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
-    }
-
-    /**
-     * Native binding to register the ConnectivityManager to C-Ares
-     *
-     * @param connectivityManager Android's ConnectivityManager
-     * @return int for successful initialization
-     */
-    private static native int initialize(ConnectivityManager connectivityManager);
-  }
-
+  public AndroidEngineImpl(Context context) { AndroidJniLibrary.load(context); }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -2,58 +2,47 @@ package io.envoyproxy.envoymobile.engine;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
-import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
 
-public class AndroidEngineImpl implements EnvoyEngine {
+public class AndroidEngineImpl extends EnvoyEngineImpl {
 
   // Internal reference to helper object used to load and initialize the native library.
   // Volatile to ensure double-checked locking works correctly.
-  private static volatile AndroidEngineImpl loader = null;
-
-  private final EnvoyEngine envoyEngine;
+  private static volatile AndroidLoader loader = null;
 
   // Private helper class used by the load method to ensure the native library and its
   // dependencies are loaded and initialized at most once.
   public AndroidEngineImpl(Context context) {
-    initialize((ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE));
-    envoyEngine = new EnvoyEngineImpl();
+    load(context);
   }
 
-  // Load and initialize Envoy and its dependencies, but only once.
-  public static void load(Context context) {
+  protected void load(Context context) {
+    EnvoyEngineImpl.load();
+
     if (loader != null) {
       return;
     }
 
-    synchronized (AndroidEngineImpl.class) {
+    synchronized (AndroidLoader.class) {
       if (loader != null) {
         return;
       }
 
-      loader = new AndroidEngineImpl(context);
+      loader = new AndroidLoader(context);
     }
   }
 
-  @Override
-  public EnvoyStream startStream(EnvoyObserver observer) {
-    return envoyEngine.startStream(observer);
+  private static class AndroidLoader {
+    private AndroidLoader(Context context) {
+      initialize((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
+    }
+
+    /**
+     * Native binding to register the ConnectivityManager to C-Ares
+     *
+     * @param connectivityManager Android's ConnectivityManager
+     * @return int for successful initialization
+     */
+    private static native int initialize(ConnectivityManager connectivityManager);
   }
 
-  @Override
-  public int runWithConfig(String config) {
-    return envoyEngine.runWithConfig(config);
-  }
-
-  @Override
-  public int runWithConfig(String config, String logLevel) {
-    return envoyEngine.runWithConfig(config, logLevel);
-  }
-
-  /**
-   * Native binding to register the ConnectivityManager to C-Ares
-   *
-   * @param connectivityManager Android's ConnectivityManager
-   * @return int for successful initialization
-   */
-  private static native int initialize(ConnectivityManager connectivityManager);
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
@@ -1,0 +1,43 @@
+package io.envoyproxy.envoymobile.engine;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+
+public class AndroidJniLibrary {
+
+  // Internal reference to helper object used to load and initialize the native library.
+  // Volatile to ensure double-checked locking works correctly.
+  private static volatile AndroidLoader loader = null;
+
+  public static void load(Context context) {
+    if (loader != null) {
+      return;
+    }
+
+    synchronized (AndroidLoader.class) {
+      if (loader != null) {
+        return;
+      }
+
+      JniLibrary.load();
+      loader = new AndroidLoader(context);
+    }
+  }
+
+  // Private helper class used by the load method to ensure the native library and its
+  // dependencies are loaded and initialized at most once.
+  private static class AndroidLoader {
+    private AndroidLoader(Context context) {
+      AndroidJniLibrary.initialize(
+          (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE));
+    }
+  }
+
+  /**
+   * Native binding to register the ConnectivityManager to C-Ares
+   *
+   * @param connectivityManager Android's ConnectivityManager
+   * @return int for successful initialization
+   */
+  protected static native int initialize(ConnectivityManager connectivityManager);
+}

--- a/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
@@ -23,7 +23,7 @@ envoy_mobile_java_library(
     srcs = [
         "EnvoyEngine.java",
         "EnvoyEngineImpl.java",
-        "EnvoyStream.java",
+        "EnvoyHTTPStream.java",
         "JniLibrary.java",
     ],
     visibility = ["//visibility:public"],

--- a/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
@@ -6,6 +6,7 @@ envoy_mobile_android_library(
     name = "envoy_engine_lib",
     srcs = [
         "AndroidEngineImpl.java",
+        "AndroidJniLibrary.java",
     ],
     custom_package = "io.envoyproxy.envoymobile.engine",
     manifest = "AndroidEngineManifest.xml",

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -9,7 +9,7 @@ public interface EnvoyEngine {
    * @param observer The observer for receiving callbacks from the stream.
    * @return A stream that may be used for sending data.
    */
-  EnvoyStream startStream(EnvoyObserver observer);
+  EnvoyHTTPStream startStream(EnvoyObserver observer);
 
   /**
    * Run the Envoy engine with the provided config and log level.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -4,10 +4,14 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
 
 public class EnvoyEngineImpl implements EnvoyEngine {
 
+  // Internal reference to helper object used to load and initialize the native library.
+  // Volatile to ensure double-checked locking works correctly.
+  private static volatile JavaLoader loader = null;
+
   private final long engineHandle;
 
   public EnvoyEngineImpl() {
-    System.loadLibrary("envoy_jni");
+    load();
     this.engineHandle = JniLibrary.initEngine();
   }
 
@@ -48,6 +52,28 @@ public class EnvoyEngineImpl implements EnvoyEngine {
     } catch (Throwable throwable) {
       // TODO: Need to have a way to log the exception somewhere
       return 1;
+    }
+  }
+
+  // Load and initialize Envoy and its dependencies, but only once.
+  protected static void load() {
+    if (loader != null) {
+      return;
+    }
+
+    synchronized (JavaLoader.class) {
+      if (loader != null) {
+        return;
+      }
+
+      loader = new JavaLoader();
+    }
+  }
+
+  private static class JavaLoader {
+
+    private JavaLoader() {
+      System.loadLibrary("envoy_jni");
     }
   }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -18,9 +18,9 @@ public class EnvoyEngineImpl implements EnvoyEngine {
    * @return A stream that may be used for sending data.
    */
   @Override
-  public EnvoyStream startStream(EnvoyObserver observer) {
+  public EnvoyHTTPStream startStream(EnvoyObserver observer) {
     long streamHandle = JniLibrary.initStream(engineHandle);
-    return new EnvoyStream(streamHandle, observer);
+    return new EnvoyHTTPStream(streamHandle, observer);
   }
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -6,7 +6,10 @@ public class EnvoyEngineImpl implements EnvoyEngine {
 
   private final long engineHandle;
 
-  public EnvoyEngineImpl() { this.engineHandle = JniLibrary.initEngine(); }
+  public EnvoyEngineImpl() {
+    System.loadLibrary("envoy_jni");
+    this.engineHandle = JniLibrary.initEngine();
+  }
 
   /**
    * Creates a new stream with the provided observer.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -4,14 +4,10 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
 
 public class EnvoyEngineImpl implements EnvoyEngine {
 
-  // Internal reference to helper object used to load and initialize the native library.
-  // Volatile to ensure double-checked locking works correctly.
-  private static volatile JavaLoader loader = null;
-
   private final long engineHandle;
 
   public EnvoyEngineImpl() {
-    load();
+    JniLibrary.load();
     this.engineHandle = JniLibrary.initEngine();
   }
 
@@ -52,28 +48,6 @@ public class EnvoyEngineImpl implements EnvoyEngine {
     } catch (Throwable throwable) {
       // TODO: Need to have a way to log the exception somewhere
       return 1;
-    }
-  }
-
-  // Load and initialize Envoy and its dependencies, but only once.
-  protected static void load() {
-    if (loader != null) {
-      return;
-    }
-
-    synchronized (JavaLoader.class) {
-      if (loader != null) {
-        return;
-      }
-
-      loader = new JavaLoader();
-    }
-  }
-
-  private static class JavaLoader {
-
-    private JavaLoader() {
-      System.loadLibrary("envoy_jni");
     }
   }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -4,11 +4,11 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyData;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHeaders;
 import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
 
-public class EnvoyStream {
+public class EnvoyHTTPStream {
 
   private final long streamHandle;
 
-  EnvoyStream(long streamHandle, EnvoyObserver observer) {
+  EnvoyHTTPStream(long streamHandle, EnvoyObserver observer) {
     this.streamHandle = streamHandle;
     JniLibrary.startStream(streamHandle, observer);
   }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -5,6 +5,7 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyHeaders;
 import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
 
 class JniLibrary {
+
   /**
    * Initialize an underlying HTTP stream.
    *

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -6,6 +6,36 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
 
 class JniLibrary {
 
+  private static final String ENVOY_JNI = "envoy_jni";
+
+  // Internal reference to helper object used to load and initialize the native library.
+  // Volatile to ensure double-checked locking works correctly.
+  private static volatile JavaLoader loader = null;
+
+  // Load and initialize Envoy and its dependencies, but only once.
+  public static void load() {
+    if (loader != null) {
+      return;
+    }
+
+    synchronized (JavaLoader.class) {
+      if (loader != null) {
+        return;
+      }
+
+      loader = new JavaLoader();
+    }
+  }
+
+  // Private helper class used by the load method to ensure the native library and its
+  // dependencies are loaded and initialized at most once.
+  private static class JavaLoader {
+
+    private JavaLoader() {
+      System.loadLibrary(ENVOY_JNI);
+    }
+  }
+
   /**
    * Initialize an underlying HTTP stream.
    *

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -31,9 +31,7 @@ class JniLibrary {
   // dependencies are loaded and initialized at most once.
   private static class JavaLoader {
 
-    private JavaLoader() {
-      System.loadLibrary(ENVOY_JNI);
-    }
+    private JavaLoader() { System.loadLibrary(ENVOY_JNI); }
   }
 
   /**


### PR DESCRIPTION
Create an `AndroidJniLibrary` and move specific loader logic into the `*JniLibrary` classes. Cleaning up the other layers in Kotlin due to this change.


Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Create an `AndroidJniLibrary` and move specific loader logic into the `*JniLibrary` classes
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
