### PR TITLE
bazel: enable bitcode on release for iOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,10 +29,10 @@ build:sim --ios_multi_cpus=i386,x86_64 --fat_apk_cpu=x86,x86_64
 
 build:fat --ios_multi_cpus=i386,x86_64,armv7,arm64 --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a
 
-# TODO: Enable `--copt -ggdb3`. Using this configuration currently requires python3.
+# TODO: Enable `--copt -ggdb3`. Issues were encountered previously with this:
 # https://github.com/lyft/envoy-mobile/pull/155#issuecomment-507461500
-# https://stackoverflow.com/a/38177538/1145804
 build:release \
   --linkopt=-s \
   --copt=-O2 \
-  --config=fat
+  --config=fat \
+  --apple_bitcode=embedded


### PR DESCRIPTION
Resolves https://github.com/lyft/envoy-mobile/issues/208.

Signed-off-by: Michael Rebello <me@michaelrebello.com>

Risk Level: Low
Testing: Built locally
