### PR TITLE
android: move liveliness log to main

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -65,9 +65,7 @@ jobs:
         run: ./ci/mac_start_simulator.sh
       - run: ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
         name: 'Start java app'
-      - run: ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
-        name: 'Start java app'
-      - run: 'adb logcat -e "successful response!" -m 1'
+      - run: 'adb logcat -e "successful response" -m 1'
         name: 'Check liveliness'
   mackotlin:
     name: mac_kotlin_helloworld

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -65,6 +65,8 @@ jobs:
         run: ./ci/mac_start_simulator.sh
       - run: ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
         name: 'Start java app'
+      - run: ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
+        name: 'Start java app'
       - run: 'adb logcat -e "successful response!" -m 1'
         name: 'Check liveliness'
   mackotlin:
@@ -87,7 +89,7 @@ jobs:
         run: ./ci/mac_start_simulator.sh
       - run: ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
         name: 'Start kotlin app'
-      - run: 'adb logcat -e "successful response!" -m 1'
+      - run: 'adb logcat -e "successful response" -m 1'
         name: 'Check liveliness'
   kotlintests:
     name: kotlin_tests

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -7,6 +7,7 @@ import android.os.HandlerThread;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import io.envoyproxy.envoymobile.AndroidEnvoyClientBuilder;
 import io.envoyproxy.envoymobile.Envoy;
 import io.envoyproxy.envoymobile.Request;
@@ -79,6 +80,7 @@ public class MainActivity extends Activity {
               if (status == 200) {
                 String serverHeaderField = headers.get(ENVOY_SERVER_HEADER).get(0);
                 String body = "";
+                Log.d("MainActivity", "successful response!");
                 recyclerView.post(() -> viewAdapter.add(new Success(body, serverHeaderField)));
               } else {
                 recyclerView.post(

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -78,6 +78,7 @@ class MainActivity : Activity() {
           if (status == 200) {
             val serverHeaderField = headers[ENVOY_SERVER_HEADER]?.first() ?: ""
             val body = "" // fake data
+            Log.d("MainActivity", "successful response!")
             recyclerView.post { viewAdapter.add(Success(body, serverHeaderField)) }
           } else {
             recyclerView.post { viewAdapter.add(Failure("failed with status: $status")) }

--- a/examples/kotlin/shared/ResponseViewHolder.kt
+++ b/examples/kotlin/shared/ResponseViewHolder.kt
@@ -15,7 +15,6 @@ class ResponseViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         { success ->
           responseTextView.text = responseTextView.resources.getString(R.string.title_string, success.title)
           headerTextView.text = headerTextView.resources.getString(R.string.header_string, success.header)
-          Log.d("ResponseViewHolder", "successful response!")
         },
         { failure ->
           responseTextView.text = responseTextView.resources.getString(R.string.title_string, failure.message)

--- a/examples/kotlin/shared/ResponseViewHolder.kt
+++ b/examples/kotlin/shared/ResponseViewHolder.kt
@@ -1,7 +1,6 @@
 package io.envoyproxy.envoymobile.shared
 
 import android.support.v7.widget.RecyclerView
-import android.util.Log
 import android.view.View
 import android.widget.TextView
 


### PR DESCRIPTION
Description: the liveliness CI tests for android are flaky because the response view holder doesn't log with high fidelity without UI interaction. This PR changes the logs to be printed in the main activity.
Risk Level: low
Testing: CI

Signed-off-by: Jose Nino <jnino@lyft.com>