### PR TITLE
bazel: Repeat dependencies for kt jvm test + add mocking deps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -108,6 +108,9 @@ maven_install(
         # Test artifacts
         "org.assertj:assertj-core:3.9.0",
         "junit:junit:4.12",
+        "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0",
+        "org.mockito:mockito-inline:2.28.2",
+        "org.mockito:mockito-core:2.28.2",
     ],
     repositories = [
         "https://repo1.maven.org/maven2",

--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -26,6 +26,8 @@ def envoy_mobile_kt_test(name, srcs, deps = []):
         # We'll resolve only the targets in `//library/kotlin/src/io/envoyproxy/envoymobile`
         if dep.startswith("//library/kotlin/src/io/envoyproxy/envoymobile"):
             dep_srcs.append(dep + "_srcs")
+        elif dep.startswith("//library/java/src/io/envoyproxy/envoymobile"):
+            dep_srcs.append(dep + "_srcs")
 
     kt_jvm_test(
         name = name,
@@ -35,5 +37,8 @@ def envoy_mobile_kt_test(name, srcs, deps = []):
             "//bazel:envoy_mobile_test_suite",
             "@maven//:org_assertj_assertj_core",
             "@maven//:junit_junit",
-        ],
+            "@maven//:com_nhaarman_mockitokotlin2_mockito_kotlin",
+            "@maven//:org_mockito_mockito_inline",
+            "@maven//:org_mockito_mockito_core",
+        ] + deps,
     )


### PR DESCRIPTION
A few problems:
1. We don't take into account the java directory for test source dependencies
2. We don't take into account the transitive dependencies for sources

This change is to look also at the java directory (not really needed but it'll keep the symmetry between java and kotlin and to include dependencies as actual dependencies for transitive inclusion.

Additionally, add common mocking frameworks:
1. [`org.mockito:mockito`](https://github.com/mockito/mockito)
2. [`com.nhaarman.mockitokotlin2`](https://github.com/nhaarman/mockito-kotlin)

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Repeat dependencies for kt jvm test + add mocking deps
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
