### PR TITLE
swift: fix function signature in EnvoyTests

### DIFF
--- a/library/swift/test/EnvoyTests.swift
+++ b/library/swift/test/EnvoyTests.swift
@@ -55,7 +55,7 @@ final class EnvoyTests: XCTestCase {
     let envoy = try EnvoyBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .build()
-    envoy.send(expectedRequest, data: expectedData, trailers: expectedTrailers,
+    envoy.send(expectedRequest, body: expectedData, trailers: expectedTrailers,
                handler: ResponseHandler())
     self.wait(for: [requestExpectation, dataExpectation, closeExpectation],
               timeout: 0.1, enforceOrder: true)


### PR DESCRIPTION
This was broken by https://github.com/lyft/envoy-mobile/pull/413, but wasn't caught by CI because of https://github.com/lyft/envoy-mobile/issues/383.

Signed-off-by: Michael Rebello <me@michaelrebello.com>