### PR TITLE
ios: rename Client/Envoy/EnvoyBuilder

### DIFF
--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -13,7 +13,7 @@ NSString *_REQUEST_SCHEME = @"http";
 #pragma mark - ViewController
 
 @interface ViewController ()
-@property (nonatomic, strong) Envoy *envoy;
+@property (nonatomic, strong) EnvoyClient *envoy;
 @property (nonatomic, assign) int requestCount;
 @property (nonatomic, strong) NSMutableArray<Result *> *results;
 @property (nonatomic, weak) NSTimer *requestTimer;
@@ -36,7 +36,7 @@ NSString *_REQUEST_SCHEME = @"http";
 - (void)startEnvoy {
   NSLog(@"Starting Envoy...");
   NSError *error;
-  self.envoy = [[EnvoyBuilder new] buildAndReturnError:&error];
+  self.envoy = [[EnvoyClientBuilder new] buildAndReturnError:&error];
   if (error) {
     NSLog(@"Starting Envoy failed: %@", error);
   } else {

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -10,13 +10,13 @@ final class ViewController: UITableViewController {
   private var requestCount = 0
   private var results = [Result<Response, RequestError>]()
   private var timer: Timer?
-  private var envoy: Envoy?
+  private var envoy: EnvoyClient?
 
   override func viewDidLoad() {
     super.viewDidLoad()
     do {
       NSLog("Starting Envoy...")
-      self.envoy = try EnvoyBuilder()
+      self.envoy = try EnvoyClientBuilder()
         .build()
     } catch let error {
       NSLog("Starting Envoy failed: \(error)")

--- a/library/swift/src/BUILD
+++ b/library/swift/src/BUILD
@@ -5,11 +5,11 @@ load("//bazel:swift_static_framework.bzl", "swift_static_framework")
 swift_static_framework(
     name = "ios_framework",
     srcs = [
-        "Client.swift",
-        "Envoy.swift",
-        "EnvoyBuilder.swift",
+        "EnvoyClient.swift",
+        "EnvoyClientBuilder.swift",
         "EnvoyError.swift",
         "EnvoyStreamEmitter.swift",
+        "HTTPClient.swift",
         "LogLevel.swift",
         "Request.swift",
         "RequestBuilder.swift",

--- a/library/swift/src/EnvoyClient.swift
+++ b/library/swift/src/EnvoyClient.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Envoy's implementation of `Client`, buildable using `EnvoyBuilder`.
+/// Envoy's implementation of `HTTPClient`, buildable using `EnvoyClientBuilder`.
 @objcMembers
-public final class Envoy: NSObject {
+public final class EnvoyClient: NSObject {
   private let engine: EnvoyEngine
   private let runner: RunnerThread
 
@@ -67,7 +67,7 @@ public final class Envoy: NSObject {
   }
 }
 
-extension Envoy: Client {
+extension EnvoyClient: HTTPClient {
   public func send(_ request: Request, handler: ResponseHandler) -> StreamEmitter {
     let httpStream = self.engine.startStream(with: handler.underlyingCallbacks)
     httpStream.sendHeaders(request.outboundHeaders(), close: false)

--- a/library/swift/src/EnvoyClientBuilder.swift
+++ b/library/swift/src/EnvoyClientBuilder.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Builder used for creating new instances of Envoy.
+/// Builder used for creating new instances of EnvoyClient.
 @objcMembers
-public final class EnvoyBuilder: NSObject {
+public final class EnvoyClientBuilder: NSObject {
   private var engineType: EnvoyEngine.Type = EnvoyEngineImpl.self
   private var logLevel: LogLevel = .info
   private var configYAML: String?
@@ -16,7 +16,7 @@ public final class EnvoyBuilder: NSObject {
   /// Add a log level to use with Envoy.
   ///
   /// - parameter logLevel: The log level to use with Envoy.
-  public func addLogLevel(_ logLevel: LogLevel) -> EnvoyBuilder {
+  public func addLogLevel(_ logLevel: LogLevel) -> EnvoyClientBuilder {
     self.logLevel = logLevel
     return self
   }
@@ -26,7 +26,7 @@ public final class EnvoyBuilder: NSObject {
   ///
   /// - parameter configYAML: the contents of a yaml file to use as a configuration.
   @discardableResult
-  public func addConfigYAML(_ configYAML: String?) -> EnvoyBuilder {
+  public func addConfigYAML(_ configYAML: String?) -> EnvoyClientBuilder {
     self.configYAML = configYAML
     return self
   }
@@ -36,7 +36,9 @@ public final class EnvoyBuilder: NSObject {
   /// - parameter connectTimeoutSeconds: Timeout for new network
   ///                                    connections to hosts in the cluster.
   @discardableResult
-  public func addConnectTimeoutSeconds(_ connectTimeoutSeconds: UInt32) -> EnvoyBuilder {
+  public func addConnectTimeoutSeconds(_ connectTimeoutSeconds: UInt32)
+    -> EnvoyClientBuilder
+  {
     self.connectTimeoutSeconds = connectTimeoutSeconds
     return self
   }
@@ -45,7 +47,7 @@ public final class EnvoyBuilder: NSObject {
   ///
   /// - parameter dnsRefreshSeconds: Rate in seconds to refresh DNS.
   @discardableResult
-  public func addDNSRefreshSeconds(_ dnsRefreshSeconds: UInt32) -> EnvoyBuilder {
+  public func addDNSRefreshSeconds(_ dnsRefreshSeconds: UInt32) -> EnvoyClientBuilder {
     self.dnsRefreshSeconds = dnsRefreshSeconds
     return self
   }
@@ -54,23 +56,23 @@ public final class EnvoyBuilder: NSObject {
   ///
   /// - parameter statsFlushSeconds: Interval at which to flush Envoy stats.
   @discardableResult
-  public func addStatsFlushSeconds(_ statsFlushSeconds: UInt32) -> EnvoyBuilder {
+  public func addStatsFlushSeconds(_ statsFlushSeconds: UInt32) -> EnvoyClientBuilder {
     self.statsFlushSeconds = statsFlushSeconds
     return self
   }
 
-  /// Builds a new instance of Envoy using the provided configurations.
+  /// Builds a new instance of EnvoyClient using the provided configurations.
   ///
-  /// - returns: A new instance of Envoy.
-  public func build() throws -> Envoy {
+  /// - returns: A new instance of EnvoyClient.
+  public func build() throws -> EnvoyClient {
     let engine = self.engineType.init()
     if let configYAML = self.configYAML {
-      return Envoy(configYAML: configYAML, logLevel: self.logLevel, engine: engine)
+      return EnvoyClient(configYAML: configYAML, logLevel: self.logLevel, engine: engine)
     } else {
       let config = EnvoyConfiguration(connectTimeoutSeconds: self.connectTimeoutSeconds,
                                       dnsRefreshSeconds: self.dnsRefreshSeconds,
                                       statsFlushSeconds: self.statsFlushSeconds)
-      return Envoy(config: config, logLevel: self.logLevel, engine: engine)
+      return EnvoyClient(config: config, logLevel: self.logLevel, engine: engine)
     }
   }
 
@@ -81,7 +83,7 @@ public final class EnvoyBuilder: NSObject {
   /// Used for testing, as initializing with `EnvoyEngine.Type` results in a
   /// segfault: https://github.com/lyft/envoy-mobile/issues/334
   @discardableResult
-  func addEngineType(_ engineType: EnvoyEngine.Type) -> EnvoyBuilder {
+  func addEngineType(_ engineType: EnvoyEngine.Type) -> EnvoyClientBuilder {
     self.engineType = engineType
     return self
   }
@@ -89,17 +91,17 @@ public final class EnvoyBuilder: NSObject {
 
 // MARK: - Objective-C helpers
 
-extension Envoy {
+extension EnvoyClient {
   /// Convenience builder function to allow for cleaner Objective-C syntax.
   ///
   /// For example:
   ///
-  /// Envoy *envoy = [EnvoyBuilder withBuild:^(EnvoyBuilder *builder) {
+  /// EnvoyClient *envoy = [EnvoyClientBuilder withBuild:^(EnvoyClientBuilder *builder) {
   ///   [builder addDNSRefreshSeconds:30];
   /// }];
   @objc
-  public static func with(build: (EnvoyBuilder) -> Void) throws -> Envoy {
-    let builder = EnvoyBuilder()
+  public static func with(build: (EnvoyClientBuilder) -> Void) throws -> EnvoyClient {
+    let builder = EnvoyClientBuilder()
     build(builder)
     return try builder.build()
   }

--- a/library/swift/src/HTTPClient.swift
+++ b/library/swift/src/HTTPClient.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Client that is able to send and receive requests through Envoy.
+/// Client that is able to send and receive HTTP requests.
 @objc
-public protocol Client {
+public protocol HTTPClient {
   /// Start a new stream.
   ///
   /// - parameter request: The request for opening a stream.

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -3,17 +3,17 @@ licenses(["notice"])  # Apache 2
 load("//bazel:swift_test.bzl", "envoy_mobile_swift_test")
 
 envoy_mobile_swift_test(
-    name = "envoy_tests",
+    name = "envoy_client_tests",
     srcs = [
-        "EnvoyTests.swift",
+        "EnvoyClientTests.swift",
         "MockEnvoyHTTPStream.swift",
     ],
 )
 
 envoy_mobile_swift_test(
-    name = "envoy_builder_tests",
+    name = "envoy_client_builder_tests",
     srcs = [
-        "EnvoyBuilderTests.swift",
+        "EnvoyClientBuilderTests.swift",
         "MockEnvoyHTTPStream.swift",
     ],
 )

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -29,7 +29,7 @@ private final class MockEnvoyEngine: NSObject, EnvoyEngine {
   }
 }
 
-final class EnvoyBuilderTests: XCTestCase {
+final class EnvoyClientBuilderTests: XCTestCase {
   override func tearDown() {
     super.tearDown()
     MockEnvoyEngine.onRunWithConfig = nil
@@ -43,7 +43,7 @@ final class EnvoyBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = try EnvoyBuilder()
+    _ = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addConfigYAML("foobar")
       .build()
@@ -57,7 +57,7 @@ final class EnvoyBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = try EnvoyBuilder()
+    _ = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addLogLevel(.trace)
       .build()

--- a/library/swift/test/EnvoyClientTests.swift
+++ b/library/swift/test/EnvoyClientTests.swift
@@ -16,7 +16,7 @@ private final class MockEnvoyEngine: EnvoyEngine {
   }
 }
 
-final class EnvoyTests: XCTestCase {
+final class EnvoyClientTests: XCTestCase {
   override func tearDown() {
     super.tearDown()
     MockEnvoyHTTPStream.onHeaders = nil
@@ -52,7 +52,7 @@ final class EnvoyTests: XCTestCase {
       closeExpectation.fulfill()
     }
 
-    let envoy = try EnvoyBuilder()
+    let envoy = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .build()
     envoy.send(expectedRequest, body: expectedData, trailers: expectedTrailers,


### PR DESCRIPTION
`Client` -> `HTTPClient`
`Envoy` -> `EnvoyClient`
`EnvoyBuilder` -> `EnvoyClientBuilder`

Consistent with [this Android change](https://github.com/lyft/envoy-mobile/pull/424), and helps us to avoid naming collisions with the `Envoy` type and `Envoy` module namespace.

Signed-off-by: Michael Rebello <me@michaelrebello.com>