### PR TITLE
ios: update rules_apple & remove hack

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,9 +33,9 @@ http_file(
 
 git_repository(
     name = "build_bazel_rules_apple",
-    commit = "7edb4c18fca1514aa6c26fbdf6271625f6823f33",
+    commit = "821ca56c920f88679c90a807e6d7bd071950d7f8",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    shallow_since = "1562886228 -0700",
+    shallow_since = "1567794850 -0700",
 )
 
 load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")

--- a/examples/objective-c/hello_world/BUILD
+++ b/examples/objective-c/hello_world/BUILD
@@ -1,7 +1,6 @@
 licenses(["notice"])  # Apache 2
 
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 objc_library(
     name = "appmain",
@@ -12,15 +11,6 @@ objc_library(
     deps = ["//dist:envoy_mobile_ios"],
 )
 
-# This is forces linking of necessary Swift dependencies.
-# https://github.com/bazelbuild/rules_apple/issues/557
-swift_library(
-    name = "empty_swift_lib",
-    srcs = ["Empty.swift"],
-    module_name = "empty_swift_lib",
-    deps = [],
-)
-
 ios_application(
     name = "app",
     bundle_id = "io.envoyproxy.envoymobile.helloworld",
@@ -29,6 +19,5 @@ ios_application(
     minimum_os_version = "10.0",
     deps = [
         "appmain",
-        "empty_swift_lib",
     ],
 )

--- a/examples/objective-c/hello_world/Empty.swift
+++ b/examples/objective-c/hello_world/Empty.swift
@@ -1,2 +1,0 @@
-// This empty Swift file allows us to depend on a Swift library which will
-// properly link Swift dependencies: https://github.com/bazelbuild/rules_apple/issues/557


### PR DESCRIPTION
We can now remove the hack for building the Objective-C demo now that https://github.com/bazelbuild/rules_apple/pull/566 has merged (thanks @kastiglione!).

Description:
Risk Level: Low
Testing: Locally

Signed-off-by: Michael Rebello <me@michaelrebello.com>
