### PR TITLE
core: fix server early capture

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -64,8 +64,8 @@ envoy_status_t Engine::run(std::string config, std::string log_level) {
     // as we did previously).
     postinit_callback_handler_ = main_common_->server()->lifecycleNotifier().registerCallback(
         Envoy::Server::ServerLifecycleNotifier::Stage::PostInit, [this]() -> void {
-          http_dispatcher_->ready(TS_UNCHECKED_READ(main_common_)->server()->dispatcher(),
-                                  TS_UNCHECKED_READ(main_common_)->server()->clusterManager());
+          Server::Instance* server = TS_UNCHECKED_READ(main_common_)->server();
+          http_dispatcher_->ready(server->dispatcher(), server->clusterManager());
         });
   } // mutex_
 

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -62,10 +62,10 @@ envoy_status_t Engine::run(std::string config, std::string log_level) {
     // When we improve synchronous failure handling and/or move to dynamic forwarding, we only need
     // to wait until the dispatcher is running (and can drain by enqueueing a drain callback on it,
     // as we did previously).
-    auto server = main_common_->server();
     postinit_callback_handler_ = main_common_->server()->lifecycleNotifier().registerCallback(
-        Envoy::Server::ServerLifecycleNotifier::Stage::PostInit, [this, server]() -> void {
-          http_dispatcher_->ready(server->dispatcher(), server->clusterManager());
+        Envoy::Server::ServerLifecycleNotifier::Stage::PostInit, [this]() -> void {
+          http_dispatcher_->ready(TS_UNCHECKED_READ(main_common_)->server()->dispatcher(),
+                                  TS_UNCHECKED_READ(main_common_)->server()->clusterManager());
         });
   } // mutex_
 


### PR DESCRIPTION
Description: when the server pointer was moved from being captured in the post init callback to outside of it https://github.com/lyft/envoy-mobile/pull/498/files#diff-b5c0c85b8d3df6960fe582b70fe1c122L112 to https://github.com/lyft/envoy-mobile/pull/498/files#diff-79839c4e6bee0a2fa78e0f8215db7433R64 we introduced the possibility that the captured pointer pointer to an invalid memory address. This PR returns the server capture to inside the callback.
Risk Level: med - moving pointer captures from synchronous to inside the event loop

Signed-off-by: Jose Nino <jnino@lyft.com>
