### PR TITLE
bazel: fix Objective-C compilation & demo

### DIFF
--- a/bazel/swift_static_framework.bzl
+++ b/bazel/swift_static_framework.bzl
@@ -43,6 +43,13 @@ def _swift_static_framework_impl(ctx):
             fail("Unhandled platform '{}'".format(platform))
 
         swift_info = archive[SwiftInfo]
+
+        # We can potentially simplify this if this change lands upstream:
+        # https://github.com/bazelbuild/rules_swift/issues/291
+        objc_headers = archive[apple_common.Objc].header.to_list()
+        print("** Swift info: {}".format(archive[apple_common.Objc].header.to_list()))
+        #        print("** Swift info: {}".format(dir(archive[CcInfo].compilation_context.)))
+
         swiftdoc = swift_info.direct_swiftdocs[0]
         swiftmodule = swift_info.direct_swiftmodules[0]
 

--- a/bazel/swift_static_framework.bzl
+++ b/bazel/swift_static_framework.bzl
@@ -21,6 +21,12 @@ def _zip_binary_arg(module_name, input_file):
         file_path = input_file.path,
     )
 
+def _zip_header_arg(module_name, input_file):
+    return "{module_name}.framework/Headers/{module_name}-Swift.h={file_path}".format(
+        module_name = module_name,
+        file_path = input_file.path,
+    )
+
 def _zip_swift_arg(module_name, swift_identifier, input_file):
     return "{module_name}.framework/Modules/{module_name}.swiftmodule/{swift_identifier}.{ext}={file_path}".format(
         module_name = module_name,
@@ -47,8 +53,9 @@ def _swift_static_framework_impl(ctx):
         # We can potentially simplify this if this change lands upstream:
         # https://github.com/bazelbuild/rules_swift/issues/291
         objc_headers = archive[apple_common.Objc].header.to_list()
-        print("** Swift info: {}".format(archive[apple_common.Objc].header.to_list()))
-        #        print("** Swift info: {}".format(dir(archive[CcInfo].compilation_context.)))
+        objc_header = objc_headers[-1]
+        if objc_header:
+            zip_args.append(_zip_header_arg(module_name, objc_header))
 
         swiftdoc = swift_info.direct_swiftdocs[0]
         swiftmodule = swift_info.direct_swiftmodules[0]

--- a/examples/objective-c/hello_world/AppDelegate.mm
+++ b/examples/objective-c/hello_world/AppDelegate.mm
@@ -16,7 +16,7 @@
   [self.window setRootViewController:controller];
   [self.window makeKeyAndVisible];
 
-  self.envoy = [[EnvoyBuilder new] build];
+  self.envoy = [[EnvoyBuilder new] buildAndReturnError:NULL];
   NSLog(@"Finished launching!");
   return YES;
 }

--- a/examples/objective-c/hello_world/BUILD
+++ b/examples/objective-c/hello_world/BUILD
@@ -12,6 +12,8 @@ objc_library(
     deps = ["//dist:envoy_mobile_ios"],
 )
 
+# This is forces linking of necessary Swift dependencies.
+# https://github.com/bazelbuild/rules_apple/issues/557
 swift_library(
     name = "empty_swift_lib",
     srcs = ["Empty.swift"],

--- a/examples/objective-c/hello_world/BUILD
+++ b/examples/objective-c/hello_world/BUILD
@@ -1,6 +1,7 @@
 licenses(["notice"])  # Apache 2
 
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_framework", "ios_static_framework")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 objc_library(
     name = "appmain",
@@ -11,11 +12,21 @@ objc_library(
     deps = ["//dist:envoy_mobile_ios"],
 )
 
+swift_library(
+    name = "empty_swift_lib",
+    srcs = ["Empty.swift"],
+    module_name = "empty_swift_lib",
+    deps = [],
+)
+
 ios_application(
     name = "app",
     bundle_id = "io.envoyproxy.envoymobile.helloworld",
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = "10.0",
-    deps = ["appmain"],
+    deps = [
+        "appmain",
+        "empty_swift_lib",
+    ],
 )

--- a/examples/objective-c/hello_world/Empty.swift
+++ b/examples/objective-c/hello_world/Empty.swift
@@ -1,0 +1,2 @@
+// This empty Swift file allows us to depend on a Swift library which will
+// properly link Swift dependencies: https://github.com/bazelbuild/rules_apple/issues/557

--- a/examples/objective-c/hello_world/ViewController.mm
+++ b/examples/objective-c/hello_world/ViewController.mm
@@ -71,8 +71,8 @@ NSString *_ENDPOINT = @"http://localhost:9001/api.lyft.com/static/demo/hello_wor
 - (void)performRequest {
   // Note that the request is sent to the envoy thread listening locally on port 9001.
   NSURL *url = [NSURL URLWithString:_ENDPOINT];
-  NSMutableURLRequest *request = [NSURLRequest requestWithURL:url];
-  [request addValue:@"s3.amazonaws.com" forHTTPHeaderField:@"host"];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+ [request addValue:@"s3.amazonaws.com" forHTTPHeaderField:@"host"];
   NSLog(@"Starting request to '%@'", url.path);
 
   self.requestCount++;

--- a/examples/objective-c/hello_world/ViewController.mm
+++ b/examples/objective-c/hello_world/ViewController.mm
@@ -72,7 +72,7 @@ NSString *_ENDPOINT = @"http://localhost:9001/api.lyft.com/static/demo/hello_wor
   // Note that the request is sent to the envoy thread listening locally on port 9001.
   NSURL *url = [NSURL URLWithString:_ENDPOINT];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
- [request addValue:@"s3.amazonaws.com" forHTTPHeaderField:@"host"];
+  [request addValue:@"s3.amazonaws.com" forHTTPHeaderField:@"host"];
   NSLog(@"Starting request to '%@'", url.path);
 
   self.requestCount++;


### PR DESCRIPTION
This updates our static framework rule to properly copy the `-Swift.h` header file from the bazel output directory into our final `Envoy.framework/Headers/Envoy-Swift.h`.

There are a few workarounds here for issues that @kastiglione has been nice enough to file upstream:

**https://github.com/bazelbuild/rules_swift/issues/291**

The code required to find and copy the `-Swift.h` header file could be simplified with this issue.

**https://github.com/bazelbuild/rules_apple/issues/557**

From the Objective-C demo app, we also depend on an empty Swift library to force dependencies like `swiftFoundation` to link.

Resolves https://github.com/lyft/envoy-mobile/issues/230

Signed-off-by: Michael Rebello <me@michaelrebello.com>