### PR TITLE
android: create network condition monitor

### DIFF
--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -62,8 +62,7 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_isAresInitialized(JNIEnv
 extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIEnv* env,
                                                                             jclass, // class
-                                                                            jint network
-) {
+                                                                            jint network) {
   return set_preferred_network(static_cast<envoy_network_t>(network));
 }
 

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -59,6 +59,14 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_isAresInitialized(JNIEnv
   return ares_library_android_initialized() == ARES_SUCCESS;
 }
 
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIEnv* env,
+                                                                            jclass, // class
+                                                                            jint network
+) {
+  return set_preferred_network(static_cast<envoy_network_t>(network));
+}
+
 extern "C" JNIEXPORT jstring JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_templateString(JNIEnv* env,
                                                                 jclass // class

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -7,5 +7,6 @@ public class AndroidEngineImpl extends EnvoyEngineImpl {
   public AndroidEngineImpl(Context context) {
     super();
     AndroidJniLibrary.load(context);
+    AndroidNetworkMonitor.load(context);
   }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
@@ -40,4 +40,6 @@ public class AndroidJniLibrary {
    * @return int for successful initialization
    */
   protected static native int initialize(ConnectivityManager connectivityManager);
+
+  protected static native int setPreferredNetwork(int network);
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -14,7 +14,9 @@ import android.net.NetworkRequest;
 import android.os.Build;
 
 /**
- * This class makes use of some deprecated APIs, but it's only current purpose is to attempt to distill some notion of a preferred network from the OS, upon which we can assume new sockets will be opened.
+ * This class makes use of some deprecated APIs, but it's only current purpose is to attempt to
+ * distill some notion of a preferred network from the OS, upon which we can assume new sockets will
+ * be opened.
  */
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class AndroidNetworkMonitor extends BroadcastReceiver {
@@ -42,10 +44,11 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
   }
 
   private AndroidNetworkMonitor(Context context) {
-    connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+    connectivityManager =
+        (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
     networkRequest = new NetworkRequest.Builder()
-      .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-      .build();
+                         .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                         .build();
 
     networkCallback = new NetworkCallback() {
       @Override
@@ -66,9 +69,9 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       }
     };
 
-    context.registerReceiver(this, new IntentFilter() {{
-      addAction(ConnectivityManager.CONNECTIVITY_ACTION);
-    }});
+    context.registerReceiver(this, new IntentFilter() {
+      { addAction(ConnectivityManager.CONNECTIVITY_ACTION); }
+    });
   }
 
   @Override
@@ -83,13 +86,14 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       return;
     }
     switch (networkInfo.getType()) {
-      case ConnectivityManager.TYPE_MOBILE:
-        AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_WWAN);
-        return;
-      case ConnectivityManager.TYPE_WIFI:
-        AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_WLAN);
-        return;
-      default:
-        AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_GENERIC);
-    }}
+    case ConnectivityManager.TYPE_MOBILE:
+      AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_WWAN);
+      return;
+    case ConnectivityManager.TYPE_WIFI:
+      AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_WLAN);
+      return;
+    default:
+      AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_GENERIC);
+    }
+  }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -1,0 +1,95 @@
+package io.envoyproxy.envoymobile.engine;
+
+import android.annotation.TargetApi;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
+import android.net.ConnectivityManager.NetworkCallback;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
+import android.net.NetworkRequest;
+import android.os.Build;
+
+/**
+ * This class makes use of some deprecated APIs, but it's only current purpose is to attempt to distill some notion of a preferred network from the OS, upon which we can assume new sockets will be opened.
+ */
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+public class AndroidNetworkMonitor extends BroadcastReceiver {
+  private static final int ENVOY_NET_GENERIC = 0;
+  private static final int ENVOY_NET_WWAN = 1;
+  private static final int ENVOY_NET_WLAN = 2;
+
+  private static volatile AndroidNetworkMonitor instance = null;
+
+  private ConnectivityManager connectivityManager;
+  private NetworkCallback networkCallback;
+  private NetworkRequest networkRequest;
+
+  public static void load(Context context) {
+    if (instance != null) {
+      return;
+    }
+
+    synchronized (instance) {
+      if (instance != null) {
+        return;
+      }
+      instance = new AndroidNetworkMonitor(context);
+    }
+  }
+
+  private AndroidNetworkMonitor(Context context) {
+    connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+    networkRequest = new NetworkRequest.Builder()
+      .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+      .build();
+
+    networkCallback = new NetworkCallback() {
+      @Override
+      public void onAvailable(Network network) {
+        handleNetworkChange();
+      }
+      @Override
+      public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
+        handleNetworkChange();
+      }
+      @Override
+      public void onLosing(Network network, int maxMsToLive) {
+        handleNetworkChange();
+      }
+      @Override
+      public void onLost(final Network network) {
+        handleNetworkChange();
+      }
+    };
+
+    context.registerReceiver(this, new IntentFilter() {{
+      addAction(ConnectivityManager.CONNECTIVITY_ACTION);
+    }});
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    handleNetworkChange();
+  }
+
+  private void handleNetworkChange() {
+    NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
+    if (networkInfo == null) {
+      AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_GENERIC);
+      return;
+    }
+    switch (networkInfo.getType()) {
+      case ConnectivityManager.TYPE_MOBILE:
+        AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_WWAN);
+        return;
+      case ConnectivityManager.TYPE_WIFI:
+        AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_WLAN);
+        return;
+      default:
+        AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_GENERIC);
+    }}
+}

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -69,6 +69,8 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       }
     };
 
+    connectivityManager.registerNetworkCallback(networkRequest, networkCallback);
+
     context.registerReceiver(this, new IntentFilter() {
       { addAction(ConnectivityManager.CONNECTIVITY_ACTION); }
     });

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -35,7 +35,7 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       return;
     }
 
-    synchronized (instance) {
+    synchronized (AndroidNetworkMonitor.class) {
       if (instance != null) {
         return;
       }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
@@ -7,6 +7,7 @@ envoy_mobile_android_library(
     srcs = [
         "AndroidEngineImpl.java",
         "AndroidJniLibrary.java",
+        "AndroidNetworkMonitor.java",
     ],
     custom_package = "io.envoyproxy.envoymobile.engine",
     manifest = "AndroidEngineManifest.xml",


### PR DESCRIPTION
Description: Adds a platform network monitor to Android to leverage the set_preferred_network interface. This implementation only works on Lollipop and above, and does rely on some methods deprecated in the most recent versions of Android - in order to be compatible with multiple versions and not unnecessarily complicated.
Risk Level: low
Testing: local, CI, and physical device

Signed-off-by: Mike Schore <mike.schore@gmail.com>