### PR TITLE
kotlin: add support for total upstream timeouts

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
@@ -4,9 +4,9 @@ package io.envoyproxy.envoymobile
  * Specifies how a request may be retried, containing one or more rules.
  *
  * @param maxRetryCount Maximum number of retries that a request may be performed.
- * @param retryOn Whitelist of rules used for retrying. Must be <= `totalUpstreamTimeoutMS`
- * or it will be ignored.
+ * @param retryOn Whitelist of rules used for retrying.
  * @param perRetryTimeoutMs Timeout (in milliseconds) to apply to each retry.
+ * Must be <= `totalUpstreamTimeoutMS`.
  * @param totalUpstreamTimeoutMS Total timeout (in milliseconds) that includes all retries.
  * Spans the point at which the entire downstream request has been processed and when the
  * upstream response has been completely processed.
@@ -16,7 +16,13 @@ data class RetryPolicy(
   val retryOn: List<RetryRule>,
   val perRetryTimeoutMs: Long? = null,
   val totalUpstreamTimeoutMS: Long = 15000
-)
+) {
+  init {
+    if (perRetryTimeoutMs != null && perRetryTimeoutMs > totalUpstreamTimeoutMS) {
+      throw IllegalArgumentException("Per-retry timeout must be <= total timeout")
+    }
+  }
+}
 
 /**
  * These are retry rules specified in Envoy's router filter.

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
@@ -4,13 +4,18 @@ package io.envoyproxy.envoymobile
  * Specifies how a request may be retried, containing one or more rules.
  *
  * @param maxRetryCount Maximum number of retries that a request may be performed.
- * @param retryOn Whitelist of rules used for retrying.
+ * @param retryOn Whitelist of rules used for retrying. Must be <= `totalUpstreamTimeoutMS`
+ * or it will be ignored.
  * @param perRetryTimeoutMs Timeout (in milliseconds) to apply to each retry.
+ * @param totalUpstreamTimeoutMS Total timeout (in milliseconds) that includes all retries.
+ * Spans the point at which the entire downstream request has been processed and when the
+ * upstream response has been completely processed.
  */
 data class RetryPolicy(
   val maxRetryCount: Int,
   val retryOn: List<RetryRule>,
-  val perRetryTimeoutMs: Long? = null
+  val perRetryTimeoutMs: Long? = null,
+  val totalUpstreamTimeoutMS: Long = 15000
 )
 
 /**

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicyMapper.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicyMapper.kt
@@ -9,7 +9,8 @@ internal fun RetryPolicy.outboundHeaders(): Map<String, List<String>> {
 
   val headers = mutableMapOf(
       "x-envoy-max-retries" to listOf("$maxRetryCount"),
-      "x-envoy-retry-on" to retryOn.map { elm -> elm.stringValue() }
+      "x-envoy-retry-on" to retryOn.map { elm -> elm.stringValue() },
+      "x-envoy-upstream-rq-timeout-ms" to listOf("$totalUpstreamTimeoutMS")
   )
 
   if (perRetryTimeoutMs != null) {

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -8,19 +8,21 @@ class RetryPolicyMapperTest {
   @Test
   fun `all retry policy properties should all be encoded`() {
     val retryPolicy = RetryPolicy(
-        maxRetryCount = 123,
+        maxRetryCount = 3,
         retryOn = listOf(
             RetryRule.STATUS_5XX,
             RetryRule.GATEWAY_ERROR,
             RetryRule.CONNECT_FAILURE,
             RetryRule.RETRIABLE_4XX,
             RetryRule.REFUSED_UPSTREAM),
-        perRetryTimeoutMs = 9001)
+        perRetryTimeoutMs = 15000,
+        totalUpstreamTimeoutMS = 60000)
 
     assertThat(retryPolicy.outboundHeaders()).isEqualTo(mapOf(
-        "x-envoy-max-retries" to listOf("123"),
+        "x-envoy-max-retries" to listOf("3"),
         "x-envoy-retry-on" to listOf("5xx", "gateway-error", "connect-failure", "retriable-4xx", "refused-upstream"),
-        "x-envoy-upstream-rq-per-try-timeout-ms" to listOf("9001")
+        "x-envoy-upstream-rq-per-try-timeout-ms" to listOf("15000"),
+        "x-envoy-upstream-rq-timeout-ms" to listOf("60000")
     ))
   }
 

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -39,4 +39,13 @@ class RetryPolicyMapperTest {
 
     assertThat(retryPolicy.outboundHeaders()).doesNotContainKey("x-envoy-upstream-rq-per-try-timeout-ms")
   }
+
+  @Test(expected=IllegalArgumentException::class)
+  fun `throws error when per-retry timeout is larger than total timeout`() {
+    val retryPolicy = RetryPolicy(
+        maxRetryCount = 3,
+        retryOn = listOf(RetryRule.STATUS_5XX),
+        perRetryTimeoutMs = 2,
+        totalUpstreamTimeoutMS = 1)
+  }
 }


### PR DESCRIPTION
When users set a timeout via `perRetryTimeoutMS`, they silently get limited to 15 seconds due to the fact that Envoy assigns a [default timeout of 15 seconds](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-timeout). We should expose this through our `RetryPolicy` to allow consumers to override it using the already-supported `x-envoy-upstream-rq-timeout-ms` header.

Related Swift PR: https://github.com/lyft/envoy-mobile/pull/518

Details on retry semantics: [Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_routing.html?highlight=exponential#retry-semantics)

Signed-off-by: Michael Rebello <me@michaelrebello.com>