### PR TITLE
bazel: update release config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,8 +32,6 @@ build:fat --ios_multi_cpus=i386,x86_64,armv7,arm64 --fat_apk_cpu=x86,x86_64,arme
 # TODO: Enable `--copt -ggdb3`. Issues were encountered previously with this:
 # https://github.com/lyft/envoy-mobile/pull/155#issuecomment-507461500
 build:release \
-  --linkopt=-s \
-  --copt=-O2 \
-  --config=fat \
   --apple_bitcode=embedded \
+  --compilation_mode=opt \
   --copt=-fembed-bitcode

--- a/.bazelrc
+++ b/.bazelrc
@@ -29,8 +29,6 @@ build:sim --ios_multi_cpus=i386,x86_64 --fat_apk_cpu=x86,x86_64
 
 build:fat --ios_multi_cpus=i386,x86_64,armv7,arm64 --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a
 
-# TODO: Enable `--copt -ggdb3`. Issues were encountered previously with this:
-# https://github.com/lyft/envoy-mobile/pull/155#issuecomment-507461500
 build:release \
   --apple_bitcode=embedded \
   --compilation_mode=opt \


### PR DESCRIPTION
This changes the release config to use bazel's compilation_mode=opt
which implies the necessary optimization options, and some other things.
This also removes the linkopt that appears to do nothing, and requires
you pass some configuration about architectures separately.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>