### PR TITLE
core: introduce interface for setting preferred network

### DIFF
--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -54,9 +54,7 @@ envoy_engine_t init_engine() {
   return 1;
 }
 
-envoy_status_t set_preferred_network(envoy_network_t) {
-  return ENVOY_SUCCESS;
-}
+envoy_status_t set_preferred_network(envoy_network_t) { return ENVOY_SUCCESS; }
 
 /*
  * Setup envoy for interaction via the main interface.

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -54,6 +54,10 @@ envoy_engine_t init_engine() {
   return 1;
 }
 
+envoy_status_t set_preferred_network(envoy_network_t) {
+  return ENVOY_SUCCESS;
+}
+
 /*
  * Setup envoy for interaction via the main interface.
  * As it stands this function __must__ be executed after calling `run_engine`.

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -84,6 +84,14 @@ envoy_status_t reset_stream(envoy_stream_t stream);
 envoy_engine_t init_engine();
 
 /**
+ * Update the network interface to the preferred network for opening new connections.
+ * Note that this state is shared by all engines.
+ * @param network_interface, the interface to be preferred for new sockets.
+ * @return envoy_status_t, the resulting status of the operation.
+ */
+envoy_status_t set_preferred_network(envoy_network_t network_interface);
+
+/**
  * External entry point for library.
  * @param config, the configuration blob to run envoy with.
  * @param log_level, the logging level to run envoy with.

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -84,7 +84,7 @@ envoy_status_t reset_stream(envoy_stream_t stream);
 envoy_engine_t init_engine();
 
 /**
- * Update the network interface to the preferred network for opening new connections.
+ * Update the network interface to the preferred network for opening new streams.
  * Note that this state is shared by all engines.
  * @param network_interface, the interface to be preferred for new sockets.
  * @return envoy_status_t, the resulting status of the operation.

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -29,6 +29,11 @@ typedef enum { ENVOY_SUCCESS, ENVOY_FAILURE } envoy_status_t;
  */
 typedef enum { ENVOY_UNDEFINED_ERROR, ENVOY_STREAM_RESET } envoy_error_code_t;
 
+/**
+ * Networks by interface.
+ */
+typedef enum { ENVOY_WLAN, ENVOY_WWAN } envoy_network_t;
+
 #ifdef __cplusplus
 extern "C" { // release function
 #endif

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -30,9 +30,12 @@ typedef enum { ENVOY_SUCCESS, ENVOY_FAILURE } envoy_status_t;
 typedef enum { ENVOY_UNDEFINED_ERROR, ENVOY_STREAM_RESET } envoy_error_code_t;
 
 /**
- * Networks by interface.
+ * Networks classified by last physical link.
+ * ENVOY_GENERIC is default and includes cases where network characteristics are unknown.
+ * ENVOY_WLAN includes WiFi and other local area wireless networks.
+ * ENVOY_WWAN includes all mobile phone networks.
  */
-typedef enum { ENVOY_WLAN, ENVOY_WWAN } envoy_network_t;
+typedef enum { ENVOY_GENERIC, ENVOY_WLAN, ENVOY_WWAN } envoy_network_t;
 
 #ifdef __cplusplus
 extern "C" { // release function


### PR DESCRIPTION
Description: This is to allow OS/platform reachability signals to be consumed by the Envoy library engine.

Co-authored-by: Jose Nino <jnino@lyft.com>
Signed-off-by: Mike Schore <mike.schore@gmail.com>