### PR TITLE
core: expose engine via weak_ptr

### DIFF
--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -71,8 +71,14 @@ envoy_status_t run_engine(envoy_engine_t, envoy_engine_callbacks callbacks, cons
                           const char* log_level) {
   // This will change once multiple engine support is in place.
   // https://github.com/lyft/envoy-mobile/issues/332
-  static auto internal =
+
+  // The shared pointer created here will keep the engine alive until static destruction occurs.
+  static auto strong_ref =
       std::make_shared<Envoy::Engine>(callbacks, config, log_level, preferred_network_);
-  engine_ = internal;
+
+  // The weak pointer we actually expose allows calling threads to atomically check if the engine
+  // still exists and acquire a shared pointer to it - ensuring the engine persists at least for
+  // the duration of the call.
+  engine_ = strong_ref;
   return ENVOY_SUCCESS;
 }

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -48,7 +48,7 @@ envoy_status_t send_trailers(envoy_stream_t stream, envoy_headers trailers) {
 
 envoy_status_t reset_stream(envoy_stream_t stream) {
   if (auto e = engine_.lock()) {
-    return engine_->httpDispatcher().resetStream(stream);
+    return e->httpDispatcher().resetStream(stream);
   }
   return ENVOY_FAILURE;
 }


### PR DESCRIPTION
Description: Access Engine via weak_ptr so that threads can extend its lifetime for the durations of their calls to it. Despite the fact that all incoming calls are ultimately dispatched to the underlying Envoy main thread, there exists a window where the thread must leverage Engine state (e.g. to access the dispatcher) that can otherwise race with the Engine lifecycle. While it's probably possible to cover these edge cases at the platform layer, this provides a common solution.
Risk Level: Moderate
Testing: local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>