### PR TITLE
bazel: include iOS config with release

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,6 +39,7 @@ build:release-common \
 
 build:release-ios \
   --apple_bitcode=embedded \
+  --config=ios \
   --config=release-common \
   --copt=-fembed-bitcode
 

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -51,7 +51,7 @@ Android AAR
 Envoy Mobile can be compiled into an ``.aar`` file for use with Android apps.
 This command is defined in the main :repo:`BUILD <BUILD>` file of the repo, and may be run locally:
 
-``./bazelw build android_dist --config=android --config=release-android # omit release for development``
+``./bazelw build android_dist --config=android``
 
 Upon completion of the build, you'll see an ``envoy.aar`` file at :repo:`dist/envoy.aar <dist>`.
 
@@ -60,8 +60,10 @@ Alternatively, you can use the prebuilt artifact from Envoy Mobile's releases_.
 The ``envoy_mobile_android`` Bazel rule defined in the :repo:`dist BUILD file <dist/BUILD>` provides
 an example of how this artifact may be used.
 
-When building the artifact for release (usage outside of development), be sure to include the
-``--config=release-android`` option.
+**When building the artifact for release** (usage outside of development), be sure to include the
+``--config=release-android`` option, along with the architectures for which the artifact is being built:
+
+``./bazelw build android_dist --config=release-android --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a``
 
 For a demo of a working app using this artifact, see the :ref:`hello_world` example.
 
@@ -74,7 +76,7 @@ iOS static framework
 Envoy Mobile supports being compiled into a ``.framework`` for consumption by iOS apps.
 This command is defined in the main :repo:`BUILD <BUILD>` file of the repo, and may be run locally:
 
-``./bazelw build ios_dist --config=ios --config=release-ios # omit release for development``
+``./bazelw build ios_dist --config=ios``
 
 Upon completion of the build, you'll see a ``Envoy.framework`` directory at
 :repo:`dist/Envoy.framework <dist>`.
@@ -84,9 +86,10 @@ Alternatively, you can use the prebuilt artifact from Envoy Mobile's releases_.
 The ``envoy_mobile_ios`` Bazel rule defined in the :repo:`dist BUILD file <dist/BUILD>` provides an
 example of how this artifact may be used.
 
-When building the artifact for release (usage outside of development), be sure to include the
-``--config=release-ios`` option in addition to ``--config=ios`` and a list of architectures for which
-you wish to build using ``--ios_multi_cpus=...``.
+**When building the artifact for release** (usage outside of development), be sure to include the
+``--config=release-ios`` option, along with the architectures for which the artifact is being built:
+
+``./bazelw build ios_dist --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64``
 
 For a demo of a working app using this artifact, see the :ref:`hello_world` example.
 


### PR DESCRIPTION
Include the `ios` config by default when using `release-ios`. Also updates the docs for clarity on usage.

Signed-off-by: Michael Rebello <me@michaelrebello.com>