### PR TITLE
ci: build artifacts on all pushes to master

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - 'library/common/**'
-      - 'library/java/**'
-      - 'library/kotlin/**'
-      - 'envoy/**'
 
 jobs:
   master_aar_dist:


### PR DESCRIPTION
We previously only rebuilt when common or Android code changed. However, there are several other cases where we'd want to rebuild artifacts on push to master even if those source files haven't changed:

- Bazel version is updated
- Build configs are updated
- CI configs are updated

Rather than maintain a list of paths we care about, we can simply rebuild on any merge to master.

Signed-off-by: Michael Rebello <me@michaelrebello.com>