### PR TITLE
core: wire up send trailers

### DIFF
--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -38,7 +38,10 @@ envoy_status_t send_headers(envoy_stream_t stream, envoy_headers headers, bool e
 // TODO: implement.
 envoy_status_t send_data(envoy_stream_t, envoy_data, bool) { return ENVOY_FAILURE; }
 envoy_status_t send_metadata(envoy_stream_t, envoy_headers) { return ENVOY_FAILURE; }
-envoy_status_t send_trailers(envoy_stream_t, envoy_headers) { return ENVOY_FAILURE; }
+
+envoy_status_t send_trailers(envoy_stream_t stream, envoy_headers trailers) {
+  return http_dispatcher_->sendTrailers(stream, trailers);
+}
 
 envoy_status_t reset_stream(envoy_stream_t stream) { return http_dispatcher_->resetStream(stream); }
 


### PR DESCRIPTION
Description: I noticed that the swift iOS demo was leaking streams. This PR fixes the issue by wiring up trailer sending code and causing the stream to close locally.
Risk Level: low
Testing: built and ran the demo app, verified correct closure and clean up via logging.

Co-authored-by: Mike Schore <mike.schore@gmail.com>
Signed-off-by: Jose Nino <jnino@lyft.com>