### PR TITLE
ios: move configuration to Objective-C

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -9,9 +9,10 @@ public class EnvoyConfiguration {
   /**
    * Create an EnvoyConfiguration with a user provided configuration values.
    *
-   * @param connectTimeoutSeconds timeout for new network connections to hosts in the cluster.
-   * @param dnsRefreshSeconds rate in seconds to refresh DNS.
-   * @param statsFlushSeconds interval at which to flush Envoy stats.
+   * @param connectTimeoutSeconds timeout for new network connections to hosts in
+   *                              the cluster.
+   * @param dnsRefreshSeconds     rate in seconds to refresh DNS.
+   * @param statsFlushSeconds     interval at which to flush Envoy stats.
    */
   public EnvoyConfiguration(int connectTimeoutSeconds, int dnsRefreshSeconds,
                             int statsFlushSeconds) {
@@ -21,12 +22,13 @@ public class EnvoyConfiguration {
   }
 
   /**
-   * Resolves the provided configuration template using properties on this configuration.
-   * This default configuration is provided by the native layer.
+   * Resolves the provided configuration template using properties on this
+   * configuration.
    *
-   * @param templateYAML the default template configuration.
+   * @param templateYAML the template configuration to resolve.
    * @return String, the resolved template.
-   * @throws ConfigurationException, when the template provided is not fully resolved.
+   * @throws ConfigurationException, when the template provided is not fully
+   *                                 resolved.
    */
   String resolveTemplate(String templateYAML) {
     String resolvedConfiguration =

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyBuilder.kt
@@ -25,10 +25,10 @@ open class EnvoyBuilder internal constructor(
   }
 
   /**
-   * Add a YAML file to use as a configuration.
+   * Add contents of a yaml file to use as a configuration.
    * Setting this will supersede any other configuration settings in the builder.
    *
-   * @param configYAML the YAML file to use as a configuration.
+   * @param configYAML the contents of a yaml file to use as a configuration.
    */
   fun addConfigYAML(configYAML: String?): EnvoyBuilder {
     this.configYAML = configYAML

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -4,8 +4,38 @@
 
 @implementation EnvoyConfiguration
 
-+ (NSString *)templateString {
-  return [[NSString alloc] initWithUTF8String:config_template];
+- (instancetype)initWithConnectTimeoutSeconds:(UInt32)connectTimeoutSeconds
+                            dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
+                            statsFlushSeconds:(UInt32)statsFlushSeconds {
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  self.connectTimeoutSeconds = connectTimeoutSeconds;
+  self.dnsRefreshSeconds = dnsRefreshSeconds;
+  self.statsFlushSeconds = statsFlushSeconds;
+  return self;
+}
+
+- (nullable NSString *)resolveTemplate:(NSString *)templateYAML {
+  NSDictionary<NSString *, NSString *> *templateKeysToValues = @{
+    @"connect_timeout" : [NSString stringWithFormat:@"%is", self.connectTimeoutSeconds],
+    @"dns_refresh_rate" : [NSString stringWithFormat:@"%is", self.dnsRefreshSeconds],
+    @"stats_flush_interval" : [NSString stringWithFormat:@"%is", self.statsFlushSeconds]
+  };
+  for (NSString *templateKey in templateKeysToValues) {
+    NSString *keyToReplace = [NSString stringWithFormat:@"{{ %@ }}", templateKey];
+    templateYAML =
+        [templateYAML stringByReplacingOccurrencesOfString:keyToReplace
+                                                withString:templateKeysToValues[templateKey]];
+  }
+
+  if ([templateYAML rangeOfString:@"{{"].length != 0) {
+    return nil;
+  }
+
+  return templateYAML;
 }
 
 @end

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -117,6 +117,32 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
 @end
 
+#pragma mark - EnvoyConfiguration
+
+/// Typed configuration that may be used for starting Envoy.
+@interface EnvoyConfiguration : NSObject
+
+@property (nonatomic, assign) UInt32 connectTimeoutSeconds;
+@property (nonatomic, assign) UInt32 dnsRefreshSeconds;
+@property (nonatomic, assign) UInt32 statsFlushSeconds;
+
+/**
+ Create a new instance of the configuration.
+ */
+- (instancetype)initWithConnectTimeoutSeconds:(UInt32)connectTimeoutSeconds
+                            dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
+                            statsFlushSeconds:(UInt32)statsFlushSeconds;
+
+/**
+ Resolves the provided configuration template using properties on this configuration.
+
+ @param templateYAML The template configuration to resolve.
+ @return The resolved template. Nil if the template fails to fully resolve.
+ */
+- (nullable NSString *)resolveTemplate:(NSString *)templateYAML;
+
+@end
+
 #pragma mark - EnvoyEngine
 
 /// Wrapper layer for calling into Envoy's C/++ API.
@@ -128,21 +154,22 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 - (instancetype)init;
 
 /**
- Run the Envoy engine with the provided config and log level.
+ Run the Envoy engine with the provided configuration and log level.
 
- @param config The configuration file with which to start Envoy.
- @return A status indicating if the action was successful.
- */
-- (int)runWithConfig:(NSString *)config;
-
-/**
- Run the Envoy engine with the provided config and log level.
-
- @param config The configuration file with which to start Envoy.
+ @param configuration The EnvoyConfiguration used to start Envoy.
  @param logLevel The log level to use when starting Envoy.
  @return A status indicating if the action was successful.
  */
-- (int)runWithConfig:(NSString *)config logLevel:(NSString *)logLevel;
+- (int)runWithConfig:(EnvoyConfiguration *)config logLevel:(NSString *)logLevel;
+
+/**
+ Run the Envoy engine with the provided yaml string and log level.
+
+ @param configYAML The configuration yaml with which to start Envoy.
+ @param logLevel The log level to use when starting Envoy.
+ @return A status indicating if the action was successful.
+ */
+- (int)runWithConfigYAML:(NSString *)configYAML logLevel:(NSString *)logLevel;
 
 /**
  Opens a new HTTP stream attached to this engine.
@@ -150,20 +177,6 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  @param callbacks Handler for observing stream events.
  */
 - (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks;
-
-@end
-
-#pragma mark - EnvoyConfiguration
-
-/// Namespace for Envoy configurations.
-@interface EnvoyConfiguration : NSObject
-
-/**
- Provides a default configuration template that may be used for starting Envoy.
-
- @return A template that may be used as a starting point for constructing configurations.
- */
-+ (NSString *)templateString;
 
 @end
 

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -16,15 +16,21 @@
   return self;
 }
 
-- (int)runWithConfig:(NSString *)config {
-  return [self runWithConfig:config logLevel:@"info"];
+- (int)runWithConfig:(EnvoyConfiguration *)config logLevel:(NSString *)logLevel {
+  NSString *templateYAML = [[NSString alloc] initWithUTF8String:config_template];
+  NSString *resolvedYAML = [config resolveTemplate:templateYAML];
+  if (resolvedYAML == nil) {
+    return 1;
+  }
+
+  return [self runWithConfigYAML:resolvedYAML logLevel:logLevel];
 }
 
-- (int)runWithConfig:(NSString *)config logLevel:(NSString *)logLevel {
+- (int)runWithConfigYAML:(NSString *)configYAML logLevel:(NSString *)logLevel {
   // Envoy exceptions will only be caught here when compiled for 64-bit arches.
   // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Exceptions/Articles/Exceptions64Bit.html
   @try {
-    return (int)run_engine(config.UTF8String, logLevel.UTF8String);
+    return (int)run_engine(configYAML.UTF8String, logLevel.UTF8String);
   } @catch (...) {
     NSLog(@"Envoy exception caught.");
     [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyException" object:self];

--- a/library/swift/test/EnvoyBuilderTests.swift
+++ b/library/swift/test/EnvoyBuilderTests.swift
@@ -11,15 +11,16 @@ mock_template:
 """
 
 private final class MockEnvoyEngine: NSObject, EnvoyEngine {
-  static var onRun: ((_ config: String, _ logLevel: String?) -> Void)?
+  static var onRunWithConfig: ((_ config: EnvoyConfiguration, _ logLevel: String?) -> Void)?
+  static var onRunWithYAML: ((_ configYAML: String, _ logLevel: String?) -> Void)?
 
-  func run(withConfig config: String) -> Int32 {
-    MockEnvoyEngine.onRun?(config, nil)
+  func run(withConfig config: EnvoyConfiguration, logLevel: String) -> Int32 {
+    MockEnvoyEngine.onRunWithConfig?(config, logLevel)
     return 0
   }
 
-  func run(withConfig config: String, logLevel: String) -> Int32 {
-    MockEnvoyEngine.onRun?(config, logLevel)
+  func run(withConfigYAML configYAML: String, logLevel: String) -> Int32 {
+    MockEnvoyEngine.onRunWithYAML?(configYAML, logLevel)
     return 0
   }
 
@@ -33,12 +34,13 @@ private final class MockEnvoyEngine: NSObject, EnvoyEngine {
 final class EnvoyBuilderTests: XCTestCase {
   override func tearDown() {
     super.tearDown()
-    MockEnvoyEngine.onRun = nil
+    MockEnvoyEngine.onRunWithConfig = nil
+    MockEnvoyEngine.onRunWithYAML = nil
   }
 
   func testAddingCustomConfigYAMLUsesSpecifiedYAMLWhenRunningEnvoy() throws {
     let expectation = self.expectation(description: "Run called with expected data")
-    MockEnvoyEngine.onRun = { yaml, _ in
+    MockEnvoyEngine.onRunWithYAML = { yaml, _ in
       XCTAssertEqual("foobar", yaml)
       expectation.fulfill()
     }
@@ -52,7 +54,7 @@ final class EnvoyBuilderTests: XCTestCase {
 
   func testAddingLogLevelAddsLogLevelWhenRunningEnvoy() throws {
     let expectation = self.expectation(description: "Run called with expected data")
-    MockEnvoyEngine.onRun = { _, logLevel in
+    MockEnvoyEngine.onRunWithConfig = { _, logLevel in
       XCTAssertEqual("trace", logLevel)
       expectation.fulfill()
     }
@@ -64,37 +66,24 @@ final class EnvoyBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
-  func testResolvesYAMLWithConnectTimeout() throws {
-    let resolvedYAML = try EnvoyBuilder()
-      .addEngineType(MockEnvoyEngine.self)
-      .addConnectTimeoutSeconds(200)
-      .resolvedYAML(kMockTemplate)
+  func testResolvesYAMLWithIndividuallySetValues() throws {
+    let config = EnvoyConfiguration(connectTimeoutSeconds: 200,
+                                    dnsRefreshSeconds: 300,
+                                    statsFlushSeconds: 400)
+    guard let resolvedYAML = config.resolveTemplate(kMockTemplate) else {
+      XCTFail("Resolved template YAML is nil")
+      return
+    }
 
     XCTAssertTrue(resolvedYAML.contains("connect_timeout: 200s"))
+    XCTAssertTrue(resolvedYAML.contains("dns_refresh_rate: 300s"))
+    XCTAssertTrue(resolvedYAML.contains("stats_flush_interval: 400s"))
   }
 
-  func testResolvesYAMLWithDNSRefreshSeconds() throws {
-    let resolvedYAML = try EnvoyBuilder()
-      .addEngineType(MockEnvoyEngine.self)
-      .addDNSRefreshSeconds(200)
-      .resolvedYAML(kMockTemplate)
-
-    XCTAssertTrue(resolvedYAML.contains("dns_refresh_rate: 200s"))
-  }
-
-  func testResolvesYAMLWithStatsFlushSeconds() throws {
-    let resolvedYAML = try EnvoyBuilder()
-      .addEngineType(MockEnvoyEngine.self)
-      .addStatsFlushSeconds(200)
-      .resolvedYAML(kMockTemplate)
-
-    XCTAssertTrue(resolvedYAML.contains("stats_flush_interval: 200s"))
-  }
-
-  func testThrowsWhenUnresolvedValueInTemplate() {
-    let builder = EnvoyBuilder().addEngineType(MockEnvoyEngine.self)
-    XCTAssertThrowsError(try builder.resolvedYAML("{{ missing }}")) { error in
-      XCTAssertEqual(.unresolvedTemplateKey, error as? EnvoyBuilderError)
-    }
+  func testReturnsNilWhenUnresolvedValueInTemplate() {
+    let config = EnvoyConfiguration(connectTimeoutSeconds: 200,
+                                    dnsRefreshSeconds: 300,
+                                    statsFlushSeconds: 400)
+    XCTAssertNil(config.resolveTemplate("{{ missing }}"))
   }
 }

--- a/library/swift/test/EnvoyTests.swift
+++ b/library/swift/test/EnvoyTests.swift
@@ -3,11 +3,11 @@ import Foundation
 import XCTest
 
 private final class MockEnvoyEngine: EnvoyEngine {
-  func run(withConfig config: String) -> Int32 {
+  func run(withConfig config: EnvoyConfiguration, logLevel: String) -> Int32 {
     return 0
   }
 
-  func run(withConfig config: String, logLevel: String) -> Int32 {
+  func run(withConfigYAML configYAML: String, logLevel: String) -> Int32 {
     return 0
   }
 


### PR DESCRIPTION
This is a mirror of the Android change made in https://github.com/lyft/envoy-mobile/pull/385.

The change was originally motivated by the fact that Android was unable to obtain the configuration template within C++ before the JNI was loaded. Moving the template resolution logic to Java fixed this issue by allowing the JNI to be initialized before loading the template.

Key changes in this PR:
- Moved template resolution to Objective-C
- Custom YAML files are no longer treated as templates, and are not resolved (but are passed through as-is). This matches Android
- Updated initializers as necessary to match Android

Signed-off-by: Michael Rebello <me@michaelrebello.com>