### PR TITLE
kotlin: fix no-oped tests in ResponseHandlerTest

### DIFF
--- a/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHandlerTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHandlerTest.kt
@@ -2,34 +2,50 @@ package io.envoyproxy.envoymobile
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit
 
 class ResponseHandlerTest {
-  @Test
+  @Test(timeout = 100L)
   fun `parsing status code from headers returns first status code`() {
+    val countDownLatch = CountDownLatch(1)
     val headers = mapOf(":status" to listOf("204", "200"), "other" to listOf("1"))
     val responseHandler = ResponseHandler(Executor {})
-    responseHandler.underlyingCallbacks.onHeaders(headers, false)
 
-    responseHandler.onHeaders { _, statusCode, _ -> assertThat(statusCode).isEqualTo(204) }
+    responseHandler.onHeaders { _, statusCode, _ ->
+      assertThat(statusCode).isEqualTo(204)
+      countDownLatch.countDown()
+    }
+    responseHandler.underlyingCallbacks.onHeaders(headers, false)
+    countDownLatch.await(1L, TimeUnit.SECONDS)
   }
 
-  @Test
+  @Test(timeout = 100L)
   fun `parsing invalid status code from headers returns 0`() {
+    val countDownLatch = CountDownLatch(1)
     val headers = mapOf(":status" to listOf("invalid"), "other" to listOf("1"))
     val responseHandler = ResponseHandler(Executor {})
+
+    responseHandler.onHeaders { _, statusCode, _ ->
+      assertThat(statusCode).isEqualTo(0)
+      countDownLatch.countDown()
+    }
     responseHandler.underlyingCallbacks.onHeaders(headers, false)
-
-    responseHandler.onHeaders { _, statusCode, _ -> assertThat(statusCode).isEqualTo(0) }
-
+    countDownLatch.await(1L, TimeUnit.SECONDS)
   }
 
-  @Test
+  @Test(timeout = 100L)
   fun `parsing missing status code from headers returns 0`() {
+    val countDownLatch = CountDownLatch(1)
     val headers = mapOf("other" to listOf("1"))
-    val responseHandler = ResponseHandler(Executor {})
-    responseHandler.underlyingCallbacks.onHeaders(headers, false)
+    val responseHandler = ResponseHandler(Executor { })
 
-    responseHandler.onHeaders { _, statusCode, _ -> assertThat(statusCode).isEqualTo(0) }
+    responseHandler.onHeaders { _, statusCode, _ ->
+      assertThat(statusCode).isEqualTo(0)
+      countDownLatch.countDown()
+    }
+    responseHandler.underlyingCallbacks.onHeaders(headers, false)
+    countDownLatch.await(1L, TimeUnit.SECONDS)
   }
 }


### PR DESCRIPTION
Adding countdown latch for ensuring we have asserted the response callback data

Signed-off-by: Alan Chiu <achiu@lyft.com>

Description: kotlin: fix no-oped tests in ResponseHandlerTest
Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
