### PR TITLE
bazel: use iOS 13 by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@ build \
   --define=tcmalloc=disabled \
   --ios_minimum_os=10.0 \
   --ios_simulator_device="iPhone X" \
-  --ios_simulator_version=12.4 \
+  --ios_simulator_version=13.0 \
   --spawn_strategy=local \
   --verbose_failures \
   --workspace_status_command=envoy/bazel/get_workspace_status \


### PR DESCRIPTION
This runtime is available in Xcode 11 by default.

Signed-off-by: Michael Rebello <me@michaelrebello.com>