### PR TITLE
ci: add job to publish iOS release artifact on merge to master

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,24 +1,43 @@
 name: artifacts
 
-on:
-  push:
-    branches:
-      - master
+# on:
+#   push:
+#     branches:
+#       - master
 
 jobs:
-  master_aar_dist:
-    name: master_aar_dist
+  master_android_dist:
+    name: master_android_dist
     runs-on: macOS-10.14
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - run: ./ci/mac_ci_setup.sh
-        name: 'Install dependencies'
+      - name: 'Install dependencies'
+        run: ./ci/mac_ci_setup.sh
       - name: 'Build envoy_master.aar distributable'
         run: ./bazelw build --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_dist
       - uses: actions/upload-artifact@v1
         with:
-          name: envoy_master.zip
+          name: envoy_android_aar.zip
           path: dist/envoy.aar
+
+  master_ios_dist:
+    name: master_ios_dist
+    runs-on: macOS-10.14
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: 'Install dependencies'
+        run: ./ci/mac_ci_setup.sh
+      - name: 'Build Envoy.framework distributable'
+        run: ./bazelw build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 //:ios_dist
+      - name: 'Zip Envoy.framework.zip distributable'
+        run: zip -r dist/Envoy.framework.zip dist/Envoy.framework
+      - uses: actions/upload-artifact@v1
+        with:
+          name: envoy_ios_framework.zip
+          path: dist/Envoy.framework.zip

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -34,9 +34,7 @@ jobs:
         run: ./ci/mac_ci_setup.sh
       - name: 'Build Envoy.framework distributable'
         run: ./bazelw build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 //:ios_dist
-      - name: 'Zip Envoy.framework.zip distributable'
-        run: zip -r dist/Envoy.framework.zip dist/Envoy.framework
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_ios_framework.zip
-          path: dist/Envoy.framework.zip
+          path: dist/Envoy.framework

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,10 +1,9 @@
 name: artifacts
 
-on: [push]
-# on:
-#   push:
-#     branches:
-#       - master
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   master_android_dist:
@@ -17,7 +16,7 @@ jobs:
           submodules: true
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
-      - name: 'Build envoy_master.aar distributable'
+      - name: 'Build envoy.aar distributable'
         run: ./bazelw build --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_dist
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,5 +1,6 @@
 name: artifacts
 
+on: [push]
 # on:
 #   push:
 #     branches:
@@ -22,7 +23,6 @@ jobs:
         with:
           name: envoy_android_aar.zip
           path: dist/envoy.aar
-
   master_ios_dist:
     name: master_ios_dist
     runs-on: macOS-10.14


### PR DESCRIPTION
Adds a job that runs on master and builds/uploads a zip artifact of the `Envoy.framework` for iOS using the release configurations. This should make it easier for consumers to utilize the most recent iOS versions of Envoy Mobile.

Resolves https://github.com/lyft/envoy-mobile/issues/547.

Tested against this PR, which resulted in the expected artifacts being uploaded successfully:

<img width="326" alt="Screen Shot 2019-10-30 at 2 15 05 PM" src="https://user-images.githubusercontent.com/2643476/67899621-ebcab880-fb1f-11e9-89f9-25fac9a96097.png">

Signed-off-by: Michael Rebello <me@michaelrebello.com>