### PR TITLE
core: change handles to a more suitable type

### DIFF
--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -11,13 +11,13 @@
  * Handle to an Envoy engine instance. Valid only for the lifetime of the engine and not intended
  * for any external interpretation or use.
  */
-typedef uint64_t envoy_engine_t;
+typedef intptr_t envoy_engine_t;
 
 /**
  * Handle to an outstanding Envoy HTTP stream. Valid only for the duration of the stream and not
  * intended for any external interpretation or use.
  */
-typedef uint64_t envoy_stream_t;
+typedef intptr_t envoy_stream_t;
 
 /**
  * Result codes returned by all calls made to this interface.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -68,7 +68,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  @param handle Underlying handle of the HTTP stream owned by an Envoy engine.
  @param callbacks The callbacks for the stream.
  */
-- (instancetype)initWithHandle:(uint64_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks;
+- (instancetype)initWithHandle:(intptr_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks;
 
 /**
  Send headers over the provided stream.

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -171,7 +171,7 @@ static void ios_on_error(envoy_error error, void *context) {
   envoy_stream_t _streamHandle;
 }
 
-- (instancetype)initWithHandle:(uint64_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks {
+- (instancetype)initWithHandle:(intptr_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks {
   self = [super init];
   if (!self) {
     return nil;

--- a/library/swift/test/MockEnvoyHTTPStream.swift
+++ b/library/swift/test/MockEnvoyHTTPStream.swift
@@ -6,7 +6,7 @@ final class MockEnvoyHTTPStream {
   static var onData: ((Data, Bool) -> Void)?
   static var onTrailers: (([String: [String]]) -> Void)?
 
-  init(handle: UInt64, callbacks: EnvoyHTTPCallbacks) {}
+  init(handle: Int, callbacks: EnvoyHTTPCallbacks) {}
 }
 
 extension MockEnvoyHTTPStream: EnvoyHTTPStream {


### PR DESCRIPTION
Description: Better fit for storing opaque memory addresses and/or sentinel values.

Signed-off-by: Mike Schore <mike.schore@gmail.com>
