### PR TITLE
ios: update RetryPolicy Equatable conformance

### DIFF
--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -72,7 +72,7 @@ extension RetryPolicy {
 
     return self.maxRetryCount == other.maxRetryCount
       && self.retryOn == other.retryOn
-      && self.perRetryTimeoutMS == other.perRetryTimeoutMS &&
+      && self.perRetryTimeoutMS == other.perRetryTimeoutMS
       && self.totalUpstreamTimeoutMS == other.totalUpstreamTimeoutMS
   }
 }

--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -72,6 +72,7 @@ extension RetryPolicy {
 
     return self.maxRetryCount == other.maxRetryCount
       && self.retryOn == other.retryOn
-      && self.perRetryTimeoutMS == other.perRetryTimeoutMS
+      && self.perRetryTimeoutMS == other.perRetryTimeoutMS &&
+      && self.totalUpstreamTimeoutMS == other.totalUpstreamTimeoutMS
   }
 }


### PR DESCRIPTION
Was missing a new property.

Signed-off-by: Michael Rebello <me@michaelrebello.com>
