### PR TITLE
grpc: support chaining emitters

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/GRPCStreamEmitter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/GRPCStreamEmitter.kt
@@ -3,7 +3,6 @@ package io.envoyproxy.envoymobile
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
-
 class GRPCStreamEmitter(
     private val emitter: StreamEmitter
 ) {
@@ -11,8 +10,9 @@ class GRPCStreamEmitter(
    * Send a protobuf messageData's binary data over the gRPC stream.
    *
    * @param messageData Binary data of a protobuf messageData to send.
+   * @return GRPCStreamEmitter, this stream emitter.
    */
-  fun sendMessage(messageData: ByteBuffer) {
+  fun sendMessage(messageData: ByteBuffer): GRPCStreamEmitter {
     // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
     // Length-Prefixed-Message = Compressed-Flag | Message-Length | Message
     // Compressed-Flag = 0 / 1, encoded as 1 byte unsigned integer
@@ -30,6 +30,7 @@ class GRPCStreamEmitter(
 
     emitter.sendData(byteBuffer)
     emitter.sendData(messageData)
+    return this
   }
 
   /**

--- a/library/kotlin/test/io/envoyproxy/envoymobile/GRPCStreamEmitterTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/GRPCStreamEmitterTest.kt
@@ -48,44 +48,40 @@ class GRPCStreamEmitterTest {
 
   @Test
   fun `prefix and data is sent on send data`() {
-    val grpcStreamEmitter = GRPCStreamEmitter(emitter)
-
     val payload = "data".toByteArray(Charsets.UTF_8)
     val message = ByteBuffer.wrap(payload)
-    grpcStreamEmitter.sendMessage(message)
+    GRPCStreamEmitter(emitter)
+      .sendMessage(message)
 
     assertThat(dataOutputStream.toByteArray()).hasSize(payload.size + GRPC_PREFIX_LENGTH)
   }
 
   @Test
   fun `compression flag is set on the first bit of the prefix`() {
-    val grpcStreamEmitter = GRPCStreamEmitter(emitter)
-
     val payload = "data".toByteArray(Charsets.UTF_8)
     val message = ByteBuffer.wrap(payload)
-    grpcStreamEmitter.sendMessage(message)
+    GRPCStreamEmitter(emitter)
+      .sendMessage(message)
 
     assertThat(dataOutputStream.toByteArray()[0]).isEqualTo(0)
   }
 
   @Test
   fun `message length is set on the 1-4 bytes of the prefix`() {
-    val grpcStreamEmitter = GRPCStreamEmitter(emitter)
-
     val payload = "data".toByteArray(Charsets.UTF_8)
     val message = ByteBuffer.wrap(payload)
-    grpcStreamEmitter.sendMessage(message)
+    GRPCStreamEmitter(emitter)
+      .sendMessage(message)
 
     assertThat(ByteBuffer.wrap(dataOutputStream.toByteArray().sliceArray(1..4)).order(ByteOrder.BIG_ENDIAN).int).isEqualTo(payload.size)
   }
 
   @Test
   fun `message is sent after the prefix`() {
-    val grpcStreamEmitter = GRPCStreamEmitter(emitter)
-
     val payload = "data".toByteArray(Charsets.UTF_8)
     val message = ByteBuffer.wrap(payload)
-    grpcStreamEmitter.sendMessage(message)
+    GRPCStreamEmitter(emitter)
+      .sendMessage(message)
 
     assertThat(dataOutputStream.toByteArray().sliceArray(GRPC_PREFIX_LENGTH until dataOutputStream.size()).toString(Charsets.UTF_8)).isEqualTo("data")
 
@@ -93,9 +89,8 @@ class GRPCStreamEmitterTest {
 
   @Test
   fun `close is called with empty data frame`() {
-    val grpcStreamEmitter = GRPCStreamEmitter(emitter)
-
-    grpcStreamEmitter.close()
+    GRPCStreamEmitter(emitter)
+      .close()
 
     assertThat(isCloseCalledWithNull).isTrue()
   }

--- a/library/swift/src/GRPCStreamEmitter.swift
+++ b/library/swift/src/GRPCStreamEmitter.swift
@@ -22,7 +22,10 @@ public final class GRPCStreamEmitter: NSObject {
   /// Send a protobuf message's binary data over the gRPC stream.
   ///
   /// - parameter messageData: Binary data of a protobuf message to send.
-  public func sendMessage(_ messageData: Data) {
+  ///
+  /// - returns: The stream emitter, for chaining syntax.
+  @discardableResult
+  public func sendMessage(_ messageData: Data) -> GRPCStreamEmitter {
     // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
     // Length-Prefixed-Message = Compressed-Flag | Message-Length | Message
     // Compressed-Flag = 0 / 1, encoded as 1 byte unsigned integer
@@ -40,6 +43,7 @@ public final class GRPCStreamEmitter: NSObject {
     // Send prefix data followed by message data
     self.underlyingEmitter.sendData(prefixData)
     self.underlyingEmitter.sendData(messageData)
+    return self
   }
 
   /// Close this connection.

--- a/library/swift/test/GRPCStreamEmitterTests.swift
+++ b/library/swift/test/GRPCStreamEmitterTests.swift
@@ -35,24 +35,24 @@ final class GRPCStreamEmitterTests: XCTestCase {
   func testDataSizeIsFiveBytesGreaterThanMessageSize() {
     var sentData = Data()
     let mockEmitter = MockEmitter(onSendData: { sentData.append(contentsOf: $0) })
-    let grpcEmitter = GRPCStreamEmitter(emitter: mockEmitter)
-    grpcEmitter.sendMessage(kMessageData)
+    GRPCStreamEmitter(emitter: mockEmitter)
+      .sendMessage(kMessageData)
     XCTAssertEqual(5 + kMessageData.count, sentData.count)
   }
 
   func testPrefixesSentDataWithZeroCompressionFlag() {
     var sentData = Data()
     let mockEmitter = MockEmitter(onSendData: { sentData.append(contentsOf: $0) })
-    let grpcEmitter = GRPCStreamEmitter(emitter: mockEmitter)
-    grpcEmitter.sendMessage(kMessageData)
+    GRPCStreamEmitter(emitter: mockEmitter)
+      .sendMessage(kMessageData)
     XCTAssertEqual(UInt8(0), sentData.integer(atIndex: 0))
   }
 
   func testPrefixesSentDataWithBigEndianLengthOfMessage() {
     var sentData = Data()
     let mockEmitter = MockEmitter(onSendData: { sentData.append(contentsOf: $0) })
-    let grpcEmitter = GRPCStreamEmitter(emitter: mockEmitter)
-    grpcEmitter.sendMessage(kMessageData)
+    GRPCStreamEmitter(emitter: mockEmitter)
+      .sendMessage(kMessageData)
 
     let expectedMessageLength = UInt32(kMessageData.count).bigEndian
     let messageLength: UInt32? = sentData.integer(atIndex: 1)
@@ -62,16 +62,16 @@ final class GRPCStreamEmitterTests: XCTestCase {
   func testAppendsMessageDataAtTheEndOfSentData() {
     var sentData = Data()
     let mockEmitter = MockEmitter(onSendData: { sentData.append(contentsOf: $0) })
-    let grpcEmitter = GRPCStreamEmitter(emitter: mockEmitter)
-    grpcEmitter.sendMessage(kMessageData)
+    GRPCStreamEmitter(emitter: mockEmitter)
+      .sendMessage(kMessageData)
     XCTAssertEqual(kMessageData, sentData.subdata(in: 5..<sentData.count))
   }
 
   func testCloseIsCalledWithNilTrailersInOrderToCloseWithEmptyDataFrame() {
     var sentTrailers: [String: [String]]? = ["x": ["invalid"]]
     let mockEmitter = MockEmitter(onSendData: { _ in }, onClose: { sentTrailers = $0 })
-    let grpcEmitter = GRPCStreamEmitter(emitter: mockEmitter)
-    grpcEmitter.close()
+    GRPCStreamEmitter(emitter: mockEmitter)
+      .close()
     XCTAssertNil(sentTrailers)
   }
 }


### PR DESCRIPTION
We should support chaining with gRPC stream emitters the same way we do for HTTP stream emitters.

I.e.,

```
let emitter = ...
  .sendMessage(...)
  .sendMessage(...)
```

This PR also updates tests to use chaining syntax for gRPC.

Signed-off-by: Michael Rebello <me@michaelrebello.com>