### PR TITLE
objc: use internal type for handle in EnvoyHTTPStreamImpl

### DIFF
--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -171,7 +171,7 @@ static void ios_on_error(envoy_error error, void *context) {
   envoy_stream_t _streamHandle;
 }
 
-- (instancetype)initWithHandle:(intptr_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks {
+- (instancetype)initWithHandle:(envoy_stream_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks {
   self = [super init];
   if (!self) {
     return nil;


### PR DESCRIPTION
Description: Ensure we get a compiler warning if the type declared in the bridge header doesn't match the internal type.

Signed-off-by: Mike Schore <mike.schore@gmail.com>
