### PR TITLE
core: shut down more aggressively in the engine destructor

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -96,9 +96,8 @@ Engine::~Engine() {
     ASSERT(main_common_);
     event_dispatcher_->post([this]() -> void {
       callbacks_.on_exit();
-      // This call will gracefully shutdown the Server::Instance and exit the event loop,
-      // returning main_thread_'s execution to Engine::run
-      TS_UNCHECKED_READ(main_common_)->server()->shutdown();
+      // Exit the event loop and finish up in Engine::run(...)
+      event_dispatcher_->exit();
     });
   } // _mutex
 


### PR DESCRIPTION
Description: At the point where this destructor is being called, the OS is already trying to terminate the thread holding Envoy's static state. shutdown() may simply not be aggressive enough to tear things down in time. This will cause the event loop to exit.

Signed-off-by: Mike Schore <mike.schore@gmail.com>
