### PR TITLE
android: make response handler arguments non-optional

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
@@ -16,12 +16,12 @@ class ResponseHandler(val executor: Executor) {
 
     override fun getExecutor(): Executor = responseHandler.executor
 
-    override fun onHeaders(headers: Map<String, List<String>>?, endStream: Boolean) {
+    override fun onHeaders(headers: Map<String, List<String>>, endStream: Boolean) {
       val statusCode = headers!![":status"]?.first()?.toIntOrNull() ?: 0
       responseHandler.onHeadersClosure(headers, statusCode, endStream)
     }
 
-    override fun onData(byteBuffer: ByteBuffer?, endStream: Boolean) {
+    override fun onData(byteBuffer: ByteBuffer, endStream: Boolean) {
       responseHandler.onDataClosure(byteBuffer, endStream)
     }
 
@@ -45,7 +45,7 @@ class ResponseHandler(val executor: Executor) {
   internal val underlyingObserver = EnvoyObserverAdapter(this)
 
   private var onHeadersClosure: (headers: Map<String, List<String>>, statusCode: Int, endStream: Boolean) -> Unit = { _, _, _ -> Unit }
-  private var onDataClosure: (byteBuffer: ByteBuffer?, endStream: Boolean) -> Unit = { _, _ -> Unit }
+  private var onDataClosure: (byteBuffer: ByteBuffer, endStream: Boolean) -> Unit = { _, _ -> Unit }
   private var onMetadataClosure: (metadata: Map<String, List<String>>) -> Unit = { Unit }
   private var onTrailersClosure: (trailers: Map<String, List<String>>) -> Unit = { Unit }
   private var onErrorClosure: () -> Unit = { Unit }
@@ -72,7 +72,7 @@ class ResponseHandler(val executor: Executor) {
    *                 and flag indicating if the stream is complete.
    * @return ResponseHandler, this ResponseHandler.
    */
-  fun onData(closure: (byteBuffer: ByteBuffer?, endStream: Boolean) -> Unit): ResponseHandler {
+  fun onData(closure: (byteBuffer: ByteBuffer, endStream: Boolean) -> Unit): ResponseHandler {
     this.onDataClosure = closure
     return this
   }


### PR DESCRIPTION
Description: these fields should not be optional. The callbacks _must_ send up that data.
Risk Level: low
Testing: tested with e2e demo

Signed-off-by: Jose Nino <jnino@lyft.com>