### PR TITLE
ci: add timeouts

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,7 @@ jobs:
   linuxdist:
     name: linux_dist
     runs-on: ubuntu-18.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
         with:
@@ -31,6 +32,7 @@ jobs:
   macdist:
     name: mac_dist
     runs-on: macOS-10.14
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
         with:
@@ -47,6 +49,7 @@ jobs:
     name: mac_java_helloworld
     needs: macdist
     runs-on: macOS-10.14
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
         with:
@@ -68,6 +71,7 @@ jobs:
     name: mac_kotlin_helloworld
     needs: macdist
     runs-on: macOS-10.14
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
         with:
@@ -88,6 +92,7 @@ jobs:
   kotlintests:
     name: kotlin_tests
     runs-on: ubuntu-18.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -6,6 +6,7 @@ jobs:
   unittests:
     name: unit_tests
     runs-on: macOS-10.14
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,7 @@ jobs:
   formatall:
     name: format_all
     runs-on: ubuntu-18.04
+    timeout-minutes: 45
     container:
       image: envoyproxy/envoy-build:cfc514546bc0284536893cca5fa43d7128edcd35
     steps:
@@ -19,6 +20,7 @@ jobs:
   precommit:
     name: precommit
     runs-on: macOS-10.14
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
       - name: 'Install precommit'
@@ -28,6 +30,7 @@ jobs:
   swiftlint:
     name: swift_lint
     runs-on: ubuntu-18.04
+    timeout-minutes: 45
     container:
       image: norionomura/swiftlint:0.33.0_swift-5.0
     steps:
@@ -37,6 +40,7 @@ jobs:
   kotlinlint:
     name: kotlin_lint
     runs-on: ubuntu-18.04
+    timeout-minutes: 45
     container:
       image: openjdk:8-jdk
     steps:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,6 +8,7 @@ jobs:
   macdist:
     name: mac_dist
     runs-on: macOS-10.14
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
         with:
@@ -35,6 +36,7 @@ jobs:
   swifttests:
     name: swift_tests
     runs-on: macOS-10.14
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
     # TODO(rebello95): to fill out.

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,6 +6,7 @@ jobs:
   sizecurrent:
     name: size_current
     runs-on: ubuntu-18.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
         with:
@@ -21,6 +22,7 @@ jobs:
   sizemaster:
     name: size_master
     runs-on: ubuntu-18.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
         with:
@@ -39,6 +41,7 @@ jobs:
     name: size_compare
     needs: [sizecurrent, sizemaster]
     runs-on: ubuntu-18.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
       - name: 'Install dependencies'


### PR DESCRIPTION
Description: add tighter timeouts to CI than the default 360 mins.
Risk Level: low

Signed-off-by: Jose Nino <jnino@lyft.com>
