### PR TITLE
java: call Jni.load() before accessing the configuration template

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfigurationImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfigurationImpl.java
@@ -9,6 +9,7 @@ public class EnvoyConfigurationImpl implements EnvoyConfiguration {
    */
   @Override
   public String templateString() {
+    JniLibrary.load();
     return JniLibrary.templateString();
   }
 }


### PR DESCRIPTION
This is the fast solution for this problem

A few options to really root fix here:
1. We hide all `native` methods behind another method which mirrors the current `JniLibrary` interfaces but calls the static `load()` method prior to using any methods (super safe but removes some of the control from when we load the native lib)
2. Only call the `templateString()` method *after* the initialization of the `EnvoyEngine` (feels kind of brittle still)
3. (@goaway's suggestion) Move the configuration resolution down to the Engine layer since that is a lower level detail


Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: java: call Jni.load() before accessing the configuration template
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
