### PR TITLE
kotlin: fix unit tests and add java tests to ci

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -99,5 +99,17 @@ jobs:
           submodules: true
       - name: 'Install dependencies'
         run: ./ci/linux_ci_setup.sh
-      - run: ./bazelw test --test_output=all --build_tests_only //library/kotlin/test/... //library/java/test/...
+      - run: ./bazelw test --test_output=all --build_tests_only //library/kotlin/test/...
         name: 'Run Kotlin library tests'
+  javatests:
+    name: java_tests
+    runs-on: ubuntu-18.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: 'Install dependencies'
+        run: ./ci/linux_ci_setup.sh
+      - run: ./bazelw test --test_output=all --build_tests_only //library/java/test/...
+        name: 'Run Java library tests'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -99,5 +99,5 @@ jobs:
           submodules: true
       - name: 'Install dependencies'
         run: ./ci/linux_ci_setup.sh
-      - run: ./bazelw test --test_output=all --build_tests_only //library/kotlin/test/...
+      - run: ./bazelw test --test_output=all --build_tests_only //library/kotlin/test/... //library/java/test/...
         name: 'Run Kotlin library tests'

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -7,9 +7,9 @@ private const val TEST_CONFIG = """
 mock_template:
 - name: mock
   domain: {{ domain }}
-  connect_timeout: {{ connect_timeout_seconds }}
-  dns_refresh_rate: {{ dns_refresh_rate_seconds }}
-  stats_flush_interval: {{ stats_flush_interval_seconds }}
+  connect_timeout: {{ connect_timeout_seconds }}s
+  dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+  stats_flush_interval: {{ stats_flush_interval_seconds }}s
 """
 
 
@@ -21,9 +21,9 @@ class EnvoyConfigurationTest {
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG)
     assertThat(resolvedTemplate).contains("domain: api.foo.com")
-    assertThat(resolvedTemplate).contains("connect_timeout: 123")
-    assertThat(resolvedTemplate).contains("dns_refresh_rate: 234")
-    assertThat(resolvedTemplate).contains("stats_flush_interval: 345")
+    assertThat(resolvedTemplate).contains("connect_timeout: 123s")
+    assertThat(resolvedTemplate).contains("dns_refresh_rate: 234s")
+    assertThat(resolvedTemplate).contains("stats_flush_interval: 345s")
   }
 
 

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -21,9 +21,9 @@ class EnvoyConfigurationTest {
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG)
     assertThat(resolvedTemplate).contains("domain: api.foo.com")
-    assertThat(resolvedTemplate).contains("connect_timeout: 123s")
-    assertThat(resolvedTemplate).contains("dns_refresh_rate: 234s")
-    assertThat(resolvedTemplate).contains("stats_flush_interval: 345s")
+    assertThat(resolvedTemplate).contains("connect_timeout: 123")
+    assertThat(resolvedTemplate).contains("dns_refresh_rate: 234")
+    assertThat(resolvedTemplate).contains("stats_flush_interval: 345")
   }
 
 

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
@@ -1,9 +1,5 @@
-package io.envoyproxy.envoymobile.io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile
 
-import io.envoyproxy.envoymobile.Domain
-import io.envoyproxy.envoymobile.EnvoyClientBuilder
-import io.envoyproxy.envoymobile.LogLevel
-import io.envoyproxy.envoymobile.Yaml
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -62,6 +58,5 @@ class EnvoyBuilderTest {
     clientBuilder.build()
     val envoy = clientBuilder.build()
     assertThat(envoy.envoyConfiguration!!.statsFlushSeconds).isEqualTo(1234)
-
   }
 }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -1,9 +1,5 @@
-package library.kotlin.test.io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile
 
-import io.envoyproxy.envoymobile.Envoy
-import io.envoyproxy.envoymobile.RequestBuilder
-import io.envoyproxy.envoymobile.RequestMethod
-import io.envoyproxy.envoymobile.ResponseHandler
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyHTTPStream
@@ -27,12 +23,12 @@ class EnvoyClientTest {
     val envoy = Envoy(engine, config)
 
     val expectedHeaders = mapOf(
-      "key_1" to listOf("value_a"),
-      ":method" to listOf("POST"),
-      ":scheme" to listOf("https"),
-      ":authority" to listOf("api.foo.com"),
-      ":path" to listOf("foo")
-      )
+        "key_1" to listOf("value_a"),
+        ":method" to listOf("POST"),
+        ":scheme" to listOf("https"),
+        ":authority" to listOf("api.foo.com"),
+        ":path" to listOf("foo")
+    )
     envoy.send(
         RequestBuilder(
             method = RequestMethod.POST,
@@ -132,11 +128,11 @@ class EnvoyClientTest {
     val envoy = Envoy(engine, config)
 
     val expectedHeaders = mapOf(
-      "key_1" to listOf("value_a"),
-      ":method" to listOf("POST"),
-      ":scheme" to listOf("https"),
-      ":authority" to listOf("api.foo.com"),
-      ":path" to listOf("foo")
+        "key_1" to listOf("value_a"),
+        ":method" to listOf("POST"),
+        ":scheme" to listOf("https"),
+        ":authority" to listOf("api.foo.com"),
+        ":path" to listOf("foo")
     )
     envoy.send(
         RequestBuilder(

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestMapperTest.kt
@@ -1,10 +1,5 @@
-package library.kotlin.test.io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile
 
-import io.envoyproxy.envoymobile.RequestBuilder
-import io.envoyproxy.envoymobile.RequestMethod
-import io.envoyproxy.envoymobile.RetryPolicy
-import io.envoyproxy.envoymobile.RetryRule
-import io.envoyproxy.envoymobile.outboundHeaders
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 

--- a/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHandlerTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHandlerTest.kt
@@ -1,6 +1,5 @@
-package library.kotlin.test.io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile
 
-import io.envoyproxy.envoymobile.ResponseHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.util.concurrent.Executor;

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -1,8 +1,5 @@
-package library.kotlin.test.io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile
 
-import io.envoyproxy.envoymobile.RetryPolicy
-import io.envoyproxy.envoymobile.RetryRule
-import io.envoyproxy.envoymobile.outboundHeaders
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 


### PR DESCRIPTION
We weren't running CI for the java tests previously because they weren't being specified in the CI task

Signed-off-by: Alan Chiu <achiu@lyft.com>

Description: kotlin: fix unit tests and add java tests to ci
Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
