### PR TITLE
android: add pom xml capabilities

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,6 +93,9 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     artifacts = [
+        # Kotlin
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11",
+
         # Test artifacts
         "org.assertj:assertj-core:3.9.0",
         "junit:junit:4.12",
@@ -103,6 +106,12 @@ maven_install(
         "https://repo1.maven.org/maven2",
         "https://jcenter.bintray.com/",
     ],
+)
+
+http_archive(
+    name = "google_bazel_common",
+    strip_prefix = "bazel-common-f1115e0f777f08c3cdb115526c4e663005bec69b",
+    urls = ["https://github.com/google/bazel-common/archive/f1115e0f777f08c3cdb115526c4e663005bec69b.zip"],
 )
 
 git_repository(

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -15,3 +15,7 @@ kt_jvm_library(
         "@maven//:junit_junit",
     ],
 )
+
+exports_files([
+    "pom_template.xml",
+])

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -1,3 +1,5 @@
+load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
+
 # This file is based on https://github.com/aj-michael/aar_with_jni which is
 # subject to the following copyright and license:
 
@@ -28,9 +30,6 @@
 # creates a few underlying libraries, because of this the classes.jar in
 # the aar we built was empty. This rule separately builds the underlying
 # kt.jar file, and replaces the aar's classes.jar with the kotlin jar
-
-load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
-
 def aar_with_jni(name, android_library, archive_name = "", visibility = None):
     if not archive_name:
         archive_name = name

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -28,6 +28,9 @@
 # creates a few underlying libraries, because of this the classes.jar in
 # the aar we built was empty. This rule separately builds the underlying
 # kt.jar file, and replaces the aar's classes.jar with the kotlin jar
+
+load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
+
 def aar_with_jni(name, android_library, archive_name = "", visibility = None):
     if not archive_name:
         archive_name = name
@@ -46,6 +49,12 @@ EOF
 """,
     )
 
+    pom_file(
+        name = archive_name + "_pom",
+        targets = [android_library],
+        template_file = "//bazel:pom_template.xml",
+    )
+
     native.android_binary(
         name = archive_name + "_jni",
         manifest = archive_name + "_generated_AndroidManifest.xml",
@@ -58,6 +67,7 @@ EOF
         srcs = [android_library + "_kt.jar", android_library + ".aar", archive_name + "_jni_unsigned.apk"],
         outs = [archive_name + ".aar"],
         cmd = """
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 cp $(location {android_library}.aar) $(location :{archive_name}.aar)
 chmod +w $(location :{archive_name}.aar)
 origdir=$$PWD

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -67,7 +67,6 @@ EOF
         srcs = [android_library + "_kt.jar", android_library + ".aar", archive_name + "_jni_unsigned.apk"],
         outs = [archive_name + ".aar"],
         cmd = """
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 cp $(location {android_library}.aar) $(location :{archive_name}.aar)
 chmod +w $(location :{archive_name}.aar)
 origdir=$$PWD

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -18,7 +18,7 @@ def envoy_mobile_kt_aar_android_library(name, custom_package, manifest, visibili
         custom_package = custom_package,
         manifest = manifest,
         visibility = ["//visibility:public"],
-        deps = ["@maven//:org_jetbrains_kotlin_kotlin_stdlib_jdk8"] + deps,
+        deps = deps + ["@maven//:org_jetbrains_kotlin_kotlin_stdlib_jdk8"],
     )
 
 def envoy_mobile_android_library(name, custom_package, manifest, visibility = None, srcs = [], deps = []):

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_jvm_library")
-load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
 
 # Android library drops exported dependencies from dependent rules. The kt_android_library
 #  internally is just a macro which wraps two rules into one:

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_jvm_library")
+load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
 
 # Android library drops exported dependencies from dependent rules. The kt_android_library
 #  internally is just a macro which wraps two rules into one:
@@ -17,7 +18,7 @@ def envoy_mobile_kt_aar_android_library(name, custom_package, manifest, visibili
         custom_package = custom_package,
         manifest = manifest,
         visibility = ["//visibility:public"],
-        deps = deps,
+        deps = ["@maven//:org_jetbrains_kotlin_kotlin_stdlib_jdk8"] + deps,
     )
 
 def envoy_mobile_android_library(name, custom_package, manifest, visibility = None, srcs = [], deps = []):

--- a/bazel/pom_template.xml
+++ b/bazel/pom_template.xml
@@ -4,7 +4,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.envoyprox.envoymobile</groupId>
+    <groupId>io.envoyproxy.envoymobile</groupId>
     <artifactId>envoy-mobile</artifactId>
     <version>{pom_version}</version>
 

--- a/bazel/pom_template.xml
+++ b/bazel/pom_template.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.envoyprox.envoymobile</groupId>
+    <artifactId>envoy-mobile</artifactId>
+    <version>{pom_version}</version>
+
+    <dependencies>
+        {generated_bzl_deps}
+    </dependencies>
+</project>

--- a/bazel/pom_template.xml
+++ b/bazel/pom_template.xml
@@ -3,7 +3,7 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-
+    <packaging>aar</packaging>
     <groupId>io.envoyproxy.envoymobile</groupId>
     <artifactId>envoy-mobile</artifactId>
     <version>{pom_version}</version>


### PR DESCRIPTION
Adding the pom xml generation rule from `google_bazel_common`. To generate a pom file run the command: 
```
bazel build //library/kotlin/src/io/envoyproxy/envoymobile:envoy_pom
```
This will generate the following pom:
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <modelVersion>4.0.0</modelVersion>

    <groupId>io.envoyprox.envoymobile</groupId>
    <artifactId>envoy-mobile</artifactId>
    <version>LOCAL-SNAPSHOT</version>

    <dependencies>
        <dependency>
  <groupId>org.jetbrains.kotlin</groupId>
  <artifactId>kotlin-stdlib-jdk8</artifactId>
  <version>1.3.11</version>
</dependency>
    </dependencies>
</project>
```

To override the `LOCAL-SNAPSHOT` with an actual version, you pass in the flag `--define=pom_version=SNAPSHOT-1.0.0` with the build

Alternatives would be to just generate our own pom file off our own mechanism when we want to release/upload.

Signed-off-by: Alan Chiu <achiu@lyft.com>

Description: android: add pom xml capabilities
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
