### PR TITLE
android: Use new envoy builder + clean up

### DIFF
--- a/examples/java/hello_world/BUILD
+++ b/examples/java/hello_world/BUILD
@@ -9,7 +9,6 @@ android_binary(
     manifest = "AndroidManifest.xml",
     resource_files = [
         "res/layout/activity_main.xml",
-        "res/raw/config.yaml",
     ],
     deps = [
         "//dist:envoy_mobile_android",

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -47,7 +47,7 @@ public class MainActivity extends Activity {
 
     this.envoy = new AndroidEnvoyBuilder(getBaseContext()).build();
 
-    recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
+    recyclerView = (RecyclerView)findViewById(R.id.recycler_view);
     recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
     final ResponseRecyclerViewAdapter adapter = new ResponseRecyclerViewAdapter();
@@ -63,7 +63,7 @@ public class MainActivity extends Activity {
       @Override
       public void run() {
         final Response response = makeRequest();
-        recyclerView.post((Runnable) () -> adapter.add(response));
+        recyclerView.post((Runnable)() -> adapter.add(response));
 
         // Make a call again
         handler.postDelayed(this, TimeUnit.SECONDS.toMillis(1));
@@ -80,7 +80,7 @@ public class MainActivity extends Activity {
     try {
       URL url = new URL(ENDPOINT);
       // Open connection to the envoy thread listening locally on port 9001.
-      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+      HttpURLConnection connection = (HttpURLConnection)url.openConnection();
       connection.setRequestProperty("host", "s3.amazonaws.com");
       int status = connection.getResponseCode();
       if (status == 200) {
@@ -90,7 +90,7 @@ public class MainActivity extends Activity {
         inputStream.close();
         Log.d("Response", "successful response!");
         return new Success(body,
-            serverHeaderField != null ? String.join(", ", serverHeaderField) : "");
+                           serverHeaderField != null ? String.join(", ", serverHeaderField) : "");
       } else {
         return new Failure("failed with status " + status);
       }

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -9,6 +9,7 @@ import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
+import io.envoyproxy.envoymobile.AndroidEnvoyBuilder;
 import io.envoyproxy.envoymobile.Envoy;
 import io.envoyproxy.envoymobile.engine.AndroidEngineImpl;
 import io.envoyproxy.envoymobile.engine.EnvoyEngine;
@@ -44,21 +45,9 @@ public class MainActivity extends Activity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    Context context = getBaseContext();
+    this.envoy = new AndroidEnvoyBuilder(getBaseContext()).build();
 
-    // Create envoy instance with config.
-    String config;
-    try {
-      config = loadEnvoyConfig(getBaseContext(), R.raw.config);
-    } catch (RuntimeException e) {
-      Log.d("MainActivity", "exception getting config.", e);
-      throw new RuntimeException("Can't get config to run envoy.");
-    }
-
-    EnvoyEngine envoyEngine = new AndroidEngineImpl(context);
-    envoy = new Envoy(envoyEngine, config);
-
-    recyclerView = (RecyclerView)findViewById(R.id.recycler_view);
+    recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
     recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
     final ResponseRecyclerViewAdapter adapter = new ResponseRecyclerViewAdapter();
@@ -74,7 +63,7 @@ public class MainActivity extends Activity {
       @Override
       public void run() {
         final Response response = makeRequest();
-        recyclerView.post((Runnable)() -> adapter.add(response));
+        recyclerView.post((Runnable) () -> adapter.add(response));
 
         // Make a call again
         handler.postDelayed(this, TimeUnit.SECONDS.toMillis(1));
@@ -91,7 +80,7 @@ public class MainActivity extends Activity {
     try {
       URL url = new URL(ENDPOINT);
       // Open connection to the envoy thread listening locally on port 9001.
-      HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
       connection.setRequestProperty("host", "s3.amazonaws.com");
       int status = connection.getResponseCode();
       if (status == 200) {
@@ -101,7 +90,7 @@ public class MainActivity extends Activity {
         inputStream.close();
         Log.d("Response", "successful response!");
         return new Success(body,
-                           serverHeaderField != null ? String.join(", ", serverHeaderField) : "");
+            serverHeaderField != null ? String.join(", ", serverHeaderField) : "");
       } else {
         return new Failure("failed with status " + status);
       }

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -110,22 +110,4 @@ public class MainActivity extends Activity {
     bufferedReader.close();
     return stringBuilder.toString();
   }
-
-  private String loadEnvoyConfig(Context context, int configResourceId) throws RuntimeException {
-    InputStream inputStream = context.getResources().openRawResource(configResourceId);
-    InputStreamReader inputReader = new InputStreamReader(inputStream);
-    BufferedReader bufReader = new BufferedReader(inputReader);
-    StringBuilder text = new StringBuilder();
-
-    try {
-      String line;
-      while ((line = bufReader.readLine()) != null) {
-        text.append(line);
-        text.append('\n');
-      }
-    } catch (IOException e) {
-      return null;
-    }
-    return text.toString();
-  }
 }

--- a/examples/java/hello_world/res/raw/config.yaml
+++ b/examples/java/hello_world/res/raw/config.yaml
@@ -1,1 +1,0 @@
-../../../../common/config.yaml

--- a/examples/kotlin/hello_world/BUILD
+++ b/examples/kotlin/hello_world/BUILD
@@ -20,7 +20,6 @@ kt_android_library(
     manifest = "AndroidManifest.xml",
     resource_files = [
         "res/layout/activity_main.xml",
-        "res/raw/config.yaml",
     ],
     deps = [
         "//dist:envoy_mobile_android",

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -1,7 +1,6 @@
 package io.envoyproxy.envoymobile.helloenvoykotlin
 
 import android.app.Activity
-import android.content.Context
 import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
@@ -9,8 +8,8 @@ import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.util.Log
+import io.envoyproxy.envoymobile.AndroidEnvoyBuilder
 import io.envoyproxy.envoymobile.Envoy
-import io.envoyproxy.envoymobile.engine.AndroidEngineImpl
 import io.envoyproxy.envoymobile.shared.Failure
 import io.envoyproxy.envoymobile.shared.Response
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter
@@ -34,9 +33,7 @@ class MainActivity : Activity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
 
-    // Create Envoy instance with config.
-    val envoyEngine = AndroidEngineImpl(baseContext)
-    envoy = Envoy(envoyEngine, loadEnvoyConfig(baseContext, R.raw.config))
+    envoy = AndroidEnvoyBuilder(baseContext).build()
 
     recyclerView = findViewById(R.id.recycler_view) as RecyclerView
     recyclerView.layoutManager = LinearLayoutManager(this)
@@ -70,7 +67,7 @@ class MainActivity : Activity() {
   }
 
   private fun makeRequest(): Response {
-    return  try {
+    return try {
       val url = URL(ENDPOINT)
       // Open connection to the envoy thread listening locally on port 9001
       val connection = url.openConnection() as HttpURLConnection
@@ -91,11 +88,6 @@ class MainActivity : Activity() {
   }
 
   private fun deserialize(inputStream: InputStream): String {
-    return inputStream.bufferedReader().use { reader -> reader.readText() }
-  }
-
-  private fun loadEnvoyConfig(context: Context, configResourceId: Int): String {
-    val inputStream = context.getResources().openRawResource(configResourceId)
     return inputStream.bufferedReader().use { reader -> reader.readText() }
   }
 }

--- a/examples/kotlin/hello_world/res/raw/config.yaml
+++ b/examples/kotlin/hello_world/res/raw/config.yaml
@@ -1,1 +1,0 @@
-../../../../common/config.yaml

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -19,7 +19,6 @@ envoy_mobile_kt_aar_android_library(
     manifest = "EnvoyManifest.xml",
     visibility = ["//visibility:public"],
     deps = [
-        ":envoy_interfaces_lib",
         "//library/java/src/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
         "//library/java/src/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
         "//library/java/src/io/envoyproxy/envoymobile/engine/types:envoy_c_types_lib",

--- a/library/kotlin/src/io/envoyproxy/envoymobile/Envoy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Envoy.kt
@@ -64,11 +64,12 @@ class Envoy constructor(
   }
 
   override fun send(request: Request, data: ByteBuffer?, trailers: Map<String, List<String>>, responseHandler: ResponseHandler): CancelableStream {
-    val stream = engine.startStream(responseHandler.underlyingObserver)
-    stream.sendHeaders(request.headers, false)
-    stream.sendData(data, false)
-    stream.sendTrailers(trailers)
-    return EnvoyStreamEmitter(stream)
+    val stream = send(request, responseHandler)
+    if (data != null) {
+      stream.sendData(data)
+    }
+    stream.close(trailers)
+    return stream
   }
 
   override fun send(request: Request, body: ByteBuffer?, responseHandler: ResponseHandler): CancelableStream {


### PR DESCRIPTION
Using new envoy builders in the example applications and the default config

Doing some clean up also

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Using new envoy builders in the example applications and the default config
Risk Level: low
Testing: ci/local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
