### PR TITLE
cleanup: rename instances of 'observer' to 'callbacks'

### DIFF
--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -10,37 +10,37 @@ namespace Envoy {
 namespace Http {
 
 Dispatcher::DirectStreamCallbacks::DirectStreamCallbacks(envoy_stream_t stream,
-                                                         envoy_observer observer,
+                                                         envoy_http_callbacks callbacks,
                                                          Dispatcher& http_dispatcher)
-    : stream_handle_(stream), observer_(observer), http_dispatcher_(http_dispatcher) {}
+    : stream_handle_(stream), callbacks_(callbacks), http_dispatcher_(http_dispatcher) {}
 
 void Dispatcher::DirectStreamCallbacks::onHeaders(HeaderMapPtr&& headers, bool end_stream) {
   ENVOY_LOG(debug, "[S{}] response headers for stream (end_stream={}):\n{}", stream_handle_,
             end_stream, *headers);
   envoy_headers bridge_headers = Utility::toBridgeHeaders(*headers);
-  observer_.on_headers(bridge_headers, end_stream, observer_.context);
+  callbacks_.on_headers(bridge_headers, end_stream, callbacks_.context);
 }
 
 void Dispatcher::DirectStreamCallbacks::onData(Buffer::Instance& data, bool end_stream) {
   ENVOY_LOG(debug, "[S{}] response data for stream (length={} end_stream={})", stream_handle_,
             data.length(), end_stream);
-  observer_.on_data(Buffer::Utility::toBridgeData(data), end_stream, observer_.context);
+  callbacks_.on_data(Buffer::Utility::toBridgeData(data), end_stream, callbacks_.context);
 }
 
 void Dispatcher::DirectStreamCallbacks::onTrailers(HeaderMapPtr&& trailers) {
   ENVOY_LOG(debug, "[S{}] response trailers for stream:\n{}", stream_handle_, *trailers);
-  observer_.on_trailers(Utility::toBridgeHeaders(*trailers), observer_.context);
+  callbacks_.on_trailers(Utility::toBridgeHeaders(*trailers), callbacks_.context);
 }
 
 void Dispatcher::DirectStreamCallbacks::onComplete() {
   ENVOY_LOG(debug, "[S{}] complete stream", stream_handle_);
-  observer_.on_complete(observer_.context);
+  callbacks_.on_complete(callbacks_.context);
   http_dispatcher_.cleanup(stream_handle_);
 }
 
 void Dispatcher::DirectStreamCallbacks::onReset() {
   ENVOY_LOG(debug, "[S{}] remote reset stream", stream_handle_);
-  observer_.on_error({ENVOY_STREAM_RESET, envoy_nodata}, observer_.context);
+  callbacks_.on_error({ENVOY_STREAM_RESET, envoy_nodata}, callbacks_.context);
 }
 
 Dispatcher::DirectStream::DirectStream(envoy_stream_t stream_handle,
@@ -53,10 +53,11 @@ Dispatcher::Dispatcher(Event::Dispatcher& event_dispatcher,
                        Upstream::ClusterManager& cluster_manager)
     : event_dispatcher_(event_dispatcher), cluster_manager_(cluster_manager) {}
 
-envoy_status_t Dispatcher::startStream(envoy_stream_t new_stream_handle, envoy_observer observer) {
-  event_dispatcher_.post([this, observer, new_stream_handle]() -> void {
+envoy_status_t Dispatcher::startStream(envoy_stream_t new_stream_handle,
+                                       envoy_http_callbacks callbacks) {
+  event_dispatcher_.post([this, callbacks, new_stream_handle]() -> void {
     DirectStreamCallbacksPtr callbacks =
-        std::make_unique<DirectStreamCallbacks>(new_stream_handle, observer, *this);
+        std::make_unique<DirectStreamCallbacks>(new_stream_handle, callbacks, *this);
     AsyncClient& async_client = cluster_manager_.httpAsyncClientForCluster("base");
     AsyncClient::Stream* underlying_stream = async_client.start(*callbacks, {});
 

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -28,10 +28,10 @@ public:
    * Attempts to open a new stream to the remote. Note that this function is asynchronous and
    * opening a stream may fail. The returned handle is immediately valid for use with this API, but
    * there is no guarantee it will ever functionally represent an open stream.
-   * @param observer wrapper for callbacks for events on this stream.
+   * @param callbacks wrapper for callbacks for events on this stream.
    * @return envoy_stream_t handle to the stream being created.
    */
-  envoy_status_t startStream(envoy_stream_t stream, envoy_observer observer);
+  envoy_status_t startStream(envoy_stream_t stream, envoy_http_callbacks callbacks);
 
   /**
    * Send headers over an open HTTP stream. This method can be invoked once and needs to be called
@@ -88,7 +88,7 @@ private:
   class DirectStreamCallbacks : public AsyncClient::StreamCallbacks,
                                 public Logger::Loggable<Logger::Id::http> {
   public:
-    DirectStreamCallbacks(envoy_stream_t stream_handle, envoy_observer observer,
+    DirectStreamCallbacks(envoy_stream_t stream_handle, envoy_http_callbacks callbacks,
                           Dispatcher& http_dispatcher);
 
     // AsyncClient::StreamCallbacks
@@ -100,7 +100,7 @@ private:
 
   private:
     const envoy_stream_t stream_handle_;
-    const envoy_observer observer_;
+    const envoy_http_callbacks callbacks_;
     Dispatcher& http_dispatcher_;
   };
 

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -28,10 +28,10 @@ public:
    * Attempts to open a new stream to the remote. Note that this function is asynchronous and
    * opening a stream may fail. The returned handle is immediately valid for use with this API, but
    * there is no guarantee it will ever functionally represent an open stream.
-   * @param callbacks wrapper for callbacks for events on this stream.
+   * @param bridge_callbacks wrapper for callbacks for events on this stream.
    * @return envoy_stream_t handle to the stream being created.
    */
-  envoy_status_t startStream(envoy_stream_t stream, envoy_http_callbacks callbacks);
+  envoy_status_t startStream(envoy_stream_t stream, envoy_http_callbacks bridge_callbacks);
 
   /**
    * Send headers over an open HTTP stream. This method can be invoked once and needs to be called
@@ -88,7 +88,7 @@ private:
   class DirectStreamCallbacks : public AsyncClient::StreamCallbacks,
                                 public Logger::Loggable<Logger::Id::http> {
   public:
-    DirectStreamCallbacks(envoy_stream_t stream_handle, envoy_http_callbacks callbacks,
+    DirectStreamCallbacks(envoy_stream_t stream_handle, envoy_http_callbacks bridge_callbacks,
                           Dispatcher& http_dispatcher);
 
     // AsyncClient::StreamCallbacks
@@ -100,7 +100,7 @@ private:
 
   private:
     const envoy_stream_t stream_handle_;
-    const envoy_http_callbacks callbacks_;
+    const envoy_http_callbacks bridge_callbacks_;
     Dispatcher& http_dispatcher_;
   };
 

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -247,7 +247,8 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   envoy_http_callbacks native_callbacks = {jvm_on_headers,  jvm_on_data,  jvm_on_metadata,
                                            jvm_on_trailers, jvm_on_error, jvm_on_complete,
                                            retained_context};
-  envoy_status_t result = start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks);
+  envoy_status_t result =
+      start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks);
   if (result != ENVOY_SUCCESS) {
     env->DeleteGlobalRef(retained_context); // No callbacks are fired and we need to release
   }

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -67,11 +67,11 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_templateString(JNIEnv* env,
   return result;
 }
 
-// JvmObserverContext
+// JvmCallbackContext
 
 static void pass_headers(JNIEnv* env, envoy_headers headers, jobject j_context) {
-  jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
-  jmethodID jmid_passHeader = env->GetMethodID(jcls_JvmObserverContext, "passHeader", "([B[BZ)V");
+  jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
+  jmethodID jmid_passHeader = env->GetMethodID(jcls_JvmCallbackContext, "passHeader", "([B[BZ)V");
   env->PushLocalFrame(headers.length * 2);
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
     // Note this is just an initial implementation, and we will pass a more optimized structure in
@@ -103,7 +103,7 @@ static void pass_headers(JNIEnv* env, envoy_headers headers, jobject j_context) 
     // consider this and/or periodically popping the frame.
   }
   env->PopLocalFrame(nullptr);
-  env->DeleteLocalRef(jcls_JvmObserverContext);
+  env->DeleteLocalRef(jcls_JvmCallbackContext);
   release_envoy_headers(headers);
 }
 
@@ -121,14 +121,14 @@ static void jvm_on_headers(envoy_headers headers, bool end_stream, void* context
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
 
-  jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
-  jmethodID jmid_onHeaders = env->GetMethodID(jcls_JvmObserverContext, "onHeaders", "(JZ)V");
+  jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
+  jmethodID jmid_onHeaders = env->GetMethodID(jcls_JvmCallbackContext, "onHeaders", "(JZ)V");
   // Note: be careful of JVM types
   // FIXME: make this cast safer
   env->CallVoidMethod(j_context, jmid_onHeaders, (jlong)headers.length,
                       end_stream ? JNI_TRUE : JNI_FALSE);
 
-  env->DeleteLocalRef(jcls_JvmObserverContext);
+  env->DeleteLocalRef(jcls_JvmCallbackContext);
   pass_headers(env, headers, j_context);
 }
 
@@ -137,8 +137,8 @@ static void jvm_on_data(envoy_data data, bool end_stream, void* context) {
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
 
-  jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
-  jmethodID jmid_onData = env->GetMethodID(jcls_JvmObserverContext, "onData", "([BZ)V");
+  jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
+  jmethodID jmid_onData = env->GetMethodID(jcls_JvmCallbackContext, "onData", "([BZ)V");
 
   jbyteArray j_data = env->NewByteArray(data.length);
   // FIXME: check if copied via isCopy
@@ -151,7 +151,7 @@ static void jvm_on_data(envoy_data data, bool end_stream, void* context) {
 
   data.release(data.context);
   env->DeleteLocalRef(j_data);
-  env->DeleteLocalRef(jcls_JvmObserverContext);
+  env->DeleteLocalRef(jcls_JvmCallbackContext);
 }
 
 static void jvm_on_metadata(envoy_headers metadata, void* context) {
@@ -240,17 +240,18 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_startStream(
     JNIEnv* env, jclass, jlong stream_handle, jobject j_context) {
 
-  jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
-  jmethodID jmid_onHeaders = env->GetMethodID(jcls_JvmObserverContext, "onHeaders", "(JZ)V");
+  jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
+  jmethodID jmid_onHeaders = env->GetMethodID(jcls_JvmCallbackContext, "onHeaders", "(JZ)V");
   // TODO: To be truly safe we may need stronger guarantees of operation ordering on this ref
   jobject retained_context = env->NewGlobalRef(j_context);
-  envoy_observer native_obs = {jvm_on_headers, jvm_on_data,     jvm_on_metadata, jvm_on_trailers,
-                               jvm_on_error,   jvm_on_complete, retained_context};
-  envoy_status_t result = start_stream(static_cast<envoy_stream_t>(stream_handle), native_obs);
+  envoy_http_callbacks native_callbacks = {jvm_on_headers,  jvm_on_data,  jvm_on_metadata,
+                                           jvm_on_trailers, jvm_on_error, jvm_on_complete,
+                                           retained_context};
+  envoy_status_t result = start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks);
   if (result != ENVOY_SUCCESS) {
     env->DeleteGlobalRef(retained_context); // No callbacks are fired and we need to release
   }
-  env->DeleteLocalRef(jcls_JvmObserverContext);
+  env->DeleteLocalRef(jcls_JvmCallbackContext);
   return result;
 }
 

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -26,8 +26,8 @@ static std::atomic<envoy_stream_t> current_stream_handle_{0};
 
 envoy_stream_t init_stream(envoy_engine_t) { return current_stream_handle_++; }
 
-envoy_status_t start_stream(envoy_stream_t stream, envoy_observer observer) {
-  http_dispatcher_->startStream(stream, observer);
+envoy_status_t start_stream(envoy_stream_t stream, envoy_http_callbacks callbacks) {
+  http_dispatcher_->startStream(stream, callbacks);
   return ENVOY_SUCCESS;
 }
 

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -71,7 +71,7 @@ envoy_status_t send_metadata(envoy_stream_t stream, envoy_headers metadata);
 envoy_status_t send_trailers(envoy_stream_t stream, envoy_headers trailers);
 
 /**
- * Detach all callbackss from a stream and send an interrupt upstream if supported by transport.
+ * Detach all callbacks from a stream and send an interrupt upstream if supported by transport.
  * @param stream, the stream to evict.
  * @return envoy_status_t, the resulting status of the operation.
  */

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -29,10 +29,10 @@ envoy_stream_t init_stream(envoy_engine_t);
  * Open an underlying HTTP stream. Note: Streams must be started before other other interaction can
  * can occur.
  * @param stream, handle to the stream to be started.
- * @param observer, the observer that will run the stream callbacks.
+ * @param callbacks, the callbacks that will run the stream callbacks.
  * @return envoy_stream, with a stream handle and a success status, or a failure status.
  */
-envoy_status_t start_stream(envoy_stream_t, envoy_observer observer);
+envoy_status_t start_stream(envoy_stream_t, envoy_http_callbacks callbacks);
 
 /**
  * Send headers over an open HTTP stream. This method can be invoked once and needs to be called
@@ -71,7 +71,7 @@ envoy_status_t send_metadata(envoy_stream_t stream, envoy_headers metadata);
 envoy_status_t send_trailers(envoy_stream_t stream, envoy_headers trailers);
 
 /**
- * Detach all observers from a stream and send an interrupt upstream if supported by transport.
+ * Detach all callbackss from a stream and send an interrupt upstream if supported by transport.
  * @param stream, the stream to evict.
  * @return envoy_status_t, the resulting status of the operation.
  */

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -187,4 +187,4 @@ typedef struct {
   envoy_on_error_f on_error;
   envoy_on_complete_f on_complete;
   void* context; // Will be passed through to callbacks to provide dispatch and execution state.
-} envoy_observer;
+} envoy_http_callbacks;

--- a/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
@@ -27,7 +27,7 @@ envoy_mobile_java_library(
         "EnvoyEngineImpl.java",
         "EnvoyHTTPStream.java",
         "JniLibrary.java",
-        "JvmObserverContext.java",
+        "JvmCallbackContext.java",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -1,15 +1,15 @@
 package io.envoyproxy.envoymobile.engine;
 
-import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 
 public interface EnvoyEngine {
   /**
-   * Creates a new stream with the provided observer.
+   * Creates a new stream with the provided callbacks.
    *
-   * @param observer The observer for receiving callbacks from the stream.
+   * @param callbacks The callbacks for receiving callbacks from the stream.
    * @return A stream that may be used for sending data.
    */
-  EnvoyHTTPStream startStream(EnvoyObserver observer);
+  EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks);
 
   /**
    * Run the Envoy engine with the provided config and log level.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile.engine;
 
-import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 
 public class EnvoyEngineImpl implements EnvoyEngine {
 
@@ -12,15 +12,15 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   }
 
   /**
-   * Creates a new stream with the provided observer.
+   * Creates a new stream with the provided callbacks.
    *
-   * @param observer The observer for receiving callbacks from the stream.
+   * @param callbacks The callbacks for receiving callbacks from the stream.
    * @return A stream that may be used for sending data.
    */
   @Override
-  public EnvoyHTTPStream startStream(EnvoyObserver observer) {
+  public EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks) {
     long streamHandle = JniLibrary.initStream(engineHandle);
-    return new EnvoyHTTPStream(streamHandle, observer);
+    return new EnvoyHTTPStream(streamHandle, callbacks);
   }
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -14,7 +14,7 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   /**
    * Creates a new stream with the provided callbacks.
    *
-   * @param callbacks The callbacks for receiving callbacks from the stream.
+   * @param callbacks The callbacks for the stream.
    * @return A stream that may be used for sending data.
    */
   @Override

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile.engine;
 
-import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.ByteBuffer;
@@ -11,12 +11,12 @@ import java.util.Map;
 public class EnvoyHTTPStream {
 
   private final long streamHandle;
-  private final JvmObserverContext observerContext;
+  private final JvmCallbackContext callbacksContext;
 
-  EnvoyHTTPStream(long streamHandle, EnvoyObserver observer) {
+  EnvoyHTTPStream(long streamHandle, EnvoyHTTPCallbacks callbacks) {
     this.streamHandle = streamHandle;
-    observerContext = new JvmObserverContext(observer);
-    JniLibrary.startStream(streamHandle, observerContext);
+    callbacksContext = new JvmCallbackContext(callbacks);
+    JniLibrary.startStream(streamHandle, callbacksContext);
   }
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile.engine;
 
-import io.envoyproxy.envoymobile.engine.types.EnvoyObserver;
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -51,12 +51,12 @@ class JniLibrary {
    * other interaction can can occur.
    *
    * @param stream,  handle to the stream to be started.
-   * @param context, context that contains dispatch logic to fire observer
+   * @param context, context that contains dispatch logic to fire callbacks
    *                 callbacks.
    * @return envoy_stream, with a stream handle and a success status, or a failure
    *         status.
    */
-  protected static native int startStream(long stream, JvmObserverContext context);
+  protected static native int startStream(long stream, JvmCallbackContext context);
 
   /**
    * Send headers over an open HTTP stream. This method can be invoked once and
@@ -100,7 +100,7 @@ class JniLibrary {
   protected static native int sendTrailers(long stream, byte[][] trailers);
 
   /**
-   * Detach all observers from a stream and send an interrupt upstream if
+   * Detach all callbackss from a stream and send an interrupt upstream if
    * supported by transport.
    *
    * @param stream, the stream to evict.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -100,7 +100,7 @@ class JniLibrary {
   protected static native int sendTrailers(long stream, byte[][] trailers);
 
   /**
-   * Detach all callbackss from a stream and send an interrupt upstream if
+   * Detach all callbacks from a stream and send an interrupt upstream if
    * supported by transport.
    *
    * @param stream, the stream to evict.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/BUILD
@@ -7,7 +7,7 @@ envoy_mobile_java_library(
     srcs = [
         "EnvoyError.java",
         "EnvoyErrorCode.java",
-        "EnvoyObserver.java",
+        "EnvoyHTTPCallbacks.java",
         "EnvoyStatus.java",
     ],
     visibility = ["//visibility:public"],

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
@@ -5,7 +5,7 @@ import java.util.concurrent.Executor;
 import java.util.List;
 import java.util.Map;
 
-public interface EnvoyObserver {
+public interface EnvoyHTTPCallbacks {
 
   Executor getExecutor();
 

--- a/library/kotlin/src/io/envoyproxy/envoymobile/Envoy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Envoy.kt
@@ -58,7 +58,7 @@ class Envoy constructor(
   }
 
   override fun send(request: Request, responseHandler: ResponseHandler): StreamEmitter {
-    val stream = engine.startStream(responseHandler.underlyingObserver)
+    val stream = engine.startStream(responseHandler.underlyingCallbacks)
     stream.sendHeaders(request.outboundHeaders(), false)
     return EnvoyStreamEmitter(stream)
   }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile
 
-import io.envoyproxy.envoymobile.engine.types.EnvoyObserver
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks
 import java.nio.ByteBuffer
 import java.util.concurrent.Executor;
 
@@ -10,9 +10,9 @@ import java.util.concurrent.Executor;
  */
 class ResponseHandler(val executor: Executor) {
 
-  class EnvoyObserverAdapter(
+  class EnvoyHTTPCallbacksAdapter(
       private val responseHandler: ResponseHandler
-  ) : EnvoyObserver {
+  ) : EnvoyHTTPCallbacks {
 
     override fun getExecutor(): Executor = responseHandler.executor
 
@@ -42,7 +42,7 @@ class ResponseHandler(val executor: Executor) {
     }
   }
 
-  internal val underlyingObserver = EnvoyObserverAdapter(this)
+  internal val underlyingCallbacks = EnvoyHTTPCallbacksAdapter(this)
 
   private var onHeadersClosure: (headers: Map<String, List<String>>, statusCode: Int, endStream: Boolean) -> Unit = { _, _, _ -> Unit }
   private var onDataClosure: (byteBuffer: ByteBuffer, endStream: Boolean) -> Unit = { _, _ -> Unit }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHandlerTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHandlerTest.kt
@@ -10,7 +10,7 @@ class ResponseHandlerTest {
   fun `parsing status code from headers returns first status code`() {
     val headers = mapOf(":status" to listOf("204", "200"), "other" to listOf("1"))
     val responseHandler = ResponseHandler(Executor {})
-    responseHandler.underlyingObserver.onHeaders(headers, false)
+    responseHandler.underlyingCallbacks.onHeaders(headers, false)
 
     responseHandler.onHeaders { _, statusCode, _ -> assertThat(statusCode).isEqualTo(204) }
   }
@@ -19,7 +19,7 @@ class ResponseHandlerTest {
   fun `parsing invalid status code from headers returns 0`() {
     val headers = mapOf(":status" to listOf("invalid"), "other" to listOf("1"))
     val responseHandler = ResponseHandler(Executor {})
-    responseHandler.underlyingObserver.onHeaders(headers, false)
+    responseHandler.underlyingCallbacks.onHeaders(headers, false)
 
     responseHandler.onHeaders { _, statusCode, _ -> assertThat(statusCode).isEqualTo(0) }
 
@@ -29,7 +29,7 @@ class ResponseHandlerTest {
   fun `parsing missing status code from headers returns 0`() {
     val headers = mapOf("other" to listOf("1"))
     val responseHandler = ResponseHandler(Executor {})
-    responseHandler.underlyingObserver.onHeaders(headers, false)
+    responseHandler.underlyingCallbacks.onHeaders(headers, false)
 
     responseHandler.onHeaders { _, statusCode, _ -> assertThat(statusCode).isEqualTo(0) }
   }

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -12,8 +12,8 @@ objc_library(
     srcs = [
         "EnvoyConfiguration.m",
         "EnvoyEngineImpl.m",
+        "EnvoyHTTPCallbacks.m",
         "EnvoyHTTPStreamImpl.m",
-        "EnvoyObserver.m",
     ],
     hdrs = [
         "EnvoyEngine.h",

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -7,10 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// A set of headers that may be passed to/from an Envoy stream.
 typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
-#pragma mark - EnvoyObserver
+#pragma mark - EnvoyHTTPCallbacks
 
 /// Interface that can handle callbacks from an HTTP stream.
-@interface EnvoyObserver : NSObject
+@interface EnvoyHTTPCallbacks : NSObject
 
 /**
  * Dispatch queue provided to handle callbacks.
@@ -66,9 +66,9 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  Open an underlying HTTP stream.
 
  @param handle Underlying handle of the HTTP stream owned by an Envoy engine.
- @param observer The observer that will run the stream callbacks.
+ @param callbacks The callbacks that will run the stream callbacks.
  */
-- (instancetype)initWithHandle:(uint64_t)handle observer:(EnvoyObserver *)observer;
+- (instancetype)initWithHandle:(uint64_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks;
 
 /**
  Send headers over the provided stream.
@@ -147,9 +147,9 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 /**
  Opens a new HTTP stream attached to this engine.
 
- @param observer Handler for observing stream events.
+ @param callbacks Handler for observing stream events.
  */
-- (id<EnvoyHTTPStream>)startStreamWithObserver:(EnvoyObserver *)observer;
+- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks;
 
 @end
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -66,7 +66,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  Open an underlying HTTP stream.
 
  @param handle Underlying handle of the HTTP stream owned by an Envoy engine.
- @param callbacks The callbacks that will run the stream callbacks.
+ @param callbacks The callbacks for the stream.
  */
 - (instancetype)initWithHandle:(uint64_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks;
 

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -32,8 +32,9 @@
   }
 }
 
-- (id<EnvoyHTTPStream>)startStreamWithObserver:(EnvoyObserver *)observer {
-  return [[EnvoyHTTPStreamImpl alloc] initWithHandle:init_stream(_engineHandle) observer:observer];
+- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks {
+  return [[EnvoyHTTPStreamImpl alloc] initWithHandle:init_stream(_engineHandle)
+                                           callbacks:callbacks];
 }
 
 @end

--- a/library/objective-c/EnvoyHTTPCallbacks.m
+++ b/library/objective-c/EnvoyHTTPCallbacks.m
@@ -1,4 +1,4 @@
 #import "library/objective-c/EnvoyEngine.h"
 
-@implementation EnvoyObserver
+@implementation EnvoyHTTPCallbacks
 @end

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -8,7 +8,7 @@
 #pragma mark - Utility types and functions
 
 typedef struct {
-  EnvoyObserver *observer;
+  EnvoyHTTPCallbacks *callbacks;
   atomic_bool *canceled;
 } ios_context;
 
@@ -80,53 +80,53 @@ static EnvoyHeaders *to_ios_headers(envoy_headers headers) {
 
 static void ios_on_headers(envoy_headers headers, bool end_stream, void *context) {
   ios_context *c = (ios_context *)context;
-  EnvoyObserver *observer = c->observer;
+  EnvoyHTTPCallbacks *callbacks = c->callbacks;
   // TODO: protection against null pointers.
-  dispatch_async(observer.dispatchQueue, ^{
+  dispatch_async(callbacks.dispatchQueue, ^{
     if (atomic_load(c->canceled)) {
       return;
     }
-    observer.onHeaders(to_ios_headers(headers), end_stream);
+    callbacks.onHeaders(to_ios_headers(headers), end_stream);
   });
 }
 
 static void ios_on_data(envoy_data data, bool end_stream, void *context) {
   ios_context *c = (ios_context *)context;
-  EnvoyObserver *observer = c->observer;
-  dispatch_async(observer.dispatchQueue, ^{
+  EnvoyHTTPCallbacks *callbacks = c->callbacks;
+  dispatch_async(callbacks.dispatchQueue, ^{
     if (atomic_load(c->canceled)) {
       return;
     }
-    observer.onData(to_ios_data(data), end_stream);
+    callbacks.onData(to_ios_data(data), end_stream);
   });
 }
 
 static void ios_on_metadata(envoy_headers metadata, void *context) {
   ios_context *c = (ios_context *)context;
-  EnvoyObserver *observer = c->observer;
-  dispatch_async(observer.dispatchQueue, ^{
+  EnvoyHTTPCallbacks *callbacks = c->callbacks;
+  dispatch_async(callbacks.dispatchQueue, ^{
     if (atomic_load(c->canceled)) {
       return;
     }
-    observer.onMetadata(to_ios_headers(metadata));
+    callbacks.onMetadata(to_ios_headers(metadata));
   });
 }
 
 static void ios_on_trailers(envoy_headers trailers, void *context) {
   ios_context *c = (ios_context *)context;
-  EnvoyObserver *observer = c->observer;
-  dispatch_async(observer.dispatchQueue, ^{
+  EnvoyHTTPCallbacks *callbacks = c->callbacks;
+  dispatch_async(callbacks.dispatchQueue, ^{
     if (atomic_load(c->canceled)) {
       return;
     }
-    observer.onTrailers(to_ios_headers(trailers));
+    callbacks.onTrailers(to_ios_headers(trailers));
   });
 }
 
 static void ios_on_complete(void *context) {
   ios_context *c = (ios_context *)context;
-  EnvoyObserver *observer = c->observer;
-  dispatch_async(observer.dispatchQueue, ^{
+  EnvoyHTTPCallbacks *callbacks = c->callbacks;
+  dispatch_async(callbacks.dispatchQueue, ^{
     // TODO: release stream
     if (atomic_load(c->canceled)) {
       return;
@@ -136,24 +136,24 @@ static void ios_on_complete(void *context) {
 
 static void ios_on_cancel(void *context) {
   ios_context *c = (ios_context *)context;
-  EnvoyObserver *observer = c->observer;
+  EnvoyHTTPCallbacks *callbacks = c->callbacks;
   // TODO: release stream
-  dispatch_async(observer.dispatchQueue, ^{
+  dispatch_async(callbacks.dispatchQueue, ^{
     // This call is atomically gated at the call-site and will only happen once.
-    observer.onCancel();
+    callbacks.onCancel();
   });
 }
 
 static void ios_on_error(envoy_error error, void *context) {
   ios_context *c = (ios_context *)context;
-  EnvoyObserver *observer = c->observer;
-  dispatch_async(observer.dispatchQueue, ^{
+  EnvoyHTTPCallbacks *callbacks = c->callbacks;
+  dispatch_async(callbacks.dispatchQueue, ^{
     // TODO: release stream
     if (atomic_load(c->canceled)) {
       return;
     }
     // FIXME transform error and pass up
-    observer.onError();
+    callbacks.onError();
   });
 }
 
@@ -161,37 +161,38 @@ static void ios_on_error(envoy_error error, void *context) {
 
 @implementation EnvoyHTTPStreamImpl {
   EnvoyHTTPStreamImpl *_strongSelf;
-  EnvoyObserver *_platformObserver;
-  envoy_observer _nativeObserver;
+  EnvoyHTTPCallbacks *_platformCallbacks;
+  envoy_http_callbacks _nativeCallbacks;
   envoy_stream_t _streamHandle;
 }
 
-- (instancetype)initWithHandle:(uint64_t)handle observer:(EnvoyObserver *)observer {
+- (instancetype)initWithHandle:(uint64_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks {
   self = [super init];
   if (!self) {
     return nil;
   }
 
   _streamHandle = handle;
-  // Retain platform observer
-  _platformObserver = observer;
+  // Retain platform callbacks
+  _platformCallbacks = callbacks;
 
   // Create callback context
   ios_context *context = malloc(sizeof(ios_context));
-  context->observer = observer;
+  context->callbacks = callbacks;
   context->canceled = malloc(sizeof(atomic_bool));
   atomic_store(context->canceled, NO);
 
-  // Create native observer
-  envoy_observer native_obs = {ios_on_headers, ios_on_data,     ios_on_trailers, ios_on_metadata,
-                               ios_on_error,   ios_on_complete, context};
-  _nativeObserver = native_obs;
+  // Create native callbacks
+  envoy_http_callbacks native_callbacks = {ios_on_headers,  ios_on_data,  ios_on_trailers,
+                                           ios_on_metadata, ios_on_error, ios_on_complete,
+                                           context};
+  _nativeCallbacks = native_callbacks;
 
   // We need create the native-held strong ref on this stream before we call start_stream because
   // start_stream could result in a reset that would release the native ref.
   // TODO: To be truly safe we probably need stronger guarantees of operation ordering on this ref
   _strongSelf = self;
-  envoy_status_t result = start_stream(_streamHandle, native_obs);
+  envoy_status_t result = start_stream(_streamHandle, native_callbacks);
   if (result != ENVOY_SUCCESS) {
     _strongSelf = nil;
     return nil;
@@ -201,8 +202,8 @@ static void ios_on_error(envoy_error error, void *context) {
 }
 
 - (void)dealloc {
-  envoy_observer native_obs = _nativeObserver;
-  ios_context *context = native_obs.context;
+  envoy_http_callbacks native_callbacks = _nativeCallbacks;
+  ios_context *context = native_callbacks.context;
   free(context->canceled);
   free(context);
 }
@@ -224,7 +225,7 @@ static void ios_on_error(envoy_error error, void *context) {
 }
 
 - (int)cancel {
-  ios_context *context = _nativeObserver.context;
+  ios_context *context = _nativeCallbacks.context;
   // Step 1: atomically and synchronously prevent the execution of further callbacks other than
   // on_cancel.
   if (!atomic_exchange(context->canceled, YES)) {

--- a/library/swift/src/Envoy.swift
+++ b/library/swift/src/Envoy.swift
@@ -48,7 +48,7 @@ public final class Envoy: NSObject {
 
 extension Envoy: Client {
   public func send(_ request: Request, handler: ResponseHandler) -> StreamEmitter {
-    let httpStream = self.engine.startStream(with: handler.underlyingObserver)
+    let httpStream = self.engine.startStream(with: handler.underlyingCallbacks)
     httpStream.sendHeaders(request.outboundHeaders(), close: false)
     return EnvoyStreamEmitter(stream: httpStream)
   }

--- a/library/swift/src/ResponseHandler.swift
+++ b/library/swift/src/ResponseHandler.swift
@@ -3,14 +3,14 @@ import Foundation
 /// Callback interface for receiving stream events.
 @objcMembers
 public final class ResponseHandler: NSObject {
-  /// Underlying observer which will be passed to the Envoy Engine.
-  let underlyingObserver = EnvoyObserver()
+  /// Underlying callbacks which will be passed to the Envoy Engine.
+  let underlyingCallbacks = EnvoyHTTPCallbacks()
 
   /// Initialize a new instance of the handler.
   ///
   /// - parameter queue: Dispatch queue upon which callbacks will be called.
   public init(queue: DispatchQueue = .main) {
-    self.underlyingObserver.dispatchQueue = queue
+    self.underlyingCallbacks.dispatchQueue = queue
   }
 
   /// Specify a callback for when response headers are received by the stream.
@@ -23,7 +23,7 @@ public final class ResponseHandler: NSObject {
     @escaping (_ headers: [String: [String]], _ statusCode: Int, _ endStream: Bool) -> Void)
     -> ResponseHandler
   {
-    self.underlyingObserver.onHeaders = { headers, endStream in
+    self.underlyingCallbacks.onHeaders = { headers, endStream in
       closure(headers, ResponseHandler.statusCode(fromHeaders: headers), endStream)
     }
 
@@ -40,7 +40,7 @@ public final class ResponseHandler: NSObject {
     @escaping (_ data: Data, _ endStream: Bool) -> Void)
     -> ResponseHandler
   {
-    self.underlyingObserver.onData = closure
+    self.underlyingCallbacks.onData = closure
     return self
   }
 
@@ -53,7 +53,7 @@ public final class ResponseHandler: NSObject {
     @escaping (_ trailers: [String: [String]]) -> Void)
     -> ResponseHandler
   {
-    self.underlyingObserver.onTrailers = closure
+    self.underlyingCallbacks.onTrailers = closure
     return self
   }
 
@@ -66,7 +66,7 @@ public final class ResponseHandler: NSObject {
     @escaping () -> Void)
     -> ResponseHandler
   {
-    self.underlyingObserver.onError = closure
+    self.underlyingCallbacks.onError = closure
     return self
   }
 
@@ -79,7 +79,7 @@ public final class ResponseHandler: NSObject {
     @escaping () -> Void)
     -> ResponseHandler
   {
-    self.underlyingObserver.onCancel = closure
+    self.underlyingCallbacks.onCancel = closure
     return self
   }
 

--- a/library/swift/test/EnvoyBuilderTests.swift
+++ b/library/swift/test/EnvoyBuilderTests.swift
@@ -25,8 +25,8 @@ private final class MockEnvoyEngine: NSObject, EnvoyEngine {
 
   func setup() {}
 
-  func startStream(with observer: EnvoyObserver) -> EnvoyHTTPStream {
-    return MockEnvoyHTTPStream(handle: 0, observer: observer)
+  func startStream(with callbacks: EnvoyHTTPCallbacks) -> EnvoyHTTPStream {
+    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
   }
 }
 

--- a/library/swift/test/EnvoyTests.swift
+++ b/library/swift/test/EnvoyTests.swift
@@ -11,8 +11,8 @@ private final class MockEnvoyEngine: EnvoyEngine {
     return 0
   }
 
-  func startStream(with observer: EnvoyObserver) -> EnvoyHTTPStream {
-    return MockEnvoyHTTPStream(handle: 0, observer: observer)
+  func startStream(with callbacks: EnvoyHTTPCallbacks) -> EnvoyHTTPStream {
+    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
   }
 }
 

--- a/library/swift/test/MockEnvoyHTTPStream.swift
+++ b/library/swift/test/MockEnvoyHTTPStream.swift
@@ -6,7 +6,7 @@ final class MockEnvoyHTTPStream {
   static var onData: ((Data, Bool) -> Void)?
   static var onTrailers: (([String: [String]]) -> Void)?
 
-  init(handle: UInt64, observer: EnvoyObserver) {}
+  init(handle: UInt64, callbacks: EnvoyHTTPCallbacks) {}
 }
 
 extension MockEnvoyHTTPStream: EnvoyHTTPStream {

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -59,23 +59,23 @@ public:
   Http::ContextImpl http_context_;
   AsyncClientImpl client_;
   Dispatcher http_dispatcher_;
-  envoy_observer observer_;
+  envoy_http_callbacks callbacks_;
 };
 
 TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
   envoy_stream_t stream = 1;
-  // Setup observer to handle the response headers.
-  envoy_observer observer;
+  // Setup callbacks to handle the response headers.
+  envoy_http_callbacks callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  observer.context = &cc;
-  observer.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  callbacks.context = &cc;
+  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
     ASSERT_TRUE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  observer.on_complete = [](void* context) -> void {
+  callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -101,7 +101,7 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb;
@@ -127,7 +127,7 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
                      .counter("internal.upstream_rq_200")
                      .value());
 
-  // Ensure that the callbacks on the observer were called.
+  // Ensure that the callbacks on the callbacks were called.
   ASSERT_EQ(cc.on_headers_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 1);
   ASSERT_EQ(cc.on_data_calls, 0);
@@ -135,24 +135,24 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
 
 TEST_F(DispatcherTest, BasicStream) {
   envoy_stream_t stream = 1;
-  // Setup observer to handle the response.
-  envoy_observer observer;
+  // Setup callbacks to handle the response.
+  envoy_http_callbacks callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  observer.context = &cc;
-  observer.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  callbacks.context = &cc;
+  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
     ASSERT_FALSE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  observer.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void {
+  callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void {
     ASSERT_TRUE(end_stream);
     ASSERT_EQ(Http::Utility::convertToString(c_data), "response body");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
   };
-  observer.on_complete = [](void* context) -> void {
+  callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -182,7 +182,7 @@ TEST_F(DispatcherTest, BasicStream) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb headers_post_cb;
@@ -217,7 +217,7 @@ TEST_F(DispatcherTest, BasicStream) {
                      .counter("internal.upstream_rq_200")
                      .value());
 
-  // Ensure that the callbacks on the observer were called.
+  // Ensure that the callbacks on the callbacks were called.
   ASSERT_EQ(cc.on_headers_calls, 1);
   ASSERT_EQ(cc.on_data_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 1);
@@ -225,16 +225,16 @@ TEST_F(DispatcherTest, BasicStream) {
 
 TEST_F(DispatcherTest, ResetStream) {
   envoy_stream_t stream = 1;
-  envoy_observer observer;
+  envoy_http_callbacks callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  observer.context = &cc;
-  observer.on_error = [](envoy_error actual_error, void* context) -> void {
+  callbacks.context = &cc;
+  callbacks.on_error = [](envoy_error actual_error, void* context) -> void {
     envoy_error expected_error = {ENVOY_STREAM_RESET, envoy_nodata};
     ASSERT_EQ(actual_error.error_code, expected_error.error_code);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
-  observer.on_complete = [](void* context) -> void {
+  callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -245,7 +245,7 @@ TEST_F(DispatcherTest, ResetStream) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
 
   Event::PostCb post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
@@ -254,7 +254,7 @@ TEST_F(DispatcherTest, ResetStream) {
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   post_cb();
 
-  // Ensure that the on_error on the observer was called.
+  // Ensure that the on_error on the callbacks was called.
   ASSERT_EQ(cc.on_error_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 0);
 }
@@ -263,18 +263,18 @@ TEST_F(DispatcherTest, MultipleStreams) {
   envoy_stream_t stream1 = 1;
   envoy_stream_t stream2 = 2;
   // Start stream1.
-  // Setup observer to handle the response headers.
-  envoy_observer observer;
+  // Setup callbacks to handle the response headers.
+  envoy_http_callbacks callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  observer.context = &cc;
-  observer.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  callbacks.context = &cc;
+  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
     ASSERT_TRUE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  observer.on_complete = [](void* context) -> void {
+  callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -300,7 +300,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream1, observer), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream1, callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb;
@@ -312,20 +312,20 @@ TEST_F(DispatcherTest, MultipleStreams) {
   post_cb();
 
   // Start stream2.
-  // Setup observer to handle the response headers.
+  // Setup callbacks to handle the response headers.
   NiceMock<MockStreamEncoder> stream_encoder2;
   StreamDecoder* response_decoder2{};
-  envoy_observer observer2;
+  envoy_http_callbacks callbacks2;
   callbacks_called cc2 = {false, 0, false, false};
-  observer2.context = &cc2;
-  observer2.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  callbacks2.context = &cc2;
+  callbacks2.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
     ASSERT_TRUE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "503");
     bool* on_headers_called2 = static_cast<bool*>(context);
     *on_headers_called2 = true;
   };
-  observer2.on_complete = [](void* context) -> void {
+  callbacks2.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -352,7 +352,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
   EXPECT_CALL(event_dispatcher_, post(_));
-  EXPECT_EQ(http_dispatcher_.startStream(stream2, observer2), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream2, callbacks2), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb2;
@@ -367,7 +367,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "503"}});
   response_decoder2->decodeHeaders(std::move(response_headers2), true);
-  // Ensure that the on_headers on the observer was called.
+  // Ensure that the on_headers on the callbacks was called.
   ASSERT_EQ(cc2.on_headers_calls, 1);
   ASSERT_EQ(cc2.on_complete_calls, 1);
 
@@ -381,24 +381,24 @@ TEST_F(DispatcherTest, MultipleStreams) {
 
 TEST_F(DispatcherTest, LocalResetAfterStreamStart) {
   envoy_stream_t stream = 1;
-  envoy_observer observer;
+  envoy_http_callbacks callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  observer.context = &cc;
+  callbacks.context = &cc;
 
-  observer.on_error = [](envoy_error actual_error, void* context) -> void {
+  callbacks.on_error = [](envoy_error actual_error, void* context) -> void {
     envoy_error expected_error = {ENVOY_STREAM_RESET, envoy_nodata};
     ASSERT_EQ(actual_error.error_code, expected_error.error_code);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
-  observer.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
     ASSERT_FALSE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  observer.on_complete = [](void* context) -> void {
+  callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -424,7 +424,7 @@ TEST_F(DispatcherTest, LocalResetAfterStreamStart) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -436,7 +436,7 @@ TEST_F(DispatcherTest, LocalResetAfterStreamStart) {
   send_headers_post_cb();
 
   response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
-  // Ensure that the on_headers on the observer was called.
+  // Ensure that the on_headers on the callbacks was called.
   ASSERT_EQ(cc.on_headers_calls, 1);
 
   Event::PostCb reset_post_cb;
@@ -446,31 +446,31 @@ TEST_F(DispatcherTest, LocalResetAfterStreamStart) {
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   reset_post_cb();
 
-  // Ensure that the on_error on the observer was called.
+  // Ensure that the on_error on the callbacks was called.
   ASSERT_EQ(cc.on_error_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 0);
 }
 
 TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   envoy_stream_t stream = 1;
-  envoy_observer observer;
+  envoy_http_callbacks callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  observer.context = &cc;
+  callbacks.context = &cc;
 
-  observer.on_error = [](envoy_error actual_error, void* context) -> void {
+  callbacks.on_error = [](envoy_error actual_error, void* context) -> void {
     envoy_error expected_error = {ENVOY_STREAM_RESET, envoy_nodata};
     ASSERT_EQ(actual_error.error_code, expected_error.error_code);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
-  observer.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
     ASSERT_FALSE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  observer.on_complete = [](void* context) -> void {
+  callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -496,7 +496,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -508,11 +508,11 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   send_headers_post_cb();
 
   response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
-  // Ensure that the on_headers on the observer was called.
+  // Ensure that the on_headers on the callbacks was called.
   ASSERT_EQ(cc.on_headers_calls, 1);
 
   stream_encoder_.getStream().resetStream(StreamResetReason::RemoteReset);
-  // Ensure that the on_error on the observer was called.
+  // Ensure that the on_error on the callbacks was called.
   ASSERT_EQ(cc.on_error_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 0);
 }
@@ -537,7 +537,7 @@ TEST_F(DispatcherTest, DestroyWithActiveStream) {
   EXPECT_CALL(cm_, httpAsyncClientForCluster("base")).WillOnce(ReturnRef(cm_.async_client_));
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions())));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
 
   // Send request headers.
   EXPECT_CALL(stream_encoder_, encodeHeaders(_, false));
@@ -567,7 +567,7 @@ TEST_F(DispatcherTest, ResetInOnHeaders) {
   EXPECT_CALL(cm_, httpAsyncClientForCluster("base")).WillOnce(ReturnRef(cm_.async_client_));
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions())));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -607,7 +607,7 @@ TEST_F(DispatcherTest, StreamTimeout) {
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions().setTimeout(
                                                             std::chrono::milliseconds(40)))));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -655,7 +655,7 @@ TEST_F(DispatcherTest, StreamTimeoutHeadReply) {
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions().setTimeout(
                                                             std::chrono::milliseconds(40)))));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -693,7 +693,7 @@ TEST_F(DispatcherTest, DisableTimerWithStream) {
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions().setTimeout(
                                                             std::chrono::milliseconds(40)))));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
 
   // Send request headers and reset stream.
   Event::PostCb send_headers_post_cb;
@@ -718,23 +718,23 @@ TEST_F(DispatcherTest, DisableTimerWithStream) {
 
 TEST_F(DispatcherTest, MultipleDataStream) {
   envoy_stream_t stream = 1;
-  // Setup observer to handle the response.
-  envoy_observer observer;
+  // Setup callbacks to handle the response.
+  envoy_http_callbacks callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  observer.context = &cc;
-  observer.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  callbacks.context = &cc;
+  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
     ASSERT_FALSE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  observer.on_data = [](envoy_data, bool, void* context) -> void {
+  callbacks.on_data = [](envoy_data, bool, void* context) -> void {
     // TODO: assert end_stream and contents of c_data for multiple calls of on_data.
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
   };
-  observer.on_complete = [](void* context) -> void {
+  callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -768,7 +768,7 @@ TEST_F(DispatcherTest, MultipleDataStream) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, observer), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb headers_post_cb;
@@ -814,7 +814,7 @@ TEST_F(DispatcherTest, MultipleDataStream) {
                      .counter("internal.upstream_rq_200")
                      .value());
 
-  // Ensure that the callbacks on the observer were called.
+  // Ensure that the callbacks on the callbacks were called.
   ASSERT_EQ(cc.on_headers_calls, 1);
   ASSERT_EQ(cc.on_data_calls, 2);
   ASSERT_EQ(cc.on_complete_calls, 1);

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -59,23 +59,24 @@ public:
   Http::ContextImpl http_context_;
   AsyncClientImpl client_;
   Dispatcher http_dispatcher_;
-  envoy_http_callbacks callbacks_;
+  envoy_http_callbacks bridge_callbacks_;
 };
 
 TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
   envoy_stream_t stream = 1;
-  // Setup callbacks to handle the response headers.
-  envoy_http_callbacks callbacks;
+  // Setup bridge_callbacks to handle the response headers.
+  envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  callbacks.context = &cc;
-  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  bridge_callbacks.context = &cc;
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void {
     ASSERT_TRUE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -101,7 +102,7 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb;
@@ -127,7 +128,7 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
                      .counter("internal.upstream_rq_200")
                      .value());
 
-  // Ensure that the callbacks on the callbacks were called.
+  // Ensure that the callbacks on the bridge_callbacks were called.
   ASSERT_EQ(cc.on_headers_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 1);
   ASSERT_EQ(cc.on_data_calls, 0);
@@ -135,24 +136,25 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
 
 TEST_F(DispatcherTest, BasicStream) {
   envoy_stream_t stream = 1;
-  // Setup callbacks to handle the response.
-  envoy_http_callbacks callbacks;
+  // Setup bridge_callbacks to handle the response.
+  envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  callbacks.context = &cc;
-  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  bridge_callbacks.context = &cc;
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void {
     ASSERT_FALSE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void {
+  bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void {
     ASSERT_TRUE(end_stream);
     ASSERT_EQ(Http::Utility::convertToString(c_data), "response body");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
   };
-  callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -182,7 +184,7 @@ TEST_F(DispatcherTest, BasicStream) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb headers_post_cb;
@@ -217,7 +219,7 @@ TEST_F(DispatcherTest, BasicStream) {
                      .counter("internal.upstream_rq_200")
                      .value());
 
-  // Ensure that the callbacks on the callbacks were called.
+  // Ensure that the callbacks on the bridge_callbacks were called.
   ASSERT_EQ(cc.on_headers_calls, 1);
   ASSERT_EQ(cc.on_data_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 1);
@@ -225,16 +227,16 @@ TEST_F(DispatcherTest, BasicStream) {
 
 TEST_F(DispatcherTest, ResetStream) {
   envoy_stream_t stream = 1;
-  envoy_http_callbacks callbacks;
+  envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  callbacks.context = &cc;
-  callbacks.on_error = [](envoy_error actual_error, void* context) -> void {
+  bridge_callbacks.context = &cc;
+  bridge_callbacks.on_error = [](envoy_error actual_error, void* context) -> void {
     envoy_error expected_error = {ENVOY_STREAM_RESET, envoy_nodata};
     ASSERT_EQ(actual_error.error_code, expected_error.error_code);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
-  callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -245,7 +247,7 @@ TEST_F(DispatcherTest, ResetStream) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   Event::PostCb post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
@@ -254,7 +256,7 @@ TEST_F(DispatcherTest, ResetStream) {
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   post_cb();
 
-  // Ensure that the on_error on the callbacks was called.
+  // Ensure that the on_error on the bridge_callbacks was called.
   ASSERT_EQ(cc.on_error_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 0);
 }
@@ -263,18 +265,19 @@ TEST_F(DispatcherTest, MultipleStreams) {
   envoy_stream_t stream1 = 1;
   envoy_stream_t stream2 = 2;
   // Start stream1.
-  // Setup callbacks to handle the response headers.
-  envoy_http_callbacks callbacks;
+  // Setup bridge_callbacks to handle the response headers.
+  envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  callbacks.context = &cc;
-  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  bridge_callbacks.context = &cc;
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void {
     ASSERT_TRUE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -300,7 +303,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream1, callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream1, bridge_callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb;
@@ -312,20 +315,21 @@ TEST_F(DispatcherTest, MultipleStreams) {
   post_cb();
 
   // Start stream2.
-  // Setup callbacks to handle the response headers.
+  // Setup bridge_callbacks to handle the response headers.
   NiceMock<MockStreamEncoder> stream_encoder2;
   StreamDecoder* response_decoder2{};
-  envoy_http_callbacks callbacks2;
+  envoy_http_callbacks bridge_callbacks2;
   callbacks_called cc2 = {false, 0, false, false};
-  callbacks2.context = &cc2;
-  callbacks2.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  bridge_callbacks2.context = &cc2;
+  bridge_callbacks2.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "503");
     bool* on_headers_called2 = static_cast<bool*>(context);
     *on_headers_called2 = true;
   };
-  callbacks2.on_complete = [](void* context) -> void {
+  bridge_callbacks2.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -352,7 +356,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
   EXPECT_CALL(event_dispatcher_, post(_));
-  EXPECT_EQ(http_dispatcher_.startStream(stream2, callbacks2), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream2, bridge_callbacks2), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb2;
@@ -367,7 +371,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "503"}});
   response_decoder2->decodeHeaders(std::move(response_headers2), true);
-  // Ensure that the on_headers on the callbacks was called.
+  // Ensure that the on_headers on the bridge_callbacks was called.
   ASSERT_EQ(cc2.on_headers_calls, 1);
   ASSERT_EQ(cc2.on_complete_calls, 1);
 
@@ -381,24 +385,25 @@ TEST_F(DispatcherTest, MultipleStreams) {
 
 TEST_F(DispatcherTest, LocalResetAfterStreamStart) {
   envoy_stream_t stream = 1;
-  envoy_http_callbacks callbacks;
+  envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  callbacks.context = &cc;
+  bridge_callbacks.context = &cc;
 
-  callbacks.on_error = [](envoy_error actual_error, void* context) -> void {
+  bridge_callbacks.on_error = [](envoy_error actual_error, void* context) -> void {
     envoy_error expected_error = {ENVOY_STREAM_RESET, envoy_nodata};
     ASSERT_EQ(actual_error.error_code, expected_error.error_code);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
-  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void {
     ASSERT_FALSE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -424,7 +429,7 @@ TEST_F(DispatcherTest, LocalResetAfterStreamStart) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -436,7 +441,7 @@ TEST_F(DispatcherTest, LocalResetAfterStreamStart) {
   send_headers_post_cb();
 
   response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
-  // Ensure that the on_headers on the callbacks was called.
+  // Ensure that the on_headers on the bridge_callbacks was called.
   ASSERT_EQ(cc.on_headers_calls, 1);
 
   Event::PostCb reset_post_cb;
@@ -446,31 +451,32 @@ TEST_F(DispatcherTest, LocalResetAfterStreamStart) {
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   reset_post_cb();
 
-  // Ensure that the on_error on the callbacks was called.
+  // Ensure that the on_error on the bridge_callbacks was called.
   ASSERT_EQ(cc.on_error_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 0);
 }
 
 TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   envoy_stream_t stream = 1;
-  envoy_http_callbacks callbacks;
+  envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  callbacks.context = &cc;
+  bridge_callbacks.context = &cc;
 
-  callbacks.on_error = [](envoy_error actual_error, void* context) -> void {
+  bridge_callbacks.on_error = [](envoy_error actual_error, void* context) -> void {
     envoy_error expected_error = {ENVOY_STREAM_RESET, envoy_nodata};
     ASSERT_EQ(actual_error.error_code, expected_error.error_code);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
-  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void {
     ASSERT_FALSE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -496,7 +502,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -508,11 +514,11 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   send_headers_post_cb();
 
   response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
-  // Ensure that the on_headers on the callbacks was called.
+  // Ensure that the on_headers on the bridge_callbacks was called.
   ASSERT_EQ(cc.on_headers_calls, 1);
 
   stream_encoder_.getStream().resetStream(StreamResetReason::RemoteReset);
-  // Ensure that the on_error on the callbacks was called.
+  // Ensure that the on_error on the bridge_callbacks was called.
   ASSERT_EQ(cc.on_error_calls, 1);
   ASSERT_EQ(cc.on_complete_calls, 0);
 }
@@ -537,7 +543,7 @@ TEST_F(DispatcherTest, DestroyWithActiveStream) {
   EXPECT_CALL(cm_, httpAsyncClientForCluster("base")).WillOnce(ReturnRef(cm_.async_client_));
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions())));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
 
   // Send request headers.
   EXPECT_CALL(stream_encoder_, encodeHeaders(_, false));
@@ -567,7 +573,7 @@ TEST_F(DispatcherTest, ResetInOnHeaders) {
   EXPECT_CALL(cm_, httpAsyncClientForCluster("base")).WillOnce(ReturnRef(cm_.async_client_));
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions())));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -607,7 +613,7 @@ TEST_F(DispatcherTest, StreamTimeout) {
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions().setTimeout(
                                                             std::chrono::milliseconds(40)))));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -655,7 +661,7 @@ TEST_F(DispatcherTest, StreamTimeoutHeadReply) {
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions().setTimeout(
                                                             std::chrono::milliseconds(40)))));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -693,7 +699,7 @@ TEST_F(DispatcherTest, DisableTimerWithStream) {
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions().setTimeout(
                                                             std::chrono::milliseconds(40)))));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
 
   // Send request headers and reset stream.
   Event::PostCb send_headers_post_cb;
@@ -718,23 +724,24 @@ TEST_F(DispatcherTest, DisableTimerWithStream) {
 
 TEST_F(DispatcherTest, MultipleDataStream) {
   envoy_stream_t stream = 1;
-  // Setup callbacks to handle the response.
-  envoy_http_callbacks callbacks;
+  // Setup bridge_callbacks to handle the response.
+  envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0};
-  callbacks.context = &cc;
-  callbacks.on_headers = [](envoy_headers c_headers, bool end_stream, void* context) -> void {
+  bridge_callbacks.context = &cc;
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void {
     ASSERT_FALSE(end_stream);
     HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
   };
-  callbacks.on_data = [](envoy_data, bool, void* context) -> void {
+  bridge_callbacks.on_data = [](envoy_data, bool, void* context) -> void {
     // TODO: assert end_stream and contents of c_data for multiple calls of on_data.
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
   };
-  callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
   };
@@ -768,7 +775,7 @@ TEST_F(DispatcherTest, MultipleDataStream) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb headers_post_cb;
@@ -814,7 +821,7 @@ TEST_F(DispatcherTest, MultipleDataStream) {
                      .counter("internal.upstream_rq_200")
                      .value());
 
-  // Ensure that the callbacks on the callbacks were called.
+  // Ensure that the callbacks on the bridge_callbacks were called.
   ASSERT_EQ(cc.on_headers_calls, 1);
   ASSERT_EQ(cc.on_data_calls, 2);
   ASSERT_EQ(cc.on_complete_calls, 1);


### PR DESCRIPTION
Description: I've come to be of the opinion that 'observer' is an unfortunate and confusing name for the objects containing our callbacks:

- In Envoy itself these are called callbacks.
- In our filter proposal we're calling these callbacks.
- These entities have deviated from the reactive pattern from which they take their namesake.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>