### PR TITLE
android: wire up on trailers

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -43,6 +43,14 @@ class JvmCallbackContext {
   }
 
   /**
+   * Initializes state for accumulating trailer pairs via passHeaders, ultimately
+   * to be dispatched via the callback.
+   *
+   * @param length, the total number of trailers included in this header block.
+   */
+  public void onTrailers(long length) { startAccumulation(FrameType.TRAILERS, length, true); }
+
+  /**
    * Allows pairs of strings to be passed across the JVM, reducing overall calls
    * (at the expense of some complexity).
    *


### PR DESCRIPTION
Description: this PR wires up on trailers callback for android, which was previously missing.
Risk Level: low - using already battled tested code paths for accumulating headers.
Testing: pending testing with gRPC on the Lyft android app

Fixes #506 

Signed-off-by: Jose Nino <jnino@lyft.com>