### PR TITLE
bazel: remove unused build configs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,12 +25,6 @@ build:ios --define=manual_stamp=manual_stamp
 
 build:android --fat_apk_cpu=x86_64
 
-build:device --ios_multi_cpus=armv7,arm64 --fat_apk_cpu=armeabi-v7a,arm64-v8a
-
-build:sim --ios_multi_cpus=i386,x86_64 --fat_apk_cpu=x86,x86_64
-
-build:fat --ios_multi_cpus=i386,x86_64,armv7,arm64 --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a
-
 # TODO: Enable `--copt -ggdb3`. Issues were encountered previously with this:
 # https://github.com/lyft/envoy-mobile/pull/155#issuecomment-507461500
 build:release-common \

--- a/docs/root/development/performance/cpu_battery_impact.rst
+++ b/docs/root/development/performance/cpu_battery_impact.rst
@@ -82,7 +82,7 @@ Both apps were run (one at a time) on a physical device (iPhone 6s iOS 12.2.x) w
 
 Reproducing the Envoy example app:
 
-1. Build the library using ``bazel build ios_dist --config=ios --config=fat``
+1. Build the library using ``bazel build ios_dist --config=ios --ios_multi_cpus=armv7,arm64``
 2. Copy ``./dist/Envoy.framework`` to the example's :tree:`source directory <2f27581/examples/objective-c/xcode_variant/EnvoyObjc/EnvoyObjc>`
 3. Build/run the example app
 

--- a/envoy-mobile.tulsiproj/project.tulsiconf
+++ b/envoy-mobile.tulsiproj/project.tulsiconf
@@ -5,7 +5,7 @@
         "p" : "--config=ios"
       },
       "BazelBuildOptionsRelease" : {
-        "p" : "--config=ios --config=fat"
+        "p" : "--config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64"
       },
       "IncludeBuildSources" : {
         "p" : "YES"


### PR DESCRIPTION
Removes some build configurations that we don't explicitly use anywhere. Documentation suggests explicitly using `--ios_multi_cpus` or `--fat_apk_cpu`.

Follow up to https://github.com/lyft/envoy-mobile/pull/563#discussion_r340821651

Signed-off-by: Michael Rebello <me@michaelrebello.com>