### PR TITLE
core: comment on setup_envoy/run_engine ordering

### DIFF
--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -50,7 +50,7 @@ envoy_engine_t init_engine() {
 
 /*
  * Setup envoy for interaction via the main interface.
- * As it stands this function __has__ to be executed after run engine.
+ * As it stands this function __must__ be executed after calling `run_engine`.
  * run_engine assigns a static unique pointer used by this function.
  * TODO: this will change when the engine is no longer static:
  * https://github.com/lyft/envoy-mobile/issues/332

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -50,6 +50,10 @@ envoy_engine_t init_engine() {
 
 /*
  * Setup envoy for interaction via the main interface.
+ * As it stands this function __has__ to be executed after run engine.
+ * run_engine assigns a static unique pointer used by this function.
+ * TODO: this will change when the engine is no longer static:
+ * https://github.com/lyft/envoy-mobile/issues/332
  */
 void setup_envoy() {
   http_dispatcher_ = std::make_unique<Envoy::Http::Dispatcher>(


### PR DESCRIPTION
Description: comment describing current ordering between `setup_envoy` and `run_engine` in the main_interface.
Risk Level: low - code comment

Signed-off-by: Jose Nino <jnino@lyft.com>