### PR TITLE
bazel: enable cacheable binaries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,8 @@ build \
   --define=hot_restart=disabled \
   --define=signal_trace=disabled \
   --define=tcmalloc=disabled \
+  --features=debug_prefix_map_pwd_is_dot \
+  --features=swift.cacheable_swiftmodules \
   --ios_minimum_os=10.0 \
   --ios_simulator_device="iPhone X" \
   --ios_simulator_version=13.1 \


### PR DESCRIPTION
Description:

When building for debug with Bazel, both local and remote should have local paths excluded from the binary, or at minimum, normalized paths before being embedded in the binary.

This change enables bazel's `debug_prefix_map_pwd_is_dot` feature, which uses [clang's `-fdebug-prefix-map`](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fdebug-prefix-map). For details, see https://github.com/bazelbuild/bazel/commit/3f46dd0f6d5a042fc28d265411a6014f666a40c1 and https://github.com/bazelbuild/bazel/issues/5545.

This same feature is already enabled by default for swift.

Additionally for swift, enable the `cacheable_swiftmodules` feature. This ensures that local paths are not embedded in `.swiftmodule` files. For details, see https://github.com/bazelbuild/rules_swift/pull/296.

This change was motivated and identified after seeing developer specific file paths in binaries.

Both of these features should be irrelevant for release builds.

Risk Level: Low
Testing: None