### PR TITLE
examples: remove outdated docstrings

### DIFF
--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -54,7 +54,6 @@ NSString *_REQUEST_SCHEME = @"http";
 #pragma mark - Requests
 
 - (void)startRequests {
-  // Note that the first delay will give Envoy time to start up.
   self.requestTimer = [NSTimer scheduledTimerWithTimeInterval:1.0
                                                        target:self
                                                      selector:@selector(performRequest)

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -33,7 +33,6 @@ final class ViewController: UITableViewController {
   // MARK: - Requests
 
   private func startRequests() {
-    // Note that the first delay will give Envoy time to start up.
     self.timer = .scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
       self?.performRequest()
     }


### PR DESCRIPTION
As of https://github.com/lyft/envoy-mobile/pull/428, we now queue API calls while Envoy starts up, so the 1s delay is no longer required. Removing the outdated docstrings.

Signed-off-by: Michael Rebello <me@michaelrebello.com>