### PR TITLE
Work around BoringSSL bitcode linker warning

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,16 @@ http_archive(
     urls = ["https://github.com/abseil/abseil-cpp/archive/61c9bf3e3e1c28a4aa6d7f1be4b37fd473bb5529.tar.gz"],
 )
 
+# This should be kept in sync with Envoy itself, we just need to apply this patch
+# Remove this once https://boringssl-review.googlesource.com/c/boringssl/+/37804 is in master-with-bazel
+http_archive(
+    name = "boringssl",
+    patches = ["//bazel:boringssl.patch"],
+    sha256 = "36049e6cd09b353c83878cae0dd84e8b603ba1a40dcd74e44ebad101fc5c672d",
+    strip_prefix = "boringssl-37b57ed537987f1b4c60c60fa1aba20f3a0f6d26",
+    urls = ["https://github.com/google/boringssl/archive/37b57ed537987f1b4c60c60fa1aba20f3a0f6d26.tar.gz"],
+)
+
 local_repository(
     name = "envoy",
     path = "envoy",

--- a/bazel/boringssl.patch
+++ b/bazel/boringssl.patch
@@ -1,13 +1,15 @@
-diff --git src/include/openssl/base.h src/include/openssl/base.h
-index cb1affaca..ae664d0ac 100644
 --- src/include/openssl/base.h
 +++ src/include/openssl/base.h
-@@ -263,7 +263,7 @@ extern "C" {
+@@ -263,8 +263,12 @@ extern "C" {
  // Add OPENSSL_UNUSED so that, should an inline function be emitted via macro
  // (e.g. a |STACK_OF(T)| implementation) in a source file without tripping
  // clang's -Wunused-function.
--#define OPENSSL_INLINE static inline OPENSSL_UNUSED
++#if defined(__clang__)
 +#define OPENSSL_INLINE __attribute__((weak)) inline OPENSSL_UNUSED
++#else
+ #define OPENSSL_INLINE static inline OPENSSL_UNUSED
  #endif
++#endif
 
  #if defined(BORINGSSL_UNSAFE_FUZZER_MODE) && \
+     !defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE)

--- a/bazel/boringssl.patch
+++ b/bazel/boringssl.patch
@@ -1,15 +1,11 @@
 --- src/include/openssl/base.h
 +++ src/include/openssl/base.h
-@@ -263,8 +263,12 @@ extern "C" {
+@@ -258,7 +258,7 @@ extern "C" {
+ // with the old gnu89 model:
+ // https://stackoverflow.com/questions/216510/extern-inline
+ #if defined(__cplusplus)
+-#define OPENSSL_INLINE inline
++#define OPENSSL_INLINE static inline
+ #else
  // Add OPENSSL_UNUSED so that, should an inline function be emitted via macro
  // (e.g. a |STACK_OF(T)| implementation) in a source file without tripping
- // clang's -Wunused-function.
-+#if defined(__clang__)
-+#define OPENSSL_INLINE __attribute__((weak)) inline OPENSSL_UNUSED
-+#else
- #define OPENSSL_INLINE static inline OPENSSL_UNUSED
- #endif
-+#endif
-
- #if defined(BORINGSSL_UNSAFE_FUZZER_MODE) && \
-     !defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE)

--- a/bazel/boringssl.patch
+++ b/bazel/boringssl.patch
@@ -1,0 +1,13 @@
+diff --git src/include/openssl/base.h src/include/openssl/base.h
+index cb1affaca..ae664d0ac 100644
+--- src/include/openssl/base.h
++++ src/include/openssl/base.h
+@@ -263,7 +263,7 @@ extern "C" {
+ // Add OPENSSL_UNUSED so that, should an inline function be emitted via macro
+ // (e.g. a |STACK_OF(T)| implementation) in a source file without tripping
+ // clang's -Wunused-function.
+-#define OPENSSL_INLINE static inline OPENSSL_UNUSED
++#define OPENSSL_INLINE __attribute__((weak)) inline OPENSSL_UNUSED
+ #endif
+ 
+ #if defined(BORINGSSL_UNSAFE_FUZZER_MODE) && \

--- a/bazel/boringssl.patch
+++ b/bazel/boringssl.patch
@@ -9,5 +9,5 @@ index cb1affaca..ae664d0ac 100644
 -#define OPENSSL_INLINE static inline OPENSSL_UNUSED
 +#define OPENSSL_INLINE __attribute__((weak)) inline OPENSSL_UNUSED
  #endif
- 
+
  #if defined(BORINGSSL_UNSAFE_FUZZER_MODE) && \


### PR DESCRIPTION
When linking envoy-mobile to an iOS app that ships with bitcode, you get
these warnings from the linker:

```
ld: warning: Linker asked to preserve internal global: 'sk_CRYPTO_BUFFER_call_free_func'
ld: warning: Linker asked to preserve internal global: 'sk_X509_call_free_func'
ld: warning: Linker asked to preserve internal global: 'sk_X509_call_free_func'
ld: warning: Linker asked to preserve internal global: 'sk_X509_call_free_func'
ld: warning: Linker asked to preserve internal global: 'sk_X509_call_free_func'
```

I have submitted an upstream patch to fix this
https://boringssl-review.googlesource.com/c/boringssl/+/37804 in the
meantime I've applied that patch here.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>