### PR TITLE
bazel: fix bitcode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,4 +35,5 @@ build:release \
   --linkopt=-s \
   --copt=-O2 \
   --config=fat \
-  --apple_bitcode=embedded
+  --apple_bitcode=embedded \
+  --copt=-fembed-bitcode


### PR DESCRIPTION
When uploading an app with the previous `--config=release` configuration, bitcode wasn't actually present.

Bazel doesn't seem to be passing `-fembed-bitcode` for C targets when using `--apple_bitcode`, so we need to do so manually.

Signed-off-by: Michael Rebello <me@michaelrebello.com>