### PR TITLE
bazel: use local spawn_strategy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,7 +8,7 @@ build \
   --ios_minimum_os=10.0 \
   --ios_simulator_device="iPhone X" \
   --ios_simulator_version=12.4 \
-  --spawn_strategy=standalone \
+  --spawn_strategy=local \
   --verbose_failures \
   --workspace_status_command=envoy/bazel/get_workspace_status \
   --xcode_version=10.3.0 \


### PR DESCRIPTION
According to Bazel's [docs](https://docs.bazel.build/versions/master/user-manual.html#flag--spawn_strategy), `standalone` is deprecated, and `local` is now preferred.

Signed-off-by: Michael Rebello <me@michaelrebello.com>