### PR TITLE
bazel: Add avoid_deps to swift_static_framework

### DIFF
--- a/library/swift/src/BUILD
+++ b/library/swift/src/BUILD
@@ -26,4 +26,8 @@ swift_static_framework(
     ],
     visibility = ["//visibility:public"],
     deps = ["//library/objective-c:envoy_engine_objc_lib"],
+    avoid_deps = [
+        "@boringssl//:crypto",
+        "@boringssl//:ssl",
+    ],
 )


### PR DESCRIPTION
This field is analogous to `ios_framework`'s `avoid_deps`. It makes sure
that specifically mentioned static libraries are not included in the
final archive. This is required for us to produce a static archive that
doesn't include BoringSSL, since the Lyft app already includes BoringSSL
as part of gRPC, and we need to link that one instead.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>

Fixes https://github.com/lyft/envoy-mobile/issues/200