### PR TITLE
cleanup: delete dispatcher todo that is done

### DIFF
--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -168,7 +168,6 @@ void Dispatcher::cleanup(envoy_stream_t stream_handle) {
   RELEASE_ASSERT(direct_stream,
                  "cleanup is a private method that is only called with stream ids that exist");
 
-  // TODO: think about thread safety of deleting the DirectStream immediately.
   size_t erased = streams_.erase(stream_handle);
   ASSERT(erased == 1, "cleanup should always remove one entry from the streams map");
   ENVOY_LOG(debug, "[S{}] remove stream", stream_handle);


### PR DESCRIPTION
Description: delete dispatcher todo that is done. This TODO is done as when cleanup happens it is guaranteed that core Envoy will not fire anymore callbacks on that stream, and additionally the platform has also locally closed the stream.
Risk Level: low

Signed-off-by: Jose Nino <jnino@lyft.com>