### PR TITLE
grpc: close stream with data frame

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyStreamEmitter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyStreamEmitter.kt
@@ -36,12 +36,16 @@ class EnvoyStreamEmitter(
   /**
    * For ending an associated stream and sending trailers.
    *
-   * @param trailers to send with ending a stream. If no trailers are needed, empty map will be the default.
+   * @param trailers to send with ending a stream. If null, stream will be closed with an empty data frame.
    * @throws IllegalStateException when the stream is not active.
    * @throws EnvoyException when there is an exception ending the stream or sending trailers.
    */
-  override fun close(trailers: Map<String, List<String>>) {
-    stream.sendTrailers(trailers)
+  override fun close(trailers: Map<String, List<String>>?) {
+    trailers?.let {
+      stream.sendTrailers(it)
+      return
+    }
+    stream.sendData(ByteBuffer.allocate(0), true)
   }
 
   /**

--- a/library/kotlin/src/io/envoyproxy/envoymobile/StreamEmitter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/StreamEmitter.kt
@@ -44,10 +44,10 @@ interface StreamEmitter : CancelableStream {
   /**
    * For ending an associated stream and sending trailers.
    *
-   * @param trailers to send with ending a stream. If no trailers are needed, empty map will be the default.
+   * @param trailers to send with ending a stream. If null, stream will be closed with an empty data frame.
    * @throws IllegalStateException when the stream is not active.
    * @throws EnvoyException when there is an exception ending the stream or sending trailers.
    */
   @Throws(EnvoyException::class)
-  fun close(trailers: Map<String, List<String>> = emptyMap())
+  fun close(trailers: Map<String, List<String>>?)
 }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -84,7 +84,7 @@ class EnvoyClientTest {
   }
 
   @Test
-  fun `closing stream sends empty trailers to the underlying stream`() {
+  fun `closing stream sends empty data to the underlying stream`() {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
@@ -97,9 +97,9 @@ class EnvoyClientTest {
             .build(),
         ResponseHandler(Executor {}))
 
-    emitter.close()
+    emitter.close(null)
 
-    verify(stream).sendTrailers(emptyMap())
+    verify(stream).sendData(ByteBuffer.allocate(0), true)
   }
 
   @Test

--- a/library/swift/src/EnvoyStreamEmitter.swift
+++ b/library/swift/src/EnvoyStreamEmitter.swift
@@ -21,12 +21,12 @@ extension EnvoyStreamEmitter: StreamEmitter {
     return self
   }
 
-  func close(trailers: [String: [String]]) {
-    self.stream.sendTrailers(trailers)
-  }
-
-  func closeWithData(_ data: Data) {
-    self.stream.send(data, close: true)
+  func close(trailers: [String: [String]]?) {
+    if let trailers = trailers {
+      self.stream.sendTrailers(trailers)
+    } else {
+      self.stream.send(Data(), close: true)
+    }
   }
 
   func cancel() {

--- a/library/swift/src/EnvoyStreamEmitter.swift
+++ b/library/swift/src/EnvoyStreamEmitter.swift
@@ -25,6 +25,10 @@ extension EnvoyStreamEmitter: StreamEmitter {
     self.stream.sendTrailers(trailers)
   }
 
+  func closeWithData(_ data: Data) {
+    self.stream.send(data, close: true)
+  }
+
   func cancel() {
     _ = self.stream.cancel()
   }

--- a/library/swift/src/GRPCStreamEmitter.swift
+++ b/library/swift/src/GRPCStreamEmitter.swift
@@ -46,6 +46,6 @@ public final class GRPCStreamEmitter: NSObject {
   public func close(_ data: Data) {
     // The gRPC protocol requires the client stream to close with a DATA frame.
     // More information here: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
-    self.underlyingEmitter.closeWithData(data)
+    self.underlyingEmitter.close()
   }
 }

--- a/library/swift/src/GRPCStreamEmitter.swift
+++ b/library/swift/src/GRPCStreamEmitter.swift
@@ -45,7 +45,8 @@ public final class GRPCStreamEmitter: NSObject {
   /// Close this connection.
   public func close() {
     // The gRPC protocol requires the client stream to close with a DATA frame.
-    // More information here: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
-    self.underlyingEmitter.close()
+    // More information here:
+    // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
+    self.underlyingEmitter.close(trailers: nil)
   }
 }

--- a/library/swift/src/GRPCStreamEmitter.swift
+++ b/library/swift/src/GRPCStreamEmitter.swift
@@ -43,7 +43,9 @@ public final class GRPCStreamEmitter: NSObject {
   }
 
   /// Close this connection.
-  public func close() {
-    self.underlyingEmitter.close()
+  public func close(_ data: Data) {
+    // The gRPC protocol requires the client stream to close with a DATA frame.
+    // More information here: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
+    self.underlyingEmitter.closeWithData(data)
   }
 }

--- a/library/swift/src/GRPCStreamEmitter.swift
+++ b/library/swift/src/GRPCStreamEmitter.swift
@@ -43,7 +43,7 @@ public final class GRPCStreamEmitter: NSObject {
   }
 
   /// Close this connection.
-  public func close(_ data: Data) {
+  public func close() {
     // The gRPC protocol requires the client stream to close with a DATA frame.
     // More information here: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
     self.underlyingEmitter.close()

--- a/library/swift/src/StreamEmitter.swift
+++ b/library/swift/src/StreamEmitter.swift
@@ -32,10 +32,3 @@ public protocol StreamEmitter: CancelableStream {
   ///                       Otherwise, the stream is closed with an empty data frame.
   func close(trailers: [String: [String]]?)
 }
-
-extension StreamEmitter {
-  /// Convenience function for ending the stream without sending any trailers.
-  public func close() {
-    self.close(trailers: [:])
-  }
-}

--- a/library/swift/src/StreamEmitter.swift
+++ b/library/swift/src/StreamEmitter.swift
@@ -26,15 +26,11 @@ public protocol StreamEmitter: CancelableStream {
   @discardableResult
   func sendMetadata(_ metadata: [String: [String]]) -> StreamEmitter
 
-  /// End the stream after sending any provided trailers.
+  /// End the stream.
   ///
-  /// - parameter trailers: Trailers to send over the stream.
-  func close(trailers: [String: [String]])
-
-  /// End the stream with one last data frame.
-  ///
-  /// - parameter data: Data to send over the stream.
-  func closeWithData(_ data: Data)
+  /// - parameter trailers: optional trailers to send over the stream.
+  ///                       Otherwise, the stream is closed with an empty data frame.
+  func close(trailers: [String: [String]]?)
 }
 
 extension StreamEmitter {

--- a/library/swift/src/StreamEmitter.swift
+++ b/library/swift/src/StreamEmitter.swift
@@ -28,7 +28,7 @@ public protocol StreamEmitter: CancelableStream {
 
   /// End the stream.
   ///
-  /// - parameter trailers: optional trailers to send over the stream.
-  ///                       Otherwise, the stream is closed with an empty data frame.
+  /// - parameter trailers: Trailers with which to close the stream.
+  //                        If nil, stream will be closed with an empty data frame.
   func close(trailers: [String: [String]]?)
 }

--- a/library/swift/src/StreamEmitter.swift
+++ b/library/swift/src/StreamEmitter.swift
@@ -30,6 +30,11 @@ public protocol StreamEmitter: CancelableStream {
   ///
   /// - parameter trailers: Trailers to send over the stream.
   func close(trailers: [String: [String]])
+
+  /// End the stream with one last data frame.
+  ///
+  /// - parameter data: Data to send over the stream.
+  func closeWithData(_ data: Data)
 }
 
 extension StreamEmitter {

--- a/library/swift/test/GRPCStreamEmitterTests.swift
+++ b/library/swift/test/GRPCStreamEmitterTests.swift
@@ -20,7 +20,7 @@ private final class MockEmitter: StreamEmitter {
     return self
   }
 
-  func close(trailers: [String: [String]]) {}
+  func close(trailers: [String: [String]]?) {}
   func cancel() {}
 }
 


### PR DESCRIPTION
Description: the gRPC protocol requires closing the client stream in a DATA frame. This PR fixes the GRPCStreamEmitter for iOS.
Risk Level: med - protocol level changes.
Testing: local.

Signed-off-by: Jose Nino <jnino@lyft.com>