### PR TITLE
core: add network-specific clusters to support OS preference

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -34,7 +34,7 @@ R"(
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     load_assignment:
-      cluster_name: base
+      cluster_name: base_wlan
       endpoints:
         - lb_endpoints:
             - endpoint:
@@ -54,7 +54,7 @@ R"(
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     load_assignment:
-      cluster_name: base
+      cluster_name: base_wwan
       endpoints:
         - lb_endpoints:
             - endpoint:

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -29,8 +29,8 @@ R"(
       sni: {{ domain }}
     type: LOGICAL_DNS
   - name: base_wlan # Note: the direct API depends on the existence of a cluster with this name.
-    connect_timeout: {{ connect_timeout }}
-    dns_refresh_rate: {{ dns_refresh_rate }}
+    connect_timeout: {{ connect_timeout_seconds }}s
+    dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -49,8 +49,8 @@ R"(
       sni: {{ domain }}
     type: LOGICAL_DNS
   - name: base_wwan # Note: the direct API depends on the existence of a cluster with this name.
-    connect_timeout: {{ connect_timeout }}
-    dns_refresh_rate: {{ dns_refresh_rate }}
+    connect_timeout: {{ connect_timeout_seconds }}s
+    dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -1,5 +1,7 @@
 /**
  * Templated default configuration
+ *
+ * Note: Parts of this configuration are required for the direct API to function.
  */
 const char* config_template = R"(
 static_resources:

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -1,12 +1,10 @@
 /**
  * Templated default configuration
- *
- * Note: Parts of this configuration are required for the direct API to function.
  */
 const char* config_template = R"(
 static_resources:
   clusters:
-  - name: base
+  - name: base # Note: the direct API depends on the existence of a cluster with this name.
     connect_timeout: {{ connect_timeout_seconds }}s
     dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
     dns_lookup_family: V4_ONLY
@@ -30,7 +28,7 @@ R"(
             - {{ domain }}
       sni: {{ domain }}
     type: LOGICAL_DNS
-  - name: base_wlan
+  - name: base_wlan # Note: the direct API depends on the existence of a cluster with this name.
     connect_timeout: {{ connect_timeout }}
     dns_refresh_rate: {{ dns_refresh_rate }}
     dns_lookup_family: V4_ONLY
@@ -50,7 +48,7 @@ R"(
             - {{ domain }}
       sni: {{ domain }}
     type: LOGICAL_DNS
-  - name: base_wwan
+  - name: base_wwan # Note: the direct API depends on the existence of a cluster with this name.
     connect_timeout: {{ connect_timeout }}
     dns_refresh_rate: {{ dns_refresh_rate }}
     dns_lookup_family: V4_ONLY

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -28,6 +28,46 @@ R"(
             - {{ domain }}
       sni: {{ domain }}
     type: LOGICAL_DNS
+  - name: base_wlan
+    connect_timeout: {{ connect_timeout }}
+    dns_refresh_rate: {{ dns_refresh_rate }}
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: base
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address: {address: {{ domain }}, port_value: 443}
+    tls_context:
+      common_tls_context:
+        validation_context:
+          trusted_ca: *trusted_ca
+          verify_subject_alt_name:
+            - {{ domain }}
+      sni: {{ domain }}
+    type: LOGICAL_DNS
+  - name: base_wwan
+    connect_timeout: {{ connect_timeout }}
+    dns_refresh_rate: {{ dns_refresh_rate }}
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: base
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address: {address: {{ domain }}, port_value: 443}
+    tls_context:
+      common_tls_context:
+        validation_context:
+          trusted_ca: *trusted_ca
+          verify_subject_alt_name:
+            - {{ domain }}
+      sni: {{ domain }}
+    type: LOGICAL_DNS
 stats_flush_interval: {{ stats_flush_interval_seconds }}s
 watchdog:
   megamiss_timeout: 60s

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -203,12 +203,13 @@ AsyncClient& Dispatcher::getClient() {
          "cluster interaction must be performed on the event_dispatcher_'s thread.");
   switch (preferred_network_.load()) {
   case ENVOY_NET_WLAN:
-    return cluster_manager_->httpAsyncClientForCluster("base_wlan");
+    // The ASSERT above ensures the cluster_manager_ is visible/safe to access.
+    return TS_UNCHECKED_READ(cluster_manager_)->httpAsyncClientForCluster("base_wlan");
   case ENVOY_NET_WWAN:
-    return cluster_manager_->httpAsyncClientForCluster("base_wwan");
+    return TS_UNCHECKED_READ(cluster_manager_)->httpAsyncClientForCluster("base_wwan");
   case ENVOY_NET_GENERIC:
   default:
-    return cluster_manager_->httpAsyncClientForCluster("base");
+    return TS_UNCHECKED_READ(cluster_manager_)->httpAsyncClientForCluster("base");
   }
 }
 

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -90,14 +90,16 @@ void Dispatcher::post(Event::PostCb callback) {
   init_queue_.push_back(callback);
 }
 
+Dispatcher::Dispatcher(std::atomic<envoy_network_t>& current_preferred_network)
+    : current_preferred_network_(current_preferred_network) {}
+
 envoy_status_t Dispatcher::startStream(envoy_stream_t new_stream_handle,
-                                       envoy_network_t preferred_network,
                                        envoy_http_callbacks bridge_callbacks) {
   post([this, bridge_callbacks, new_stream_handle]() -> void {
     DirectStreamCallbacksPtr callbacks =
         std::make_unique<DirectStreamCallbacks>(new_stream_handle, bridge_callbacks, *this);
 
-    AsyncClient& async_client = getClient(preferred_network);
+    AsyncClient& async_client = getClient();
     AsyncClient::Stream* underlying_stream = async_client.start(*callbacks, {});
 
     if (!underlying_stream) {
@@ -196,10 +198,10 @@ envoy_status_t Dispatcher::resetStream(envoy_stream_t stream) {
 
 // Select the client based on the current preferred network. This helps to ensure that
 // the engine uses connections opened on the current favored interface.
-AsyncClient& Dispatcher::getClient(envoy_network_t preferred_network) {
+AsyncClient& Dispatcher::getClient() {
   ASSERT(event_dispatcher_.isThreadSafe(),
          "cluster interaction must be performed on the event_dispatcher_'s thread.");
-  switch (preferred_network) {
+  switch (current_preferred_network_.load()) {
   case ENVOY_NET_WLAN:
     return cluster_manager_.httpAsyncClientForCluster("base_wlan");
   case ENVOY_NET_WWAN:

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -90,8 +90,8 @@ void Dispatcher::post(Event::PostCb callback) {
   init_queue_.push_back(callback);
 }
 
-Dispatcher::Dispatcher(std::atomic<envoy_network_t>& current_preferred_network)
-    : current_preferred_network_(current_preferred_network) {}
+Dispatcher::Dispatcher(std::atomic<envoy_network_t>& preferred_network)
+    : preferred_network_(preferred_network) {}
 
 envoy_status_t Dispatcher::startStream(envoy_stream_t new_stream_handle,
                                        envoy_http_callbacks bridge_callbacks) {
@@ -201,7 +201,7 @@ envoy_status_t Dispatcher::resetStream(envoy_stream_t stream) {
 AsyncClient& Dispatcher::getClient() {
   ASSERT(event_dispatcher_.isThreadSafe(),
          "cluster interaction must be performed on the event_dispatcher_'s thread.");
-  switch (current_preferred_network_.load()) {
+  switch (preferred_network_.load()) {
   case ENVOY_NET_WLAN:
     return cluster_manager_.httpAsyncClientForCluster("base_wlan");
   case ENVOY_NET_WWAN:

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -199,16 +199,16 @@ envoy_status_t Dispatcher::resetStream(envoy_stream_t stream) {
 // Select the client based on the current preferred network. This helps to ensure that
 // the engine uses connections opened on the current favored interface.
 AsyncClient& Dispatcher::getClient() {
-  ASSERT(event_dispatcher_.isThreadSafe(),
+  ASSERT(event_dispatcher_->isThreadSafe(),
          "cluster interaction must be performed on the event_dispatcher_'s thread.");
   switch (preferred_network_.load()) {
   case ENVOY_NET_WLAN:
-    return cluster_manager_.httpAsyncClientForCluster("base_wlan");
+    return cluster_manager_->httpAsyncClientForCluster("base_wlan");
   case ENVOY_NET_WWAN:
-    return cluster_manager_.httpAsyncClientForCluster("base_wwan");
+    return cluster_manager_->httpAsyncClientForCluster("base_wwan");
   case ENVOY_NET_GENERIC:
   default:
-    return cluster_manager_.httpAsyncClientForCluster("base");
+    return cluster_manager_->httpAsyncClientForCluster("base");
   }
 }
 

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -33,7 +33,8 @@ public:
    * @param bridge_callbacks, wrapper for callbacks for events on this stream.
    * @return envoy_stream_t handle to the stream being created.
    */
-  envoy_status_t startStream(envoy_stream_t stream, envoy_network_t preferred_network, envoy_http_callbacks bridge_callbacks);
+  envoy_status_t startStream(envoy_stream_t stream, envoy_network_t preferred_network,
+                             envoy_http_callbacks bridge_callbacks);
 
   /**
    * Send headers over an open HTTP stream. This method can be invoked once and needs to be called

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -22,7 +22,7 @@ namespace Http {
  */
 class Dispatcher : public Logger::Loggable<Logger::Id::http> {
 public:
-  Dispatcher(std::atomic<envoy_network_t>& current_preferred_network);
+  Dispatcher(std::atomic<envoy_network_t>& preferred_network);
 
   void ready(Event::Dispatcher& event_dispatcher, Upstream::ClusterManager& cluster_manager);
 
@@ -152,7 +152,7 @@ private:
   Event::Dispatcher* event_dispatcher_ GUARDED_BY(dispatch_lock_);
   Upstream::ClusterManager* cluster_manager_ GUARDED_BY(dispatch_lock_);
   std::unordered_map<envoy_stream_t, DirectStreamPtr> streams_;
-  std::atomic<envoy_network_t>& current_preferred_network_;
+  std::atomic<envoy_network_t>& preferred_network_;
 };
 
 } // namespace Http

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -26,7 +26,7 @@ public:
 
   void ready(Event::Dispatcher& event_dispatcher, Upstream::ClusterManager& cluster_manager);
 
- /**
+  /**
    * Attempts to open a new stream to the remote. Note that this function is asynchronous and
    * opening a stream may fail. The returned handle is immediately valid for use with this API, but
    * there is no guarantee it will ever functionally represent an open stream.

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -28,10 +28,12 @@ public:
    * Attempts to open a new stream to the remote. Note that this function is asynchronous and
    * opening a stream may fail. The returned handle is immediately valid for use with this API, but
    * there is no guarantee it will ever functionally represent an open stream.
-   * @param bridge_callbacks wrapper for callbacks for events on this stream.
+   * @param stream, the stream to start.
+   * @param preferred_network, the current favored network/interface.
+   * @param bridge_callbacks, wrapper for callbacks for events on this stream.
    * @return envoy_stream_t handle to the stream being created.
    */
-  envoy_status_t startStream(envoy_stream_t stream, envoy_http_callbacks bridge_callbacks);
+  envoy_status_t startStream(envoy_stream_t stream, envoy_network_t preferred_network, envoy_http_callbacks bridge_callbacks);
 
   /**
    * Send headers over an open HTTP stream. This method can be invoked once and needs to be called

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -141,6 +141,7 @@ private:
   void post(Event::PostCb callback);
   // Everything in the below interface must only be accessed from the event_dispatcher's thread.
   // This allows us to generally avoid synchronization.
+  AsyncClient& getClient(envoy_network_t preferred_network);
   DirectStream* getStream(envoy_stream_t stream_handle);
   void cleanup(envoy_stream_t stream_handle);
 

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -60,8 +60,8 @@ envoy_engine_t init_engine() {
 }
 
 envoy_status_t set_preferred_network(envoy_network_t network) {
- current_preferred_network_.set(network);
- return ENVOY_SUCCESS;
+  current_preferred_network_.set(network);
+  return ENVOY_SUCCESS;
 }
 
 /*

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -31,7 +31,7 @@ static std::atomic<envoy_network_t> current_preferred_network_{ENVOY_NET_GENERIC
 envoy_stream_t init_stream(envoy_engine_t) { return current_stream_handle_++; }
 
 envoy_status_t start_stream(envoy_stream_t stream, envoy_http_callbacks callbacks) {
-  http_dispatcher_->startStream(stream, current_preferred_network_.load(), callbacks);
+  http_dispatcher_->startStream(stream, callbacks);
   return ENVOY_SUCCESS;
 }
 
@@ -60,7 +60,7 @@ envoy_engine_t init_engine() {
 }
 
 envoy_status_t set_preferred_network(envoy_network_t network) {
-  current_preferred_network_.set(network);
+  current_preferred_network_.store(network);
   return ENVOY_SUCCESS;
 }
 
@@ -73,7 +73,8 @@ envoy_status_t set_preferred_network(envoy_network_t network) {
  */
 void setup_envoy() {
   http_dispatcher_ = std::make_unique<Envoy::Http::Dispatcher>(
-      main_common_->server()->dispatcher(), main_common_->server()->clusterManager());
+      main_common_->server()->dispatcher(), main_common_->server()->clusterManager(),
+      current_preferred_network_);
 }
 
 /**

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -60,6 +60,18 @@ envoy_engine_t init_engine() {
 
 envoy_status_t set_preferred_network(envoy_network_t) { return ENVOY_SUCCESS; }
 
+/*
+ * Setup envoy for interaction via the main interface.
+ * As it stands this function __must__ be executed after calling `run_engine`.
+ * run_engine assigns a static unique pointer used by this function.
+ * TODO: this will change when the engine is no longer static:
+ * https://github.com/lyft/envoy-mobile/issues/332
+ */
+void setup_envoy() {
+  http_dispatcher_ = std::make_unique<Envoy::Http::Dispatcher>(
+      main_common_->server()->dispatcher(), main_common_->server()->clusterManager());
+}
+
 /**
  * External entrypoint for library.
  */

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -26,7 +26,7 @@ static std::unique_ptr<Envoy::MainCommon> main_common_;
 static std::unique_ptr<Envoy::Http::Dispatcher> http_dispatcher_;
 static Envoy::Server::ServerLifecycleNotifier::HandlePtr stageone_callback_handler_;
 static std::atomic<envoy_stream_t> current_stream_handle_{0};
-static std::atomic<envoy_network_t> current_preferred_network_{ENVOY_NET_GENERIC};
+static std::atomic<envoy_network_t> preferred_network_{ENVOY_NET_GENERIC};
 
 envoy_stream_t init_stream(envoy_engine_t) { return current_stream_handle_++; }
 
@@ -60,7 +60,7 @@ envoy_engine_t init_engine() {
 }
 
 envoy_status_t set_preferred_network(envoy_network_t network) {
-  current_preferred_network_.store(network);
+  preferred_network_.store(network);
   return ENVOY_SUCCESS;
 }
 
@@ -74,7 +74,7 @@ envoy_status_t set_preferred_network(envoy_network_t network) {
 void setup_envoy() {
   http_dispatcher_ = std::make_unique<Envoy::Http::Dispatcher>(
       main_common_->server()->dispatcher(), main_common_->server()->clusterManager(),
-      current_preferred_network_);
+      preferred_network_);
 }
 
 /**

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -53,7 +53,7 @@ envoy_status_t send_trailers(envoy_stream_t stream, envoy_headers trailers) {
 envoy_status_t reset_stream(envoy_stream_t stream) { return http_dispatcher_->resetStream(stream); }
 
 envoy_engine_t init_engine() {
-  http_dispatcher_ = std::make_unique<Envoy::Http::Dispatcher>();
+  http_dispatcher_ = std::make_unique<Envoy::Http::Dispatcher>(preferred_network_);
   // TODO(goaway): return new handle once multiple engine support is in place.
   // https://github.com/lyft/envoy-mobile/issues/332
   return 1;
@@ -62,19 +62,6 @@ envoy_engine_t init_engine() {
 envoy_status_t set_preferred_network(envoy_network_t network) {
   preferred_network_.store(network);
   return ENVOY_SUCCESS;
-}
-
-/*
- * Setup envoy for interaction via the main interface.
- * As it stands this function __must__ be executed after calling `run_engine`.
- * run_engine assigns a static unique pointer used by this function.
- * TODO: this will change when the engine is no longer static:
- * https://github.com/lyft/envoy-mobile/issues/332
- */
-void setup_envoy() {
-  http_dispatcher_ = std::make_unique<Envoy::Http::Dispatcher>(
-      main_common_->server()->dispatcher(), main_common_->server()->clusterManager(),
-      preferred_network_);
 }
 
 /**

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -86,7 +86,7 @@ envoy_engine_t init_engine();
 /**
  * Update the network interface to the preferred network for opening new streams.
  * Note that this state is shared by all engines.
- * @param network, the network to be preferred for new sockets.
+ * @param network, the network to be preferred for new streams.
  * @return envoy_status_t, the resulting status of the operation.
  */
 envoy_status_t set_preferred_network(envoy_network_t network);

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -86,10 +86,10 @@ envoy_engine_t init_engine();
 /**
  * Update the network interface to the preferred network for opening new streams.
  * Note that this state is shared by all engines.
- * @param network_interface, the interface to be preferred for new sockets.
+ * @param network, the network to be preferred for new sockets.
  * @return envoy_status_t, the resulting status of the operation.
  */
-envoy_status_t set_preferred_network(envoy_network_t network_interface);
+envoy_status_t set_preferred_network(envoy_network_t network);
 
 /**
  * External entry point for library.

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -31,11 +31,11 @@ typedef enum { ENVOY_UNDEFINED_ERROR, ENVOY_STREAM_RESET } envoy_error_code_t;
 
 /**
  * Networks classified by last physical link.
- * ENVOY_GENERIC is default and includes cases where network characteristics are unknown.
- * ENVOY_WLAN includes WiFi and other local area wireless networks.
- * ENVOY_WWAN includes all mobile phone networks.
+ * ENVOY_NET_GENERIC is default and includes cases where network characteristics are unknown.
+ * ENVOY_NET_WLAN includes WiFi and other local area wireless networks.
+ * ENVOY_NET_WWAN includes all mobile phone networks.
  */
-typedef enum { ENVOY_GENERIC, ENVOY_WLAN, ENVOY_WWAN } envoy_network_t;
+typedef enum { ENVOY_NET_GENERIC, ENVOY_NET_WLAN, ENVOY_NET_WWAN } envoy_network_t;
 
 #ifdef __cplusplus
 extern "C" { // release function


### PR DESCRIPTION
Description: Consumes OS network preference signals to classify connections based on when they're created. New streams will be opened on connections grouped under the current network indication. Note that sockets are still opened by syscalls and so it is simply assumed they are attached to the appropriate network interface.
Risk Level: Moderate
Testing: CI and local testing

Co-authored-by: Jose Nino <jnino@lyft.com>
Signed-off-by: Mike Schore <mike.schore@gmail.com>