### PR TITLE
kotlin: remove body and trailers from request object to Client interfaces

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/Client.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Client.kt
@@ -9,4 +9,24 @@ interface Client {
    * @return the emitter for streaming data outward.
    */
   fun startStream(request: Request, responseHandler: ResponseHandler): StreamEmitter
+
+
+  /**
+   * Convenience function for sending a unary request.
+   *
+   * @param request  The request to send.
+   * @param body Serialized data to send as the body of the request.
+   * @param trailers Trailers to send with the request.
+   * @param responseHandler the callback for receiving stream events.
+   */
+  fun sendUnary(request: Request, body: ByteArray?, trailers: Map<String, List<String>>, responseHandler: ResponseHandler)
+
+  /**
+   * Convenience function for sending a unary request.
+   *
+   * @param request The request to send.
+   * @param body Serialized data to send as the body of the request.
+   * @param responseHandler the callback for receiving stream events.
+   */
+  fun sendUnary(request: Request, body: ByteArray?, responseHandler: ResponseHandler)
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
@@ -8,7 +8,7 @@ package io.envoyproxy.envoymobile
  * @param authority The URL authority for the request (i.e., "api.foo.com").
  * @param path The URL path for the request (i.e., "/foo").
  */
-class Request internal constructor(
+data class Request internal constructor(
     val method: RequestMethod,
     val scheme: String,
     val authority: String,
@@ -28,31 +28,4 @@ class Request internal constructor(
         .setHeaders(headers)
         .addRetryPolicy(retryPolicy)
   }
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-
-    other as Request
-
-    if (method != other.method) return false
-    if (scheme != other.scheme) return false
-    if (authority != other.authority) return false
-    if (path != other.path) return false
-    if (headers != other.headers) return false
-    if (retryPolicy != other.retryPolicy) return false
-
-    return true
-  }
-
-  override fun hashCode(): Int {
-    var result = method.hashCode()
-    result = 31 * result + scheme.hashCode()
-    result = 31 * result + authority.hashCode()
-    result = 31 * result + path.hashCode()
-    result = 31 * result + headers.hashCode()
-    result = 31 * result + (retryPolicy?.hashCode() ?: 0)
-    return result
-  }
-
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
@@ -14,8 +14,6 @@ class Request internal constructor(
     val authority: String,
     val path: String,
     val headers: Map<String, List<String>>,
-    val trailers: Map<String, List<String>>,
-    val body: ByteArray?,
     val retryPolicy: RetryPolicy?
 ) {
 
@@ -28,8 +26,6 @@ class Request internal constructor(
   fun toBuilder(): RequestBuilder {
     return RequestBuilder(method, scheme, authority, path)
         .setHeaders(headers)
-        .setTrailers(trailers)
-        .addBody(body)
         .addRetryPolicy(retryPolicy)
   }
 
@@ -44,11 +40,6 @@ class Request internal constructor(
     if (authority != other.authority) return false
     if (path != other.path) return false
     if (headers != other.headers) return false
-    if (trailers != other.trailers) return false
-    if (body != null) {
-      if (other.body == null) return false
-      if (!body.contentEquals(other.body)) return false
-    } else if (other.body != null) return false
     if (retryPolicy != other.retryPolicy) return false
 
     return true
@@ -60,9 +51,8 @@ class Request internal constructor(
     result = 31 * result + authority.hashCode()
     result = 31 * result + path.hashCode()
     result = 31 * result + headers.hashCode()
-    result = 31 * result + trailers.hashCode()
-    result = 31 * result + (body?.contentHashCode() ?: 0)
     result = 31 * result + (retryPolicy?.hashCode() ?: 0)
     return result
   }
+
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
@@ -19,23 +19,8 @@ class RequestBuilder(
   // Multiple values for a given name are valid, and will be sent as comma-separated values.
   private val headers: MutableMap<String, MutableList<String>> = mutableMapOf()
 
-  // Trailers to send with the request.
-  // Multiple values for a given name are valid, and will be sent as comma-separated values.
-  private val trailers: MutableMap<String, MutableList<String>> = mutableMapOf()
-
-  // Serialized data to send as the body of the request.
-  private var body: ByteArray? = null
-
   // Retry policy to use for this request.
   private var retryPolicy: RetryPolicy? = null
-
-  /**
-   * Serialized data to send as the body of the request.
-   */
-  fun addBody(body: ByteArray?): RequestBuilder {
-    this.body = body
-    return this
-  }
 
   /**
    * Add a retry policy to use for this request.
@@ -93,52 +78,6 @@ class RequestBuilder(
   }
 
   /**
-   * Append a value to the trailer key.
-   *
-   * @param name the trailer key.
-   * @param value the value associated to the trailer key.
-   * @return this builder.
-   */
-  fun addTrailer(name: String, value: String): RequestBuilder {
-    if (trailers.containsKey(name)) {
-      trailers[name]!!.add(value)
-    } else {
-      trailers[name] = mutableListOf(value)
-    }
-    return this
-  }
-
-  /**
-   * Remove the value in the specified trailer.
-   *
-   * @param name the trailer key to remove.
-   * @param value the value to be removed.
-   * @return this builder.
-   */
-  fun removeTrailers(name: String): RequestBuilder {
-    trailers.remove(name)
-    return this
-  }
-
-  /**
-   * Remove the value in the specified trailer.
-   *
-   * @param name the trailer key to remove.
-   * @param value the value to be removed.
-   * @return this builder.
-   */
-  fun removeTrailer(name: String, value: String): RequestBuilder {
-    if (trailers.containsKey(name)) {
-      trailers[name]!!.remove(value)
-
-      if (trailers[name]!!.isEmpty()) {
-        trailers.remove(name)
-      }
-    }
-    return this
-  }
-
-  /**
    * Creates the {@link io.envoyproxy.envoymobile.Request} object using the data set in the builder.
    *
    * @return the {@link io.envoyproxy.envoymobile.Request} object.
@@ -150,8 +89,6 @@ class RequestBuilder(
         authority,
         path,
         headers,
-        trailers,
-        body,
         retryPolicy
     )
   }
@@ -160,14 +97,6 @@ class RequestBuilder(
     this.headers.clear()
     for (entry in headers) {
       this.headers[entry.key] = entry.value.toMutableList()
-    }
-    return this
-  }
-
-  internal fun setTrailers(trailers: Map<String, List<String>>): RequestBuilder {
-    this.trailers.clear()
-    for (entry in trailers) {
-      this.trailers[entry.key] = entry.value.toMutableList()
     }
     return this
   }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
@@ -6,24 +6,6 @@ import org.junit.Test
 class RequestBuilderTest {
 
   @Test
-  fun `adding request data should have body present in request`() {
-    val body = "data".toByteArray()
-
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addBody(body)
-        .build()
-    assertThat(request.body).isEqualTo(body)
-  }
-
-  @Test
-  fun `not adding request data should have null body in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .build()
-
-    assertThat(request.body).isNull()
-  }
-
-  @Test
   fun `adding retry policy should have policy present in request`() {
 
     val retryPolicy = RetryPolicy(maxRetryCount = 23, retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), perRetryTimeoutMs = 1234)
@@ -49,15 +31,6 @@ class RequestBuilderTest {
         .build()
 
     assertThat(request.headers["header_a"]).contains("value_a1")
-  }
-
-  @Test
-  fun `adding new trailers should append to the list of trailers keys`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addTrailer("trailer_a", "value_a1")
-        .build()
-
-    assertThat(request.trailers["trailer_a"]).contains("value_a1")
   }
 
   @Test
@@ -110,57 +83,5 @@ class RequestBuilderTest {
         .build()
 
     assertThat(request.headers["header_a"]).isNull()
-  }
-
-  @Test
-  fun `removing trailers should clear trailers in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addTrailer("trailer_a", "value_a1")
-        .removeTrailers("trailer_a")
-        .build()
-
-    assertThat(request.trailers).doesNotContainKey("trailer_a")
-  }
-
-  @Test
-  fun `removing a specific trailer value should not be in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addTrailer("trailer_a", "value_a1")
-        .addTrailer("trailer_a", "value_a2")
-        .removeTrailer("trailer_a", "value_a1")
-        .build()
-
-    assertThat(request.trailers["trailer_a"]).doesNotContain("value_a1")
-  }
-
-  @Test
-  fun `removing a specific trailer value should keep the other trailer values in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addTrailer("trailer_a", "value_a1")
-        .addTrailer("trailer_a", "value_a2")
-        .removeTrailer("trailer_a", "value_a1")
-        .build()
-
-    assertThat(request.trailers["trailer_a"]).contains("value_a2")
-  }
-
-  @Test
-  fun `adding a specific trailer value should keep the other trailer values in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addTrailer("trailer_a", "value_a1")
-        .addTrailer("trailer_a", "value_a2")
-        .build()
-
-    assertThat(request.trailers["trailer_a"]).containsExactly("value_a1", "value_a2")
-  }
-
-  @Test
-  fun `removing all trailer values should remove trailer list in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addTrailer("trailer_a", "value_a1")
-        .removeTrailer("trailer_a", "value_a1")
-        .build()
-
-    assertThat(request.trailers["trailer_a"]).isNull()
   }
 }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
@@ -9,23 +9,15 @@ class RequestTest {
   @Test
   fun `requests with the same properties should be equal`() {
     val request1 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addBody("data".toByteArray())
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .addHeader("header_b", "value_b1")
-        .addTrailer("trailer_a", "value_a1")
-        .addTrailer("trailer_a", "value_a2")
-        .addTrailer("trailer_b", "value_b1")
         .build()
 
     val request2 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addBody("data".toByteArray())
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .addHeader("header_b", "value_b1")
-        .addTrailer("trailer_a", "value_a1")
-        .addTrailer("trailer_a", "value_a2")
-        .addTrailer("trailer_b", "value_b1")
         .build()
 
     assertThat(request1).isEqualTo(request2)
@@ -34,14 +26,10 @@ class RequestTest {
   @Test
   fun `requests converted to a builder should build to the same request`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
-        .addBody("data".toByteArray())
         .addRetryPolicy(RetryPolicy(23, listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), 1234))
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .addHeader("header_b", "value_b1")
-        .addTrailer("trailer_a", "value_a1")
-        .addTrailer("trailer_a", "value_a2")
-        .addTrailer("trailer_b", "value_b1")
         .build()
 
     assertThat(request).isEqualTo(request.toBuilder().build())


### PR DESCRIPTION
The request object is no longer going to contain the body and trailers.
For the streaming case, the headers will be sent upon connection but the data/trailers will be handled by the user

For the unary case, the headers and body will be sent upon connection. The trailers will be sent once a response is sent back.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: kotlin: remove body and trailers from request object to Client interfaces
Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
