### PR TITLE
build: update bazelw to print sha on mismatch

### DIFF
--- a/bazelw
+++ b/bazelw
@@ -37,7 +37,8 @@ if [[ ! -x "$bazel_executable" ]]; then
   if echo "$bazel_version_sha  $bazel_executable" | shasum --check --status; then
     chmod +x "$bazel_executable"
   else
-    echo "Bazel installer sha mismatch" >&2
+    echo "Bazel installer sha mismatch:" >&2
+    shasum -a256 $bazel_executable | awk '{print $1;}' >&2
     rm -f "$bazel_executable"
     exit 1
   fi


### PR DESCRIPTION
Description: Just makes it easier to update validation when .bazelversion changes.

Signed-off-by: Mike Schore <mike.schore@gmail.com>