### PR TITLE
ios: update unary/streaming & add test

### DIFF
--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -67,7 +67,7 @@ final class ViewController: UITableViewController {
                                                 message: "failed within Envoy library")))
       }
 
-    envoy.sendUnary(request, handler: handler)
+    envoy.send(request, data: nil, handler: handler)
   }
 
   private func add(result: Result<Response, RequestError>) {

--- a/library/swift/src/Client.swift
+++ b/library/swift/src/Client.swift
@@ -13,7 +13,7 @@ public protocol Client {
 }
 
 extension Client {
-  /// Convenience function for sending and completing a non-streaming request.
+  /// Convenience function for sending a complete (non-streamed) request.
   ///
   /// - parameter request:  The request to send.
   /// - parameter data:     Serialized data to send as the body of the request.

--- a/library/swift/src/Client.swift
+++ b/library/swift/src/Client.swift
@@ -9,23 +9,28 @@ public protocol Client {
   /// - parameter handler: Handler for receiving stream events.
   ///
   /// - returns: Emitter for sending streaming data outward.
-  func startStream(with request: Request, handler: ResponseHandler) -> StreamEmitter
-
-  /// Convenience function for sending a unary request.
-  ///
-  /// - parameter request:  The request to send.
-  /// - parameter body:     Serialized data to send as the body of the request.
-  /// - parameter trailers: Trailers to send with the request.
-  func sendUnary(_ request: Request, body: Data?,
-                 trailers: [String: [String]], handler: ResponseHandler)
+  func send(_ request: Request, handler: ResponseHandler) -> StreamEmitter
 }
 
 extension Client {
-  /// Convenience function for sending a unary request without trailers.
+  /// Convenience function for sending and completing a non-streaming request.
   ///
   /// - parameter request:  The request to send.
-  /// - parameter body:     Serialized data to send as the body of the request.
-  public func sendUnary(_ request: Request, body: Data?, handler: ResponseHandler) {
-    self.sendUnary(request, body: body, trailers: [:], handler: handler)
+  /// - parameter data:     Serialized data to send as the body of the request.
+  /// - parameter trailers: Trailers to send with the request.
+  ///
+  /// - returns: A cancelable request.
+  @discardableResult
+  public func send(_ request: Request, data: Data?,
+                   trailers: [String: [String]] = [:], handler: ResponseHandler)
+    -> CancelableStream
+  {
+    let emitter = self.send(request, handler: handler)
+    if let data = data {
+      emitter.sendData(data)
+    }
+
+    emitter.close(trailers: trailers)
+    return emitter
   }
 }

--- a/library/swift/src/Envoy.swift
+++ b/library/swift/src/Envoy.swift
@@ -47,20 +47,9 @@ public final class Envoy: NSObject {
 }
 
 extension Envoy: Client {
-  public func startStream(with request: Request, handler: ResponseHandler) -> StreamEmitter {
+  public func send(_ request: Request, handler: ResponseHandler) -> StreamEmitter {
     let httpStream = self.engine.startStream(with: handler.underlyingObserver)
     httpStream.sendHeaders(request.outboundHeaders(), close: false)
     return EnvoyStreamEmitter(stream: httpStream)
-  }
-
-  public func sendUnary(_ request: Request, body: Data?,
-                        trailers: [String: [String]], handler: ResponseHandler)
-  {
-    let emitter = self.startStream(with: request, handler: handler)
-    if let body = body {
-      emitter.sendData(body)
-    }
-
-    emitter.close(trailers: trailers)
   }
 }

--- a/library/swift/src/StreamEmitter.swift
+++ b/library/swift/src/StreamEmitter.swift
@@ -1,8 +1,15 @@
 import Foundation
 
+/// Interface for a stream that may be canceled.
+@objc
+public protocol CancelableStream {
+  /// Cancel and end the associated stream.
+  func cancel()
+}
+
 /// Interface allowing for sending/emitting data on an Envoy stream.
 @objc
-public protocol StreamEmitter {
+public protocol StreamEmitter: CancelableStream {
   /// Send data over the associated stream.
   ///
   /// - parameter data: Data to send over the stream.
@@ -23,9 +30,6 @@ public protocol StreamEmitter {
   ///
   /// - parameter trailers: Trailers to send over the stream.
   func close(trailers: [String: [String]])
-
-  /// Cancel and end the associated stream.
-  func cancel()
 }
 
 extension StreamEmitter {

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -3,6 +3,13 @@ licenses(["notice"])  # Apache 2
 load("//bazel:swift_test.bzl", "envoy_mobile_swift_test")
 
 envoy_mobile_swift_test(
+    name = "client_tests",
+    srcs = [
+        "ClientTests.swift",
+    ],
+)
+
+envoy_mobile_swift_test(
     name = "envoy_builder_tests",
     srcs = [
         "EnvoyBuilderTests.swift",

--- a/library/swift/test/ClientTests.swift
+++ b/library/swift/test/ClientTests.swift
@@ -1,0 +1,72 @@
+import Envoy
+import Foundation
+import XCTest
+
+private final class MockStreamEmitter: StreamEmitter {
+  var onData: ((Data?) -> Void)?
+  var onTrailers: (([String: [String]]) -> Void)?
+
+  func sendData(_ data: Data) -> StreamEmitter {
+    self.onData?(data)
+    return self
+  }
+
+  func sendMetadata(_ metadata: [String: [String]]) -> StreamEmitter {
+    return self
+  }
+
+  func close(trailers: [String: [String]]) {
+    self.onTrailers?(trailers)
+  }
+
+  func cancel() {}
+}
+
+private final class MockClient: Client {
+  var onRequest: ((Request) -> Void)?
+  var onData: ((Data?) -> Void)?
+  var onTrailers: (([String: [String]]) -> Void)?
+
+  func send(_ request: Request, handler: ResponseHandler) -> StreamEmitter {
+    self.onRequest?(request)
+    let emitter = MockStreamEmitter()
+    emitter.onData = self.onData
+    emitter.onTrailers = self.onTrailers
+    return emitter
+  }
+}
+
+final class ClientTests: XCTestCase {
+  func testNonStreamingExtensionSendsRequestDetailsThroughStream() {
+    let requestExpectation = self.expectation(description: "Sends request")
+    let dataExpectation = self.expectation(description: "Sends data")
+    let closeExpectation = self.expectation(description: "Calls close")
+
+    let expectedRequest = RequestBuilder(
+      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
+      .build()
+    let expectedData = Data([1, 2, 3])
+    let expectedTrailers = ["foo": ["bar", "baz"]]
+
+    let mockClient = MockClient()
+    mockClient.onRequest = { request in
+      XCTAssertEqual(expectedRequest, request)
+      requestExpectation.fulfill()
+    }
+
+    mockClient.onData = { data in
+      XCTAssertEqual(expectedData, data)
+      dataExpectation.fulfill()
+    }
+
+    mockClient.onTrailers = { trailers in
+      XCTAssertEqual(expectedTrailers, trailers)
+      closeExpectation.fulfill()
+    }
+
+    mockClient.send(expectedRequest, data: expectedData, trailers: expectedTrailers,
+                    handler: ResponseHandler())
+    self.wait(for: [requestExpectation, dataExpectation, closeExpectation],
+              timeout: 0.1, enforceOrder: true)
+  }
+}


### PR DESCRIPTION
Per the discussion [here](https://github.com/lyft/envoy-mobile/pull/312#discussion_r315820916), updating the unary and streaming interfaces.

- Moved the non-streaming convenience function into an extension on the protocol type so that it's available to all consumers
- Added a test to validate the default behavior of this extension function
- Added a `CancelableStream` protocol which includes a subset of functionality from the `StreamEmitter`, allowing consumers of the unary function to cancel requests without having the ability to send additional data into the stream

Signed-off-by: Michael Rebello <me@michaelrebello.com>