### PR TITLE
ci: update to 90m for aar master generation

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -14,7 +14,7 @@ jobs:
   master_aar_dist:
     name: master_aar_dist
     runs-on: macOS-10.14
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -14,7 +14,7 @@ jobs:
   master_aar_dist:
     name: master_aar_dist
     runs-on: macOS-10.14
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
@@ -6,7 +6,7 @@ package io.envoyproxy.envoymobile
  * @param maxRetryCount Maximum number of retries that a request may be performed.
  * @param retryOn Whitelist of rules used for retrying.
  * @param perRetryTimeoutMS Timeout (in milliseconds) to apply to each retry.
- * Must be <= `totalUpstreamTimeoutMS`.
+ *                          Must be <= `totalUpstreamTimeoutMS`.
  * @param totalUpstreamTimeoutMS Total timeout (in milliseconds) that includes all retries.
  * Spans the point at which the entire downstream request has been processed and when the
  * upstream response has been completely processed.


### PR DESCRIPTION
These builds are taking longer than the original 45minutes since we are building multiple architectures on a release configuration

We're going to make it 90minutes and see if it works

Signed-off-by: Alan Chiu <achiu@lyft.com>

Description: ci: update to 90m for aar master generation
Risk Level: low
Testing: on master
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
