### PR TITLE
core: deal with local replies

### DIFF
--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -23,7 +23,10 @@ envoy_cc_library(
         "@envoy//source/common/common:lock_guard_lib",
         "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/common/common:thread_lib",
+        "@envoy//source/common/http:headers_lib",
+        "@envoy//source/common/http:utility_lib",
     ],
+    external_deps = ["abseil_optional"],
 )
 
 envoy_cc_library(

--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -8,6 +8,7 @@ envoy_cc_library(
     name = "dispatcher_lib",
     srcs = ["dispatcher.cc"],
     hdrs = ["dispatcher.h"],
+    external_deps = ["abseil_optional"],
     repository = "@envoy",
     deps = [
         "//library/common/buffer:bridge_fragment_lib",
@@ -26,7 +27,6 @@ envoy_cc_library(
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/http:utility_lib",
     ],
-    external_deps = ["abseil_optional"],
 )
 
 envoy_cc_library(

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -24,7 +24,7 @@ void Dispatcher::DirectStreamCallbacks::onHeaders(HeaderMapPtr&& headers, bool e
   // TODO: ***HACK*** currently Envoy sends local replies in cases where an error ought to be
   // surfaced via the error path. There are ways we can clean up Envoy's local reply path to
   // make this possible, but nothing expedient. For the immediate term this is our only real
-  // option.(PUT ISSUE HERE)
+  // option. See https://github.com/lyft/envoy-mobile/issues/460
 
   // The presence of EnvoyUpstreamServiceTime implies these headers are not due to a local reply.
   if (headers->get(Headers::get().EnvoyUpstreamServiceTime) != nullptr) {

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -21,7 +21,7 @@ Dispatcher::DirectStreamCallbacks::DirectStreamCallbacks(envoy_stream_t stream,
 void Dispatcher::DirectStreamCallbacks::onHeaders(HeaderMapPtr&& headers, bool end_stream) {
   ENVOY_LOG(debug, "[S{}] response headers for stream (end_stream={}):\n{}", stream_handle_,
             end_stream, *headers);
-  // TODO: ***HACK*** currently Envoy sends local replies in cases which for a library ought to be
+  // TODO: ***HACK*** currently Envoy sends local replies in cases where an error ought to be
   // surfaced via the error path. There are ways we can clean up Envoy's local reply path to
   // make this possible, but nothing expedient. For the immediate term this is our only real
   // option.(PUT ISSUE HERE)

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -2,8 +2,6 @@
 
 #include <unordered_map>
 
-#include "absl/types/optional.h"
-
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/async_client.h"
@@ -13,6 +11,7 @@
 #include "common/common/logger.h"
 #include "common/common/thread.h"
 
+#include "absl/types/optional.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -156,8 +156,6 @@ private:
   Upstream::ClusterManager* cluster_manager_ GUARDED_BY(dispatch_lock_);
   std::unordered_map<envoy_stream_t, DirectStreamPtr> streams_;
   std::atomic<envoy_network_t>& preferred_network_;
-  std::optional<envoy_error_code_t> error_code_;
-  std::optional<envoy_data> envoy_message_;
 };
 
 } // namespace Http

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -2,6 +2,8 @@
 
 #include <unordered_map>
 
+#include "absl/types/optional.h"
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/async_client.h"
@@ -104,6 +106,8 @@ private:
   private:
     const envoy_stream_t stream_handle_;
     const envoy_http_callbacks bridge_callbacks_;
+    absl::optional<envoy_error_code_t> error_code_;
+    absl::optional<envoy_data> error_message_;
     Dispatcher& http_dispatcher_;
   };
 

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -153,6 +153,8 @@ private:
   Upstream::ClusterManager* cluster_manager_ GUARDED_BY(dispatch_lock_);
   std::unordered_map<envoy_stream_t, DirectStreamPtr> streams_;
   std::atomic<envoy_network_t>& preferred_network_;
+  std::optional<envoy_error_code_t> error_code_;
+  std::optional<envoy_data> envoy_message_;
 };
 
 } // namespace Http

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -27,7 +27,11 @@ typedef enum { ENVOY_SUCCESS, ENVOY_FAILURE } envoy_status_t;
 /**
  * Error code associated with terminal status of a HTTP stream.
  */
-typedef enum { ENVOY_UNDEFINED_ERROR, ENVOY_STREAM_RESET, ENVOY_CONNECTION_FAILURE } envoy_error_code_t;
+typedef enum {
+  ENVOY_UNDEFINED_ERROR,
+  ENVOY_STREAM_RESET,
+  ENVOY_CONNECTION_FAILURE
+} envoy_error_code_t;
 
 /**
  * Networks classified by last physical link.

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -27,7 +27,7 @@ typedef enum { ENVOY_SUCCESS, ENVOY_FAILURE } envoy_status_t;
 /**
  * Error code associated with terminal status of a HTTP stream.
  */
-typedef enum { ENVOY_UNDEFINED_ERROR, ENVOY_STREAM_RESET } envoy_error_code_t;
+typedef enum { ENVOY_UNDEFINED_ERROR, ENVOY_STREAM_RESET, ENVOY_CONNECTION_FAILURE } envoy_error_code_t;
 
 /**
  * Networks classified by last physical link.


### PR DESCRIPTION
Description: Addresses crashes from locally-generated responses in Envoy leading to inconsistent stream state. A better fix will require an upstream change. Additionally, this adds a mechanism to map local error responses into error callbacks. This path could also be greatly improved with upstream changes.
Risk Level: Low
Testing: CI and local

Signed-off-by: Jose Nino <jnino@lyft.com>
Co-authored-by: Mike Schore <mike.schore@gmail.com>
