### PR TITLE
core: expose stream options

### DIFF
--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -28,10 +28,13 @@ public:
    * Attempts to open a new stream to the remote. Note that this function is asynchronous and
    * opening a stream may fail. The returned handle is immediately valid for use with this API, but
    * there is no guarantee it will ever functionally represent an open stream.
+   * @param stream, the stream to start.
    * @param bridge_callbacks wrapper for callbacks for events on this stream.
+   * @param stream_options, the config options to start the stream with.
    * @return envoy_stream_t handle to the stream being created.
    */
-  envoy_status_t startStream(envoy_stream_t stream, envoy_http_callbacks bridge_callbacks);
+  envoy_status_t startStream(envoy_stream_t stream, envoy_http_callbacks bridge_callbacks,
+                             envoy_stream_options stream_options);
 
   /**
    * Send headers over an open HTTP stream. This method can be invoked once and needs to be called
@@ -114,6 +117,8 @@ private:
   public:
     DirectStream(envoy_stream_t stream_handle, AsyncClient::Stream& underlying_stream,
                  DirectStreamCallbacksPtr&& callbacks);
+
+    static AsyncClient::StreamOptions toNativeStreamOptions(envoy_stream_options stream_options);
 
     const envoy_stream_t stream_handle_;
     // Used to issue outgoing HTTP stream operations.

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -273,7 +273,7 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
                                            jvm_on_trailers, jvm_on_error, jvm_on_complete,
                                            retained_context};
   envoy_status_t result =
-      start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks);
+      start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks, {});
   if (result != ENVOY_SUCCESS) {
     env->DeleteGlobalRef(retained_context); // No callbacks are fired and we need to release
   }

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -29,8 +29,9 @@ static std::atomic<envoy_stream_t> current_stream_handle_{0};
 
 envoy_stream_t init_stream(envoy_engine_t) { return current_stream_handle_++; }
 
-envoy_status_t start_stream(envoy_stream_t stream, envoy_http_callbacks callbacks) {
-  http_dispatcher_->startStream(stream, callbacks);
+envoy_status_t start_stream(envoy_stream_t stream, envoy_http_callbacks callbacks,
+                            envoy_stream_options stream_options) {
+  http_dispatcher_->startStream(stream, callbacks, stream_options);
   return ENVOY_SUCCESS;
 }
 

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -32,7 +32,8 @@ envoy_stream_t init_stream(envoy_engine_t);
  * @param callbacks, the callbacks that will run the stream callbacks.
  * @return envoy_stream, with a stream handle and a success status, or a failure status.
  */
-envoy_status_t start_stream(envoy_stream_t, envoy_http_callbacks callbacks);
+envoy_status_t start_stream(envoy_stream_t, envoy_http_callbacks callbacks,
+                            envoy_stream_options stream_options);
 
 /**
  * Send headers over an open HTTP stream. This method can be invoked once and needs to be called

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -128,6 +128,10 @@ typedef struct {
   envoy_data message;
 } envoy_error;
 
+typedef struct {
+  bool buffer_body_for_retry;
+} envoy_stream_options;
+
 #ifdef __cplusplus
 extern "C" { // function pointers
 #endif

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -197,7 +197,8 @@ static void ios_on_error(envoy_error error, void *context) {
   // start_stream could result in a reset that would release the native ref.
   // TODO: To be truly safe we probably need stronger guarantees of operation ordering on this ref
   _strongSelf = self;
-  envoy_status_t result = start_stream(_streamHandle, native_callbacks);
+  envoy_stream_options stream_options;
+  envoy_status_t result = start_stream(_streamHandle, native_callbacks, stream_options);
   if (result != ENVOY_SUCCESS) {
     _strongSelf = nil;
     return nil;

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -103,7 +103,7 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb;
@@ -185,7 +185,7 @@ TEST_F(DispatcherTest, BasicStream) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb headers_post_cb;
@@ -248,7 +248,7 @@ TEST_F(DispatcherTest, ResetStream) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
 
   Event::PostCb post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
@@ -304,7 +304,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream1, bridge_callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream1, bridge_callbacks, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb;
@@ -357,7 +357,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
   EXPECT_CALL(event_dispatcher_, post(_));
-  EXPECT_EQ(http_dispatcher_.startStream(stream2, bridge_callbacks2), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream2, bridge_callbacks2, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb2;
@@ -430,7 +430,7 @@ TEST_F(DispatcherTest, LocalResetAfterStreamStart) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -503,7 +503,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -544,7 +544,7 @@ TEST_F(DispatcherTest, DestroyWithActiveStream) {
   EXPECT_CALL(cm_, httpAsyncClientForCluster("base")).WillOnce(ReturnRef(cm_.async_client_));
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions())));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   EXPECT_CALL(stream_encoder_, encodeHeaders(_, false));
@@ -574,7 +574,7 @@ TEST_F(DispatcherTest, ResetInOnHeaders) {
   EXPECT_CALL(cm_, httpAsyncClientForCluster("base")).WillOnce(ReturnRef(cm_.async_client_));
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions())));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -614,7 +614,7 @@ TEST_F(DispatcherTest, StreamTimeout) {
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions().setTimeout(
                                                             std::chrono::milliseconds(40)))));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -662,7 +662,7 @@ TEST_F(DispatcherTest, StreamTimeoutHeadReply) {
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions().setTimeout(
                                                             std::chrono::milliseconds(40)))));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb send_headers_post_cb;
@@ -700,7 +700,7 @@ TEST_F(DispatcherTest, DisableTimerWithStream) {
   EXPECT_CALL(cm_.async_client_, start(_, _))
       .WillOnce(Return(client_.start(stream_callbacks_, AsyncClient::StreamOptions().setTimeout(
                                                             std::chrono::milliseconds(40)))));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks_, {}), ENVOY_SUCCESS);
 
   // Send request headers and reset stream.
   Event::PostCb send_headers_post_cb;
@@ -776,7 +776,7 @@ TEST_F(DispatcherTest, MultipleDataStream) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb headers_post_cb;
@@ -874,7 +874,7 @@ TEST_F(DispatcherTest, StreamResetAfterOnComplete) {
           WithArg<0>(Invoke([&](AsyncClient::StreamCallbacks& callbacks) -> AsyncClient::Stream* {
             return client_.start(callbacks, AsyncClient::StreamOptions());
           })));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
 
   // Send request headers.
   Event::PostCb post_cb;


### PR DESCRIPTION
Description: this PR introduces `envoy_stream_options` which is a subset of AsyncClient::StreamOptions, that can be used in the bridge layer.
Risk Level: med - new functionality
Testing: unit tests missing, will update after initial discussion

Signed-off-by: Jose Nino <jnino@lyft.com>

