### PR TITLE
Revert "bazel: update release config (#479)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,6 +34,5 @@ build:fat --ios_multi_cpus=i386,x86_64,armv7,arm64 --fat_apk_cpu=x86,x86_64,arme
 build:release \
   --linkopt=-s \
   --copt=-O2 \
-  --config=fat \
   --apple_bitcode=embedded \
   --copt=-fembed-bitcode

--- a/.bazelrc
+++ b/.bazelrc
@@ -29,7 +29,11 @@ build:sim --ios_multi_cpus=i386,x86_64 --fat_apk_cpu=x86,x86_64
 
 build:fat --ios_multi_cpus=i386,x86_64,armv7,arm64 --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a
 
+# TODO: Enable `--copt -ggdb3`. Issues were encountered previously with this:
+# https://github.com/lyft/envoy-mobile/pull/155#issuecomment-507461500
 build:release \
+  --linkopt=-s \
+  --copt=-O2 \
+  --config=fat \
   --apple_bitcode=embedded \
-  --compilation_mode=opt \
   --copt=-fembed-bitcode


### PR DESCRIPTION
This reverts commit 2c345529580daf2985dc99823ce6701898f3ca63. We noticed when building with these new release options that builds fail with the following errors:

```
Uncompressed input jar has size 18446744072925756006, which exceeds the maximum supported output size 4294967295.
Assuming that ijar will be smaller and hoping for the best.
Target //:ios_dist failed to build
```

Signed-off-by: Michael Rebello <me@michaelrebello.com>