### PR TITLE
kotlin: clear error closure after compression error

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/GRPCResponseHandler.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/GRPCResponseHandler.kt
@@ -27,8 +27,8 @@ class GRPCResponseHandler(
   }
 
   internal val underlyingHandler: ResponseHandler = ResponseHandler(executor)
-
   private var errorClosure: (error: EnvoyError) -> Unit = { }
+
   /**
    * Specify a callback for when response headers are received by the stream.
    *
@@ -128,6 +128,7 @@ class GRPCResponseHandler(
                   "Unable to read compressed gRPC response message"))
 
           // no op the current onData and clean up
+          errorClosure = { }
           underlyingHandler.onHeaders { _, _, _ -> }
           underlyingHandler.onData { _, _ -> }
           underlyingHandler.onTrailers { }


### PR DESCRIPTION
In the case where the client receives an unsupported compressed message, the `errorClosure` should be cleared out with the other handlers after being called once. This will prevent it from being called again if multiple compressed messages are received, which is the intended behavior as `onError` should be considered a terminal state.

Signed-off-by: Michael Rebello <me@michaelrebello.com>