### PR TITLE
cleanup: remove stale todos

### DIFF
--- a/library/common/buffer/utility.cc
+++ b/library/common/buffer/utility.cc
@@ -11,8 +11,6 @@ namespace Utility {
 Buffer::InstancePtr toInternalData(envoy_data data) {
   // This fragment only needs to live until done is called.
   // Therefore, it is sufficient to allocate on the heap, and delete in the done method.
-  // TODO: this method leaks the implementation of Buffer::BridgeFragment and could be improved to
-  // avoid new.
   Buffer::BridgeFragment* fragment = Buffer::BridgeFragment::createBridgeFragment(data);
   InstancePtr buf = std::make_unique<Buffer::OwnedImpl>();
   buf->addBufferFragment(*fragment);

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -36,10 +36,6 @@ public:
   envoy_status_t sendData(envoy_stream_t stream, envoy_data data, bool end_stream);
   envoy_status_t sendMetadata(envoy_stream_t stream, envoy_headers headers, bool end_stream);
   envoy_status_t sendTrailers(envoy_stream_t stream, envoy_headers headers);
-  // TODO: when implementing this function we have to make sure to prevent races with already
-  // scheduled and potentially scheduled callbacks. In order to do so the platform callbacks need to
-  // check for atomic state (boolean most likely) that will be updated here to mark the stream as
-  // closed.
   envoy_status_t resetStream(envoy_stream_t stream);
 
 private:

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -587,8 +587,6 @@ TEST_F(DispatcherTest, ResetInOnHeaders) {
   EXPECT_CALL(stream_callbacks_, onReset());
 
   response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
-  // TODO: Need to finish the data side (sendData, onData) in order to fully verify that onData was
-  // never called due to the reset.
 }
 
 TEST_F(DispatcherTest, StreamTimeout) {


### PR DESCRIPTION
Description: remove todos that were done already.
Risk Level: low

Signed-off-by: Jose Nino <jnino@lyft.com>