### PR TITLE
ios: only buffer when requests support retries

### DIFF
--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -67,8 +67,12 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
  @param handle Underlying handle of the HTTP stream owned by an Envoy engine.
  @param callbacks The callbacks for the stream.
+ @param bufferForRetry Whether this stream should be buffered to support future retries. Must be
+ true for requests that support retrying.
  */
-- (instancetype)initWithHandle:(intptr_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks;
+- (instancetype)initWithHandle:(intptr_t)handle
+                     callbacks:(EnvoyHTTPCallbacks *)callbacks
+                bufferForRetry:(BOOL)bufferForRetry;
 
 /**
  Send headers over the provided stream.
@@ -177,8 +181,11 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  Opens a new HTTP stream attached to this engine.
 
  @param callbacks Handler for observing stream events.
+ @param bufferForRetry Whether this stream should be buffered to support future retries. Must be
+ true for requests that support retrying.
  */
-- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks;
+- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks
+                                 bufferForRetry:(BOOL)bufferForRetry;
 
 @end
 

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -47,9 +47,11 @@ static void ios_on_exit() {
   }
 }
 
-- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks {
+- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks
+                                 bufferForRetry:(BOOL)bufferForRetry {
   return [[EnvoyHTTPStreamImpl alloc] initWithHandle:init_stream(_engineHandle)
-                                           callbacks:callbacks];
+                                           callbacks:callbacks
+                                      bufferForRetry:bufferForRetry];
 }
 
 @end

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -171,7 +171,9 @@ static void ios_on_error(envoy_error error, void *context) {
   envoy_stream_t _streamHandle;
 }
 
-- (instancetype)initWithHandle:(envoy_stream_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks {
+- (instancetype)initWithHandle:(envoy_stream_t)handle
+                     callbacks:(EnvoyHTTPCallbacks *)callbacks
+                bufferForRetry:(BOOL)bufferForRetry {
   self = [super init];
   if (!self) {
     return nil;
@@ -197,7 +199,7 @@ static void ios_on_error(envoy_error error, void *context) {
   // start_stream could result in a reset that would release the native ref.
   // TODO: To be truly safe we probably need stronger guarantees of operation ordering on this ref
   _strongSelf = self;
-  envoy_stream_options stream_options;
+  envoy_stream_options stream_options = {bufferForRetry};
   envoy_status_t result = start_stream(_streamHandle, native_callbacks, stream_options);
   if (result != ENVOY_SUCCESS) {
     _strongSelf = nil;

--- a/library/swift/src/EnvoyClient.swift
+++ b/library/swift/src/EnvoyClient.swift
@@ -69,7 +69,8 @@ public final class EnvoyClient: NSObject {
 
 extension EnvoyClient: HTTPClient {
   public func send(_ request: Request, handler: ResponseHandler) -> StreamEmitter {
-    let httpStream = self.engine.startStream(with: handler.underlyingCallbacks)
+    let httpStream = self.engine.startStream(
+      with: handler.underlyingCallbacks, bufferForRetry: request.retryPolicy != nil)
     httpStream.sendHeaders(request.outboundHeaders(), close: false)
     return EnvoyStreamEmitter(stream: httpStream)
   }

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -25,8 +25,11 @@ private final class MockEnvoyEngine: NSObject, EnvoyEngine {
     return 0
   }
 
-  func startStream(with callbacks: EnvoyHTTPCallbacks) -> EnvoyHTTPStream {
-    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
+  func startStream(with callbacks: EnvoyHTTPCallbacks, bufferForRetry: Bool)
+    -> EnvoyHTTPStream
+  {
+    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks,
+                               bufferForRetry: bufferForRetry)
   }
 }
 

--- a/library/swift/test/EnvoyClientTests.swift
+++ b/library/swift/test/EnvoyClientTests.swift
@@ -11,17 +11,18 @@ private final class MockEnvoyEngine: EnvoyEngine {
     return 0
   }
 
-  func startStream(with callbacks: EnvoyHTTPCallbacks) -> EnvoyHTTPStream {
-    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
+  func startStream(with callbacks: EnvoyHTTPCallbacks, bufferForRetry: Bool)
+    -> EnvoyHTTPStream
+  {
+    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks,
+                               bufferForRetry: bufferForRetry)
   }
 }
 
 final class EnvoyClientTests: XCTestCase {
   override func tearDown() {
     super.tearDown()
-    MockEnvoyHTTPStream.onHeaders = nil
-    MockEnvoyHTTPStream.onData = nil
-    MockEnvoyHTTPStream.onTrailers = nil
+    MockEnvoyHTTPStream.reset()
   }
 
   func testNonStreamingExtensionSendsRequestDetailsThroughStream() throws {
@@ -59,5 +60,30 @@ final class EnvoyClientTests: XCTestCase {
                handler: ResponseHandler())
     self.wait(for: [requestExpectation, dataExpectation, closeExpectation],
               timeout: 0.1, enforceOrder: true)
+  }
+
+  func testBuffersForRetriesWhenRetryPolicyIsSet() throws {
+    let request = RequestBuilder(
+      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
+      .addRetryPolicy(RetryPolicy(maxRetryCount: 3, retryOn: RetryRule.allCases))
+      .build()
+    let envoy = try EnvoyClientBuilder(domain: "api.foo.com")
+      .addEngineType(MockEnvoyEngine.self)
+      .build()
+    envoy.send(request, body: Data(), trailers: [:], handler: ResponseHandler())
+
+    XCTAssertEqual(true, MockEnvoyHTTPStream.bufferForRetry)
+  }
+
+  func testDoesNotBufferForRetriesWhenRetryPolicyIsNil() throws {
+    let request = RequestBuilder(
+      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
+      .build()
+    let envoy = try EnvoyClientBuilder(domain: "api.foo.com")
+      .addEngineType(MockEnvoyEngine.self)
+      .build()
+    envoy.send(request, body: Data(), trailers: [:], handler: ResponseHandler())
+
+    XCTAssertEqual(false, MockEnvoyHTTPStream.bufferForRetry)
   }
 }

--- a/library/swift/test/MockEnvoyHTTPStream.swift
+++ b/library/swift/test/MockEnvoyHTTPStream.swift
@@ -11,7 +11,7 @@ final class MockEnvoyHTTPStream {
     MockEnvoyHTTPStream.bufferForRetry = bufferForRetry
   }
 
-  /// Reset the current state of the stream. Should be called inbetween tests.
+  /// Reset the current state of the stream. Should be called between tests.
   static func reset() {
     self.onHeaders = nil
     self.onData = nil

--- a/library/swift/test/MockEnvoyHTTPStream.swift
+++ b/library/swift/test/MockEnvoyHTTPStream.swift
@@ -5,8 +5,19 @@ final class MockEnvoyHTTPStream {
   static var onHeaders: (([String: [String]], Bool) -> Void)?
   static var onData: ((Data, Bool) -> Void)?
   static var onTrailers: (([String: [String]]) -> Void)?
+  private(set) static var bufferForRetry: Bool?
 
-  init(handle: Int, callbacks: EnvoyHTTPCallbacks) {}
+  init(handle: Int, callbacks: EnvoyHTTPCallbacks, bufferForRetry: Bool) {
+    MockEnvoyHTTPStream.bufferForRetry = bufferForRetry
+  }
+
+  /// Reset the current state of the stream. Should be called inbetween tests.
+  static func reset() {
+    self.onHeaders = nil
+    self.onData = nil
+    self.onTrailers = nil
+    self.bufferForRetry = nil
+  }
 }
 
 extension MockEnvoyHTTPStream: EnvoyHTTPStream {


### PR DESCRIPTION
Updates to utilize the options exposed in https://github.com/lyft/envoy-mobile/pull/520 to prevent unnecessarily buffering requests that will never be retried. This can be especially useful for preventing buffering of long-lived [gRPC] streams, for example.

We discussed having a full fledged platform level struct to parallel `envoy_stream_options`, but decided that while we only expose one option we can leave the API as a boolean argument.

Matching Android functionality is being tracked here: https://github.com/lyft/envoy-mobile/issues/524.

Signed-off-by: Michael Rebello <me@michaelrebello.com>