### PR TITLE
swift: make RequestMethod.stringValue public

### DIFF
--- a/library/swift/src/RequestMethod.swift
+++ b/library/swift/src/RequestMethod.swift
@@ -13,7 +13,7 @@ public enum RequestMethod: Int {
   case trace
 
   /// String representation of this method.
-  var stringValue: String {
+  public var stringValue: String {
     switch self {
     case .delete:
       return "DELETE"


### PR DESCRIPTION
This can be useful to external consumers since the names of the enum cases are not convertible to strings due to the `@objc` attribute.

For example, when printing `print(RequestMethod.get)`, this will log `RequestMethod` instead of `get` right now since Objective-C int-backed enums don't store the names of Swift cases. Adding this read-only string representation allows consumers to utilize it.

Signed-off-by: Michael Rebello <me@michaelrebello.com>