### PR TITLE
ios: split out objc sources with single bridging header

### DIFF
--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -10,7 +10,10 @@ objc_library(
     # twice due to the way they're pulled into our swift framework rule. We should fix this to
     # maintain a valid objc target.
     srcs = [
-        "EnvoyEngine.m",
+        "EnvoyConfiguration.m",
+        "EnvoyEngineImpl.m",
+        "EnvoyHTTPStream.m",
+        "EnvoyObserver.m",
     ],
     hdrs = [
         "EnvoyEngine.h",

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -1,0 +1,11 @@
+#import "library/objective-c/EnvoyEngine.h"
+
+#import "library/common/main_interface.h"
+
+@implementation EnvoyConfiguration
+
++ (NSString *)templateString {
+  return [[NSString alloc] initWithUTF8String:config_template];
+}
+
+@end

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -1,7 +1,7 @@
 #import "library/objective-c/EnvoyEngine.h"
 
 #import "library/common/main_interface.h"
-#import "library/common/include/c_types.h"
+#import "library/common/types/c_types.h"
 
 @implementation EnvoyEngineImpl {
   envoy_engine_t _engineHandle;

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -1,0 +1,39 @@
+#import "library/objective-c/EnvoyEngine.h"
+
+#import "library/common/main_interface.h"
+#import "library/common/include/c_types.h"
+
+@implementation EnvoyEngineImpl {
+  envoy_engine_t _engineHandle;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+  _engineHandle = init_engine();
+  return self;
+}
+
+- (int)runWithConfig:(NSString *)config {
+  return [self runWithConfig:config logLevel:@"info"];
+}
+
+- (int)runWithConfig:(NSString *)config logLevel:(NSString *)logLevel {
+  // Envoy exceptions will only be caught here when compiled for 64-bit arches.
+  // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Exceptions/Articles/Exceptions64Bit.html
+  @try {
+    return (int)run_engine(config.UTF8String, logLevel.UTF8String);
+  } @catch (...) {
+    NSLog(@"Envoy exception caught.");
+    [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyException" object:self];
+    return 1;
+  }
+}
+
+- (EnvoyHTTPStream *)startStreamWithObserver:(EnvoyObserver *)observer {
+  return [[EnvoyHTTPStream alloc] initWithHandle:init_stream(_engineHandle) observer:observer];
+}
+
+@end

--- a/library/objective-c/EnvoyHTTPStream.m
+++ b/library/objective-c/EnvoyHTTPStream.m
@@ -5,59 +5,7 @@
 
 #import <stdatomic.h>
 
-#pragma mark - EnvoyObserver
-
-@implementation EnvoyObserver
-@end
-
-#pragma mark - EnvoyEngineImpl
-
-@implementation EnvoyEngineImpl {
-  envoy_engine_t _engineHandle;
-}
-
-- (instancetype)init {
-  self = [super init];
-  if (!self) {
-    return nil;
-  }
-  _engineHandle = init_engine();
-  return self;
-}
-
-- (int)runWithConfig:(NSString *)config {
-  return [self runWithConfig:config logLevel:@"info"];
-}
-
-- (int)runWithConfig:(NSString *)config logLevel:(NSString *)logLevel {
-  // Envoy exceptions will only be caught here when compiled for 64-bit arches.
-  // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Exceptions/Articles/Exceptions64Bit.html
-  @try {
-    return (int)run_engine(config.UTF8String, logLevel.UTF8String);
-  } @catch (...) {
-    NSLog(@"Envoy exception caught.");
-    [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyException" object:self];
-    return 1;
-  }
-}
-
-- (EnvoyHTTPStream *)startStreamWithObserver:(EnvoyObserver *)observer {
-  return [[EnvoyHTTPStream alloc] initWithHandle:init_stream(_engineHandle) observer:observer];
-}
-
-@end
-
-#pragma mark - EnvoyConfiguration
-
-@implementation EnvoyConfiguration
-
-+ (NSString *)templateString {
-  return [[NSString alloc] initWithUTF8String:config_template];
-}
-
-@end
-
-#pragma mark - Utilities to move elsewhere
+#pragma mark - Utility types and functions
 
 typedef struct {
   EnvoyObserver *observer;

--- a/library/objective-c/EnvoyObserver.m
+++ b/library/objective-c/EnvoyObserver.m
@@ -1,0 +1,4 @@
+#import "library/objective-c/EnvoyEngine.h"
+
+@implementation EnvoyObserver
+@end


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>

Description: Separates Objective-C sources into separate files, separating logic a little bit better. A single bridging header is still required (for now).