### PR TITLE
ios: update preferred networks via reachability

### DIFF
--- a/dist/BUILD
+++ b/dist/BUILD
@@ -20,5 +20,8 @@ apple_static_framework_import(
         "resolv.9",
         "c++",
     ],
+    sdk_frameworks = [
+        "SystemConfiguration",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -14,6 +14,7 @@ objc_library(
         "EnvoyEngineImpl.m",
         "EnvoyHTTPCallbacks.m",
         "EnvoyHTTPStreamImpl.m",
+        "EnvoyNetworkMonitor.m",
     ],
     hdrs = [
         "EnvoyEngine.h",

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -193,7 +193,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
 @interface EnvoyNetworkMonitor : NSObject
 
-// Start monitoring reachability and updating the preferred Envoy network cluster.
+// Start monitoring reachability, updating the preferred Envoy network cluster on changes.
 // This is typically called by `EnvoyEngine` automatically on startup.
 + (void)startReachabilityIfNeeded;
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -189,4 +189,14 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
 @end
 
+#pragma mark - EnvoyNetworkMonitor
+
+@interface EnvoyNetworkMonitor : NSObject
+
+// Start monitoring reachability and updating the preferred Envoy network cluster.
+// This is typically called by `EnvoyEngine` automatically on startup.
++ (void)startReachabilityIfNeeded;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -191,6 +191,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
 #pragma mark - EnvoyNetworkMonitor
 
+// Monitors network changes in order to update Envoy network cluster preferences.
 @interface EnvoyNetworkMonitor : NSObject
 
 // Start monitoring reachability, updating the preferred Envoy network cluster on changes.

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -3,16 +3,22 @@
 #import "library/common/main_interface.h"
 #import "library/common/types/c_types.h"
 
+#import <SystemConfiguration/SystemConfiguration.h>
+
 @implementation EnvoyEngineImpl {
   envoy_engine_t _engineHandle;
 }
+
+#pragma mark - Public interface
 
 - (instancetype)init {
   self = [super init];
   if (!self) {
     return nil;
   }
+
   _engineHandle = init_engine();
+  _ensure_reachability_running();
   return self;
 }
 
@@ -41,6 +47,48 @@
 - (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks {
   return [[EnvoyHTTPStreamImpl alloc] initWithHandle:init_stream(_engineHandle)
                                            callbacks:callbacks];
+}
+
+#pragma mark - Reachability
+
+static SCNetworkReachabilityRef _reachability_ref;
+
+static void _reachability_callback(SCNetworkReachabilityRef target,
+                                   SCNetworkReachabilityFlags flags, void *info) {
+  if (flags == 0) {
+    return;
+  }
+
+  BOOL isUsingWWAN = flags & kSCNetworkReachabilityFlagsIsWWAN;
+  set_preferred_network(isUsingWWAN ? ENVOY_NET_WWAN : ENVOY_NET_WLAN);
+}
+
+static void _ensure_reachability_running() {
+  if (_reachability_ref) {
+    return;
+  }
+
+  NSString *name = @"io.envoymobile.reachability";
+  SCNetworkReachabilityRef reachability =
+      SCNetworkReachabilityCreateWithName(nil, [name UTF8String]);
+  if (!reachability) {
+    return;
+  }
+
+  _reachability_ref = reachability;
+
+  SCNetworkReachabilityContext context = {0, NULL, NULL, NULL, NULL};
+  if (!SCNetworkReachabilitySetCallback(_reachability_ref, _reachability_callback, &context)) {
+    return;
+  }
+
+  dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+  if (!SCNetworkReachabilitySetDispatchQueue(_reachability_ref, queue)) {
+    SCNetworkReachabilitySetCallback(_reachability_ref, NULL, NULL);
+    return;
+  }
+
+  return;
 }
 
 @end

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -3,13 +3,9 @@
 #import "library/common/main_interface.h"
 #import "library/common/types/c_types.h"
 
-#import <SystemConfiguration/SystemConfiguration.h>
-
 @implementation EnvoyEngineImpl {
   envoy_engine_t _engineHandle;
 }
-
-#pragma mark - Public interface
 
 - (instancetype)init {
   self = [super init];
@@ -18,7 +14,7 @@
   }
 
   _engineHandle = init_engine();
-  _ensure_reachability_running();
+  [EnvoyNetworkMonitor startReachabilityIfNeeded];
   return self;
 }
 
@@ -47,45 +43,6 @@
 - (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks {
   return [[EnvoyHTTPStreamImpl alloc] initWithHandle:init_stream(_engineHandle)
                                            callbacks:callbacks];
-}
-
-#pragma mark - Reachability
-
-static SCNetworkReachabilityRef _reachability_ref;
-
-static void _reachability_callback(SCNetworkReachabilityRef target,
-                                   SCNetworkReachabilityFlags flags, void *info) {
-  if (flags == 0) {
-    return;
-  }
-
-  BOOL isUsingWWAN = flags & kSCNetworkReachabilityFlagsIsWWAN;
-  set_preferred_network(isUsingWWAN ? ENVOY_NET_WWAN : ENVOY_NET_WLAN);
-}
-
-static void _ensure_reachability_running() {
-  if (_reachability_ref) {
-    return;
-  }
-
-  NSString *name = @"io.envoymobile.reachability";
-  SCNetworkReachabilityRef reachability =
-      SCNetworkReachabilityCreateWithName(nil, [name UTF8String]);
-  if (!reachability) {
-    return;
-  }
-
-  _reachability_ref = reachability;
-
-  SCNetworkReachabilityContext context = {0, NULL, NULL, NULL, NULL};
-  if (!SCNetworkReachabilitySetCallback(_reachability_ref, _reachability_callback, &context)) {
-    return;
-  }
-
-  dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
-  if (!SCNetworkReachabilitySetDispatchQueue(_reachability_ref, queue)) {
-    SCNetworkReachabilitySetCallback(_reachability_ref, NULL, NULL);
-  }
 }
 
 @end

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -85,10 +85,7 @@ static void _ensure_reachability_running() {
   dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
   if (!SCNetworkReachabilitySetDispatchQueue(_reachability_ref, queue)) {
     SCNetworkReachabilitySetCallback(_reachability_ref, NULL, NULL);
-    return;
   }
-
-  return;
 }
 
 @end

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -82,7 +82,7 @@ static void _ensure_reachability_running() {
     return;
   }
 
-  dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+  dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
   if (!SCNetworkReachabilitySetDispatchQueue(_reachability_ref, queue)) {
     SCNetworkReachabilitySetCallback(_reachability_ref, NULL, NULL);
   }

--- a/library/objective-c/EnvoyNetworkMonitor.m
+++ b/library/objective-c/EnvoyNetworkMonitor.m
@@ -7,8 +7,8 @@
 @implementation EnvoyNetworkMonitor
 
 + (void)startReachabilityIfNeeded {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  static dispatch_once_t reachabilityStarted;
+  dispatch_once(&reachabilityStarted, ^{
     _start_reachability();
   });
 }

--- a/library/objective-c/EnvoyNetworkMonitor.m
+++ b/library/objective-c/EnvoyNetworkMonitor.m
@@ -1,0 +1,51 @@
+#import "library/objective-c/EnvoyEngine.h"
+
+#import "library/common/main_interface.h"
+
+#import <SystemConfiguration/SystemConfiguration.h>
+
+@implementation EnvoyNetworkMonitor
+
++ (void)startReachabilityIfNeeded {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    _start_reachability();
+  });
+}
+
+#pragma mark - Private methods
+
+static SCNetworkReachabilityRef _reachability_ref;
+
+static void _reachability_callback(SCNetworkReachabilityRef target,
+                                   SCNetworkReachabilityFlags flags, void *info) {
+  if (flags == 0) {
+    return;
+  }
+
+  BOOL isUsingWWAN = flags & kSCNetworkReachabilityFlagsIsWWAN;
+  set_preferred_network(isUsingWWAN ? ENVOY_NET_WWAN : ENVOY_NET_WLAN);
+}
+
+static void _start_reachability() {
+  NSString *name = @"io.envoyproxy.envoymobile.EnvoyNetworkMonitor";
+  SCNetworkReachabilityRef reachability =
+      SCNetworkReachabilityCreateWithName(nil, [name UTF8String]);
+  if (!reachability) {
+    return;
+  }
+
+  _reachability_ref = reachability;
+
+  SCNetworkReachabilityContext context = {0, NULL, NULL, NULL, NULL};
+  if (!SCNetworkReachabilitySetCallback(_reachability_ref, _reachability_callback, &context)) {
+    return;
+  }
+
+  dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+  if (!SCNetworkReachabilitySetDispatchQueue(_reachability_ref, queue)) {
+    SCNetworkReachabilitySetCallback(_reachability_ref, NULL, NULL);
+  }
+}
+
+@end

--- a/library/objective-c/EnvoyNetworkMonitor.m
+++ b/library/objective-c/EnvoyNetworkMonitor.m
@@ -13,7 +13,7 @@
   });
 }
 
-#pragma mark - Private methods
+#pragma mark - Private
 
 static SCNetworkReachabilityRef _reachability_ref;
 


### PR DESCRIPTION
Adds an implementation of observing reachability on iOS which calls in to the function added in https://github.com/lyft/envoy-mobile/pull/443 to notify Envoy of a change in preferred network selection.

Note that since the core maintains a singleton ref to the preferred network, these observations are also static and are not discarded. This should be addressed as part of implementing shutdown functionality in https://github.com/lyft/envoy-mobile/issues/445.

Signed-off-by: Michael Rebello <me@michaelrebello.com>