### PR TITLE
bazel: remove unused BUILD imports

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,5 @@
 licenses(["notice"])  # Apache 2
 
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_framework", "ios_static_framework")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
 
 alias(


### PR DESCRIPTION
Signed-off-by: Michael Rebello <me@michaelrebello.com>