### PR TITLE
ios: wire-up error to platform callbacks

### DIFF
--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -88,8 +88,8 @@ NSString *_REQUEST_SCHEME = @"http";
     NSLog(@"Response data (%i): %ld bytes", requestID, data.length);
   }];
 
-  [handler onError:^{
-    NSLog(@"Error (%i): Request failed", requestID);
+  [handler onError:^(EnvoyError *error) {
+    NSLog(@"Error (%i): Request failed: %@", requestID, error.message);
   }];
 
   [self.envoy send:request data:nil trailers:[NSDictionary new] handler:handler];

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -64,7 +64,8 @@ final class ViewController: UITableViewController {
       .onError { [weak self] error in
         NSLog("Error (\(requestID)): Request failed")
         self?.add(result: .failure(RequestError(id: requestID,
-                                                message: "failed within Envoy library: " + error.message)))
+                                                message: "failed within Envoy library: "
+                                                         + error.message)))
       }
 
     envoy.send(request, data: nil, handler: handler)

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -61,10 +61,10 @@ final class ViewController: UITableViewController {
       .onData { data, _ in
         NSLog("Response data (\(requestID)): \(data.count) bytes")
       }
-      .onError { [weak self] in
+      .onError { [weak self] error in
         NSLog("Error (\(requestID)): Request failed")
         self?.add(result: .failure(RequestError(id: requestID,
-                                                message: "failed within Envoy library")))
+                                                message: "failed within Envoy library: " + error.message)))
       }
 
     envoy.send(request, data: nil, handler: handler)

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -62,10 +62,10 @@ final class ViewController: UITableViewController {
         NSLog("Response data (\(requestID)): \(data.count) bytes")
       }
       .onError { [weak self] error in
-        NSLog("Error (\(requestID)): Request failed")
+        let message = "failed within Envoy library: \(error.message)"
+        NSLog("Error (\(requestID)): \(message)")
         self?.add(result: .failure(RequestError(id: requestID,
-                                                message: "failed within Envoy library: "
-                                                         + error.message)))
+                                                message: message)))
       }
 
     envoy.send(request, data: nil, handler: handler)

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -49,7 +49,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 /**
  * Called when the async HTTP stream has an error.
  */
-@property (nonatomic, strong) void (^onError)();
+@property (nonatomic, strong) void (^onError)(uint64_t errorCode, NSString *message);
 
 /**
  * Called when the async HTTP stream is canceled.

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -155,6 +155,7 @@ static void ios_on_error(envoy_error error, void *context) {
     NSString *errorMessage = [[NSString alloc] initWithBytes:error.message.bytes
                                                       length:error.message.length
                                                     encoding:NSUTF8StringEncoding];
+    error.message.release(error.message.context);
     callbacks.onError(error.error_code, errorMessage);
   });
 }

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -152,8 +152,10 @@ static void ios_on_error(envoy_error error, void *context) {
     if (atomic_load(c->canceled)) {
       return;
     }
-    // FIXME transform error and pass up
-    callbacks.onError();
+    NSString *errorMessage = [[NSString alloc] initWithBytes:error.message.bytes
+                                                      length:error.message.length
+                                                    encoding:NSUTF8StringEncoding];
+    callbacks.onError(error.error_code, errorMessage);
   });
 }
 

--- a/library/swift/src/EnvoyError.swift
+++ b/library/swift/src/EnvoyError.swift
@@ -3,13 +3,13 @@ import Foundation
 @objcMembers
 public final class EnvoyError: NSObject, Error {
   /// Error code associated with the exception that occurred.
-  public let errorCode: Int
+  public let errorCode: UInt64
   /// A description of what exception that occurred.
   public let message: String
   /// Optional cause for the error.
   public let cause: Error?
 
-  init(errorCode: Int, message: String, cause: Swift.Error?) {
+  init(errorCode: UInt64, message: String, cause: Swift.Error?) {
     self.errorCode = errorCode
     self.message = message
     self.cause = cause

--- a/library/swift/src/ResponseHandler.swift
+++ b/library/swift/src/ResponseHandler.swift
@@ -63,10 +63,12 @@ public final class ResponseHandler: NSObject {
   /// - parameter closure: Closure which will be called when an error occurs.
   @discardableResult
   public func onError(_ closure:
-    @escaping () -> Void)
+    @escaping (_ error: EnvoyError) -> Void)
     -> ResponseHandler
   {
-    self.underlyingCallbacks.onError = closure
+    self.underlyingCallbacks.onError = { errorCode, message in
+      closure(EnvoyError(errorCode: errorCode, message: message, cause: nil))
+    }
     return self
   }
 


### PR DESCRIPTION
Description: exposing the contents of envoy_error up to the platform. Note that this implementation differs slightly from Android. I have opened https://github.com/lyft/envoy-mobile/issues/409 to consolidate both platforms.
Risk Level: 
Testing: local, and CI

Signed-off-by: Jose Nino <jnino@lyft.com>