### PR TITLE
ci: update artifact to only run for common/java/kotlin

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - master
     paths:
-      - 'library/**'
+      - 'library/common/**'
+      - 'library/java/**'
+      - 'library/kotlin/**'
       - 'envoy/**'
 
 jobs:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -22,7 +22,7 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
       - name: 'Build envoy_master.aar distributable'
-        run: ./bazelw build --config=release --config=fat //:android_dist
+        run: ./bazelw build --config=release --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_dist
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_master.aar


### PR DESCRIPTION
Signed-off-by: Alan Chiu <achiu@lyft.com>

Description: ci: update artifact to only run for common/java/kotlin
Risk Level: low
Testing: on master
Docs Changes: n/a
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
