### PR TITLE
swift: add support for total upstream timeouts

### DIFF
--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -31,18 +31,29 @@ public enum RetryRule: Int, CaseIterable {
 /// https://www.envoyproxy.io/learn/automatic-retries
 @objcMembers
 public final class RetryPolicy: NSObject {
-  /// Maximum number of retries that a request may be performed.
   public let maxRetryCount: UInt
-  /// Whitelist of rules used for retrying.
   public let retryOn: [RetryRule]
-  /// Timeout (in milliseconds) to apply to each retry.
   public let perRetryTimeoutMS: UInt?
+  public let totalUpstreamTimeoutMS: UInt
 
-  /// Public initializer.
-  public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutMS: UInt? = nil) {
+  /// Designated initializer.
+  ///
+  /// - parameter maxRetryCount:          Maximum number of retries that a request may be
+  ///                                     performed.
+  /// - parameter retryOn:                Whitelist of rules used for retrying.
+  /// - parameter perRetryTimeoutMS:      Timeout (in milliseconds) to apply to each retry. Must
+  ///                                     be <= `totalUpstreamTimeoutMS` or it will be ignored.
+  /// - parameter totalUpstreamTimeoutMS: Total timeout (in milliseconds) that includes all
+  ///                                     retries. Spans the point at which the entire downstream
+  ///                                     request has been processed and when the upstream
+  ///                                     response has been completely processed.
+  public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutMS: UInt? = nil,
+              totalUpstreamTimeoutMS: UInt = 15_000)
+  {
     self.maxRetryCount = maxRetryCount
     self.retryOn = retryOn
     self.perRetryTimeoutMS = perRetryTimeoutMS
+    self.totalUpstreamTimeoutMS = totalUpstreamTimeoutMS
   }
 }
 

--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -50,6 +50,11 @@ public final class RetryPolicy: NSObject {
   public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutMS: UInt? = nil,
               totalUpstreamTimeoutMS: UInt = 15_000)
   {
+    if let perRetryTimeoutMS = perRetryTimeoutMS {
+      assert(perRetryTimeoutMS <= totalUpstreamTimeoutMS,
+             "Per-retry timeout must be <= total timeout")
+    }
+
     self.maxRetryCount = maxRetryCount
     self.retryOn = retryOn
     self.perRetryTimeoutMS = perRetryTimeoutMS

--- a/library/swift/src/RetryPolicyMapper.swift
+++ b/library/swift/src/RetryPolicyMapper.swift
@@ -8,6 +8,7 @@ extension RetryPolicy {
       "x-envoy-retry-on": self.retryOn
         .lazy
         .map { $0.stringValue },
+      "x-envoy-upstream-rq-timeout-ms": ["\(self.totalUpstreamTimeoutMS)"],
     ]
 
     if let perRetryTimeoutMS = self.perRetryTimeoutMS {

--- a/library/swift/test/RetryPolicyMapperTests.swift
+++ b/library/swift/test/RetryPolicyMapperTests.swift
@@ -3,30 +3,24 @@ import XCTest
 
 final class RetryPolicyMapperTests: XCTestCase {
   func testConvertingToHeadersWithPerRetryTimeoutIncludesAllHeaders() {
-    let policy = RetryPolicy(maxRetryCount: 123,
+    let policy = RetryPolicy(maxRetryCount: 3,
                              retryOn: RetryRule.allCases,
-                             perRetryTimeoutMS: 9001)
+                             perRetryTimeoutMS: 15_000,
+                             totalUpstreamTimeoutMS: 60_000)
     let expectedHeaders = [
-      "x-envoy-max-retries": ["123"],
+      "x-envoy-max-retries": ["3"],
       "x-envoy-retry-on": [
         "5xx", "gateway-error", "connect-failure", "retriable-4xx", "refused-upstream",
       ],
-      "x-envoy-upstream-rq-per-try-timeout-ms": ["9001"],
+      "x-envoy-upstream-rq-per-try-timeout-ms": ["15000"],
+      "x-envoy-upstream-rq-timeout-ms": ["60000"],
     ]
 
     XCTAssertEqual(expectedHeaders, policy.outboundHeaders())
   }
 
   func testConvertingToHeadersWithoutRetryTimeoutExcludesPerRetryTimeoutHeader() {
-    let policy = RetryPolicy(maxRetryCount: 123,
-                             retryOn: RetryRule.allCases)
-    let expectedHeaders = [
-      "x-envoy-max-retries": ["123"],
-      "x-envoy-retry-on": [
-        "5xx", "gateway-error", "connect-failure", "retriable-4xx", "refused-upstream",
-      ],
-    ]
-
-    XCTAssertEqual(expectedHeaders, policy.outboundHeaders())
+    let policy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases)
+    XCTAssertNil(policy.outboundHeaders()["x-envoy-upstream-rq-per-try-timeout-ms"])
   }
 }


### PR DESCRIPTION
When users set a timeout via `perRetryTimeoutMS`, they silently get limited to 15 seconds due to the fact that Envoy assigns a [default timeout of 15 seconds](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-timeout). We should expose this through our `RetryPolicy` to allow consumers to override it using the already-supported `x-envoy-upstream-rq-timeout-ms` header.

Related Kotlin PR: https://github.com/lyft/envoy-mobile/pull/519

Details on retry semantics: [Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_routing.html?highlight=exponential#retry-semantics)

Signed-off-by: Michael Rebello <me@michaelrebello.com>