### PR TITLE
core: partially address race with native retain on stream state

### DIFF
--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -245,7 +245,12 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   jobject retained_context = env->NewGlobalRef(j_context);
   envoy_observer native_obs = {jvm_on_headers, jvm_on_data,     jvm_on_metadata, jvm_on_trailers,
                                jvm_on_error,   jvm_on_complete, retained_context};
-  return start_stream(static_cast<envoy_stream_t>(stream_handle), native_obs);
+  EnvoyStatus result = start_stream(static_cast<envoy_stream_t>(stream_handle), native_obs);
+  if (result != ENVOY_SUCCESS) {
+    env->DeleteGlobalRef(retained_context); // No callbacks are fired and we need to release
+  }
+  env->DeleteLocalRef(jcls_JvmObserverContext);
+  return result;
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData(

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -245,7 +245,7 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   jobject retained_context = env->NewGlobalRef(j_context);
   envoy_observer native_obs = {jvm_on_headers, jvm_on_data,     jvm_on_metadata, jvm_on_trailers,
                                jvm_on_error,   jvm_on_complete, retained_context};
-  EnvoyStatus result = start_stream(static_cast<envoy_stream_t>(stream_handle), native_obs);
+  envoy_status_t result = start_stream(static_cast<envoy_stream_t>(stream_handle), native_obs);
   if (result != ENVOY_SUCCESS) {
     env->DeleteGlobalRef(retained_context); // No callbacks are fired and we need to release
   }

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -242,6 +242,7 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 
   jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
   jmethodID jmid_onHeaders = env->GetMethodID(jcls_JvmObserverContext, "onHeaders", "(JZ)V");
+  // TODO: To be truly safe we may need stronger guarantees of operation ordering on this ref
   jobject retained_context = env->NewGlobalRef(j_context);
   envoy_observer native_obs = {jvm_on_headers, jvm_on_data,     jvm_on_metadata, jvm_on_trailers,
                                jvm_on_error,   jvm_on_complete, retained_context};

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -189,6 +189,7 @@ static void ios_on_error(envoy_error error, void *context) {
 
   // We need create the native-held strong ref on this stream before we call start_stream because
   // start_stream could result in a reset that would release the native ref.
+  // TODO: To be truly safe we probably need stronger guarantees of operation ordering on this ref
   _strongSelf = self;
   envoy_status_t result = start_stream(_streamHandle, native_obs);
   if (result != ENVOY_SUCCESS) {

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -187,12 +187,15 @@ static void ios_on_error(envoy_error error, void *context) {
                                ios_on_error,   ios_on_complete, context};
   _nativeObserver = native_obs;
 
+  // We need create the native-held strong ref on this stream before we call start_stream because
+  // start_stream could result in a reset that would release the native ref.
+  _strongSelf = self;
   envoy_status_t result = start_stream(_streamHandle, native_obs);
   if (result != ENVOY_SUCCESS) {
+    _strongSelf = nil;
     return nil;
   }
 
-  _strongSelf = self;
   return self;
 }
 


### PR DESCRIPTION
Description: Our memory model requires a native retain on stream state that must be available for the duration of the lifecycle of the native stream. This partially addresses a race where the retain might not be in place before the stream is reset - resulting in a leak. In order to fully address this, the retain must be completed such that it prevents re-ordering and is visible to other threads.

Signed-off-by: Mike Schore <mike.schore@gmail.com>