### PR TITLE
bazel: Fix bitcode for android binaries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,8 +33,14 @@ build:fat --ios_multi_cpus=i386,x86_64,armv7,arm64 --fat_apk_cpu=x86,x86_64,arme
 
 # TODO: Enable `--copt -ggdb3`. Issues were encountered previously with this:
 # https://github.com/lyft/envoy-mobile/pull/155#issuecomment-507461500
-build:release \
-  --linkopt=-s \
+build:release-common \
   --copt=-O2 \
+  --linkopt=-s
+
+build:release-ios \
   --apple_bitcode=embedded \
+  --config=release-common \
   --copt=-fembed-bitcode
+
+build:release-android \
+  --config=release-common

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -22,7 +22,7 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
       - name: 'Build envoy_master.aar distributable'
-        run: ./bazelw build --config=release --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_dist
+        run: ./bazelw build --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_dist
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_master.zip

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -51,7 +51,7 @@ Android AAR
 Envoy Mobile can be compiled into an ``.aar`` file for use with Android apps.
 This command is defined in the main :repo:`BUILD <BUILD>` file of the repo, and may be run locally:
 
-``./bazelw build android_dist --config=android --config=release # omit release for development``
+``./bazelw build android_dist --config=android --config=release-android # omit release for development``
 
 Upon completion of the build, you'll see an ``envoy.aar`` file at :repo:`dist/envoy.aar <dist>`.
 
@@ -61,7 +61,7 @@ The ``envoy_mobile_android`` Bazel rule defined in the :repo:`dist BUILD file <d
 an example of how this artifact may be used.
 
 When building the artifact for release (usage outside of development), be sure to include the
-``--config=release`` option.
+``--config=release-android`` option.
 
 For a demo of a working app using this artifact, see the :ref:`hello_world` example.
 
@@ -74,7 +74,7 @@ iOS static framework
 Envoy Mobile supports being compiled into a ``.framework`` for consumption by iOS apps.
 This command is defined in the main :repo:`BUILD <BUILD>` file of the repo, and may be run locally:
 
-``./bazelw build ios_dist --config=ios --config=release # omit release for development``
+``./bazelw build ios_dist --config=ios --config=release-ios # omit release for development``
 
 Upon completion of the build, you'll see a ``Envoy.framework`` directory at
 :repo:`dist/Envoy.framework <dist>`.
@@ -85,7 +85,7 @@ The ``envoy_mobile_ios`` Bazel rule defined in the :repo:`dist BUILD file <dist/
 example of how this artifact may be used.
 
 When building the artifact for release (usage outside of development), be sure to include the
-``--config=release`` option in addition to ``--config=ios`` and a list of architectures for which
+``--config=release-ios`` option in addition to ``--config=ios`` and a list of architectures for which
 you wish to build using ``--ios_multi_cpus=...``.
 
 For a demo of a working app using this artifact, see the :ref:`hello_world` example.


### PR DESCRIPTION
Because we shared the `release` bazel config between both iOS and
Android, Android builds were incorrectly having llvm bitcode enabled for
them.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>