### PR TITLE
ci: Change aar archive name

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -25,5 +25,5 @@ jobs:
         run: ./bazelw build --config=release --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_dist
       - uses: actions/upload-artifact@v1
         with:
-          name: envoy_master.aar
+          name: envoy_master.zip
           path: dist/envoy.aar


### PR DESCRIPTION
This archive is actually a zip containing the produced aar, so this
makes that a bit less confusing.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>