### PR TITLE
metrics: add configuration for flushing stats via a metrics service

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -24,7 +24,7 @@ static_resources:
             inline_string: |
 )"
 #include "certificates.inc"
-R"(
+                              R"(
           verify_subject_alt_name:
             - {{ domain }}
       sni: {{ domain }}
@@ -51,8 +51,45 @@ R"(
       endpoints: *base_endpoints
     tls_context: *base_tls_context
     type: LOGICAL_DNS
+  - name: stats
+    connect_timeout: {{ connect_timeout_seconds }}s
+    dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+    dns_lookup_family: V4_ONLY
+    http2_protocol_options: {}
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: base_wwan
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address: {address: {{ stats_domain }}, port_value: 443}
+    tls_context: *base_tls_context
+    type: LOGICAL_DNS
 stats_flush_interval: {{ stats_flush_interval_seconds }}s
+stats_sinks:
+  - name: envoy.metrics_service
+    config:
+      grpc_service:
+        envoy_grpc:
+          cluster_name: stats
+stats_config:
+  stats_matcher:
+    inclusion_list:
+      patterns:
+        - safe_regex:
+            google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_total'
+        - safe_regex:
+            google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_cx_active'
+        - safe_regex:
+            google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_time'
 watchdog:
   megamiss_timeout: 60s
   miss_timeout: 60s
+node:
+  metadata:
+    os: {{ device_os }}
 )";

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -24,7 +24,7 @@ static_resources:
             inline_string: |
 )"
 #include "certificates.inc"
-                              R"(
+R"(
           verify_subject_alt_name:
             - {{ domain }}
       sni: {{ domain }}
@@ -58,7 +58,7 @@ static_resources:
     http2_protocol_options: {}
     lb_policy: ROUND_ROBIN
     load_assignment:
-      cluster_name: base_wwan
+      cluster_name: stats
       endpoints:
         - lb_endpoints:
             - endpoint:

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -14,7 +14,7 @@ public class EnvoyConfiguration {
    * @param domain                The domain to use with Envoy (i.e.,
    *                              `api.foo.com`). TODO:
    *                              https://github.com/lyft/envoy-mobile/issues/433
-   * @param statsDomain           The domain to flush stats too.
+   * @param statsDomain           The domain to flush stats to.
    * @param connectTimeoutSeconds timeout for new network connections to hosts in
    *                              the cluster.
    * @param dnsRefreshSeconds     rate in seconds to refresh DNS.
@@ -45,7 +45,7 @@ public class EnvoyConfiguration {
             .replace("{{ connect_timeout_seconds }}", String.format("%s", connectTimeoutSeconds))
             .replace("{{ dns_refresh_rate_seconds }}", String.format("%s", dnsRefreshSeconds))
             .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
-            .replace("{{ device_os }}", "android");
+            .replace("{{ device_os }}", "Android");
 
     if (resolvedConfiguration.contains("{{")) {
       throw new ConfigurationException();

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -3,6 +3,7 @@ package io.envoyproxy.envoymobile.engine;
 public class EnvoyConfiguration {
 
   public final String domain;
+  public final String statsDomain;
   public final Integer connectTimeoutSeconds;
   public final Integer dnsRefreshSeconds;
   public final Integer statsFlushSeconds;
@@ -13,13 +14,16 @@ public class EnvoyConfiguration {
    * @param domain                The domain to use with Envoy (i.e.,
    *                              `api.foo.com`). TODO:
    *                              https://github.com/lyft/envoy-mobile/issues/433
+   * @param statsDomain           The domain to flush stats too.
    * @param connectTimeoutSeconds timeout for new network connections to hosts in
    *                              the cluster.
    * @param dnsRefreshSeconds     rate in seconds to refresh DNS.
    * @param statsFlushSeconds     interval at which to flush Envoy stats.
    */
-  public EnvoyConfiguration(String domain, int connectTimeoutSeconds, int dnsRefreshSeconds, int statsFlushSeconds) {
+  public EnvoyConfiguration(String domain, String statsDomain, int connectTimeoutSeconds,
+                            int dnsRefreshSeconds, int statsFlushSeconds) {
     this.domain = domain;
+    this.statsDomain = statsDomain;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.dnsRefreshSeconds = dnsRefreshSeconds;
     this.statsFlushSeconds = statsFlushSeconds;
@@ -35,11 +39,13 @@ public class EnvoyConfiguration {
    *                                 resolved.
    */
   String resolveTemplate(String templateYAML) {
-    String resolvedConfiguration = templateYAML.replace("{{ domain }}", domain)
-        .replace("{{ connect_timeout_seconds }}", String.format("%s", connectTimeoutSeconds))
-        .replace("{{ dns_refresh_rate_seconds }}", String.format("%s", dnsRefreshSeconds))
-        .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
-        .replace("{{ device_os }}", "android");
+    String resolvedConfiguration =
+        templateYAML.replace("{{ domain }}", domain)
+            .replace("{{ stats_domain }}", String.format("%s", statsDomain))
+            .replace("{{ connect_timeout_seconds }}", String.format("%s", connectTimeoutSeconds))
+            .replace("{{ dns_refresh_rate_seconds }}", String.format("%s", dnsRefreshSeconds))
+            .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
+            .replace("{{ device_os }}", "android");
 
     if (resolvedConfiguration.contains("{{")) {
       throw new ConfigurationException();
@@ -48,8 +54,6 @@ public class EnvoyConfiguration {
   }
 
   static class ConfigurationException extends RuntimeException {
-    ConfigurationException() {
-      super("Unresolved Template Key");
-    }
+    ConfigurationException() { super("Unresolved Template Key"); }
   }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -18,8 +18,7 @@ public class EnvoyConfiguration {
    * @param dnsRefreshSeconds     rate in seconds to refresh DNS.
    * @param statsFlushSeconds     interval at which to flush Envoy stats.
    */
-  public EnvoyConfiguration(String domain, int connectTimeoutSeconds, int dnsRefreshSeconds,
-                            int statsFlushSeconds) {
+  public EnvoyConfiguration(String domain, int connectTimeoutSeconds, int dnsRefreshSeconds, int statsFlushSeconds) {
     this.domain = domain;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.dnsRefreshSeconds = dnsRefreshSeconds;
@@ -36,11 +35,11 @@ public class EnvoyConfiguration {
    *                                 resolved.
    */
   String resolveTemplate(String templateYAML) {
-    String resolvedConfiguration =
-        templateYAML.replace("{{ domain }}", domain)
-            .replace("{{ connect_timeout_seconds }}", String.format("%s", connectTimeoutSeconds))
-            .replace("{{ dns_refresh_rate_seconds }}", String.format("%s", dnsRefreshSeconds))
-            .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds));
+    String resolvedConfiguration = templateYAML.replace("{{ domain }}", domain)
+        .replace("{{ connect_timeout_seconds }}", String.format("%s", connectTimeoutSeconds))
+        .replace("{{ dns_refresh_rate_seconds }}", String.format("%s", dnsRefreshSeconds))
+        .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
+        .replace("{{ device_os }}", "android");
 
     if (resolvedConfiguration.contains("{{")) {
       throw new ConfigurationException();
@@ -49,6 +48,8 @@ public class EnvoyConfiguration {
   }
 
   static class ConfigurationException extends RuntimeException {
-    ConfigurationException() { super("Unresolved Template Key"); }
+    ConfigurationException() {
+      super("Unresolved Template Key");
+    }
   }
 }

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -7,9 +7,11 @@ private const val TEST_CONFIG = """
 mock_template:
 - name: mock
   domain: {{ domain }}
+  stats_domain: {{ stats_domain }}
   connect_timeout: {{ connect_timeout_seconds }}s
   dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
   stats_flush_interval: {{ stats_flush_interval_seconds }}s
+  os: {{ device_os }}
 """
 
 
@@ -17,19 +19,21 @@ class EnvoyConfigurationTest {
 
   @Test
   fun `resolving with default configuration resolves with values`() {
-    val envoyConfiguration = EnvoyConfiguration("api.foo.com", 123, 234, 345)
+    val envoyConfiguration = EnvoyConfiguration("api.foo.com", "stats.foo.com", 123, 234, 345)
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG)
     assertThat(resolvedTemplate).contains("domain: api.foo.com")
+    assertThat(resolvedTemplate).contains("stats_domain: stats.foo.com")
     assertThat(resolvedTemplate).contains("connect_timeout: 123s")
     assertThat(resolvedTemplate).contains("dns_refresh_rate: 234s")
     assertThat(resolvedTemplate).contains("stats_flush_interval: 345s")
+    assertThat(resolvedTemplate).contains("os: android")
   }
 
 
   @Test(expected = EnvoyConfiguration.ConfigurationException::class)
   fun `resolve templates with invalid templates will throw on build`() {
-    val envoyConfiguration = EnvoyConfiguration("api.foo.com", 123, 234, 345)
+    val envoyConfiguration = EnvoyConfiguration("api.foo.com", "stats.foo.com", 123, 234, 345)
 
     envoyConfiguration.resolveTemplate("{{ }}")
   }

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -27,7 +27,7 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("connect_timeout: 123s")
     assertThat(resolvedTemplate).contains("dns_refresh_rate: 234s")
     assertThat(resolvedTemplate).contains("stats_flush_interval: 345s")
-    assertThat(resolvedTemplate).contains("os: android")
+    assertThat(resolvedTemplate).contains("os: Android")
   }
 
 

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
@@ -17,6 +17,7 @@ open class EnvoyClientBuilder internal constructor(
   private var logLevel = LogLevel.INFO
   private var engineType: () -> EnvoyEngine = { EnvoyEngineImpl() }
 
+  private var statsDomain = "0.0.0.0"
   private var connectTimeoutSeconds = 30
   private var dnsRefreshSeconds = 60
   private var statsFlushSeconds = 60
@@ -27,6 +28,15 @@ open class EnvoyClientBuilder internal constructor(
    */
   fun addLogLevel(logLevel: LogLevel): EnvoyClientBuilder {
     this.logLevel = logLevel
+    return this
+  }
+
+  /**
+   * Add a domain to flush stats to.
+   * @param statsDomain the domain to flush stats to.
+   */
+  fun addStatsDomain(statsDomain: String): EnvoyClientBuilder {
+    this.statsDomain = statsDomain
     return this
   }
 
@@ -71,7 +81,7 @@ open class EnvoyClientBuilder internal constructor(
         return Envoy(engineType(), configuration.value, logLevel)
       }
       is Domain -> {
-        Envoy(engineType(), EnvoyConfiguration(configuration.value, connectTimeoutSeconds, dnsRefreshSeconds, statsFlushSeconds), logLevel)
+        Envoy(engineType(), EnvoyConfiguration(configuration.value, statsDomain, connectTimeoutSeconds, dnsRefreshSeconds, statsFlushSeconds), logLevel)
       }
     }
   }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
@@ -11,6 +11,8 @@ mock_template:
   connect_timeout: {{ connect_timeout_seconds }}
   dns_refresh_rate: {{ dns_refresh_rate_seconds }}
   stats_flush_interval: {{ stats_flush_interval_seconds }}
+  stats_domain: {{ stats_domain }}
+  os: {{ device_os }}
 """
 
 class EnvoyBuilderTest {
@@ -27,6 +29,16 @@ class EnvoyBuilderTest {
     clientBuilder.addLogLevel(LogLevel.DEBUG)
     val envoy = clientBuilder.build()
     assertThat(envoy.logLevel).isEqualTo(LogLevel.DEBUG)
+  }
+
+  @Test
+  fun `specifying stats domain overrides default`() {
+    clientBuilder = EnvoyClientBuilder(Domain("api.foo.com"))
+    clientBuilder.addEngineType { engine }
+
+    clientBuilder.addStatsDomain("stats.foo.com")
+    val envoy = clientBuilder.build()
+    assertThat(envoy.envoyConfiguration!!.statsDomain).isEqualTo("stats.foo.com")
   }
 
   @Test

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -17,7 +17,7 @@ class EnvoyClientTest {
 
   private val engine = mock(EnvoyEngine::class.java)
   private val stream = mock(EnvoyHTTPStream::class.java)
-  private val config = EnvoyConfiguration("api.foo.com", 0, 0, 0)
+  private val config = EnvoyConfiguration("api.foo.com", "stats.foo.com", 0, 0, 0)
 
   @Test
   fun `starting a stream on envoy sends headers`() {

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -28,7 +28,9 @@
     @"dns_refresh_rate_seconds" :
         [NSString stringWithFormat:@"%lu", (unsigned long)self.dnsRefreshSeconds],
     @"stats_flush_interval_seconds" :
-        [NSString stringWithFormat:@"%lu", (unsigned long)self.statsFlushSeconds]
+        [NSString stringWithFormat:@"%lu", (unsigned long)self.statsFlushSeconds],
+    @"device_os" : @"iOS"
+
   };
 
   for (NSString *templateKey in templateKeysToValues) {

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -5,6 +5,7 @@
 @implementation EnvoyConfiguration
 
 - (instancetype)initWithDomain:(NSString *)domain
+                   statsDomain:(NSString *)statsDomain
          connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
              dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
              statsFlushSeconds:(UInt32)statsFlushSeconds {
@@ -14,6 +15,7 @@
   }
 
   self.domain = domain;
+  self.statsDomain = statsDomain;
   self.connectTimeoutSeconds = connectTimeoutSeconds;
   self.dnsRefreshSeconds = dnsRefreshSeconds;
   self.statsFlushSeconds = statsFlushSeconds;
@@ -23,6 +25,7 @@
 - (nullable NSString *)resolveTemplate:(NSString *)templateYAML {
   NSDictionary<NSString *, NSString *> *templateKeysToValues = @{
     @"domain" : self.domain,
+    @"stats_domain" : self.statsDomain,
     @"connect_timeout_seconds" :
         [NSString stringWithFormat:@"%lu", (unsigned long)self.connectTimeoutSeconds],
     @"dns_refresh_rate_seconds" :

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -127,6 +127,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 @interface EnvoyConfiguration : NSObject
 
 @property (nonatomic, strong) NSString *domain;
+@property (nonatomic, strong) NSString *statsDomain;
 @property (nonatomic, assign) UInt32 connectTimeoutSeconds;
 @property (nonatomic, assign) UInt32 dnsRefreshSeconds;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
@@ -135,6 +136,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  Create a new instance of the configuration.
  */
 - (instancetype)initWithDomain:(NSString *)domain
+                   statsDomain:(NSString *)statsDomain
          connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
              dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
              statsFlushSeconds:(UInt32)statsFlushSeconds;

--- a/library/swift/src/EnvoyClientBuilder.swift
+++ b/library/swift/src/EnvoyClientBuilder.swift
@@ -12,6 +12,7 @@ public final class EnvoyClientBuilder: NSObject {
     case domain(String)
   }
 
+  private var statsDomain: String = "0.0.0.0"
   private var connectTimeoutSeconds: UInt32 = 30
   private var dnsRefreshSeconds: UInt32 = 60
   private var statsFlushSeconds: UInt32 = 60
@@ -32,6 +33,16 @@ public final class EnvoyClientBuilder: NSObject {
   /// - parameter yaml: Contents of a YAML file to use for configuration.
   public init(yaml: String) {
     self.base = .yaml(yaml)
+  }
+
+  /// Add a stats domain for Envoy to flush stats to.
+  ///
+  /// - parameter statsDomain: the domain to use.
+  ///
+  /// - returns: This builder.
+  public func addStatsDomain(_ statsDomain: String) -> EnvoyClientBuilder {
+    self.statsDomain = statsDomain
+    return self
   }
 
   /// Add a log level to use with Envoy.
@@ -90,6 +101,7 @@ public final class EnvoyClientBuilder: NSObject {
       return EnvoyClient(configYAML: yaml, logLevel: self.logLevel, engine: engine)
     case .domain(let domain):
       let config = EnvoyConfiguration(domain: domain,
+                                      statsDomain: self.statsDomain,
                                       connectTimeoutSeconds: self.connectTimeoutSeconds,
                                       dnsRefreshSeconds: self.dnsRefreshSeconds,
                                       statsFlushSeconds: self.statsFlushSeconds)

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -6,6 +6,8 @@ private let kMockTemplate = """
 mock_template:
 - name: mock
   domain: {{ domain }}
+  stats_domain: {{ stats_domain }}
+  device_os: {{ device_os }}
   connect_timeout: {{ connect_timeout_seconds }}s
   dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
   stats_flush_interval: {{ stats_flush_interval_seconds }}s
@@ -69,6 +71,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
 
   func testResolvesYAMLWithIndividuallySetValues() throws {
     let config = EnvoyConfiguration(domain: "api.foo.com",
+                                    statsDomain: "stats.foo.com",
                                     connectTimeoutSeconds: 200,
                                     dnsRefreshSeconds: 300,
                                     statsFlushSeconds: 400)
@@ -78,13 +81,16 @@ final class EnvoyClientBuilderTests: XCTestCase {
     }
 
     XCTAssertTrue(resolvedYAML.contains("domain: api.foo.com"))
+    XCTAssertTrue(resolvedYAML.contains("stats_domain: stats.foo.com"))
     XCTAssertTrue(resolvedYAML.contains("connect_timeout: 200s"))
     XCTAssertTrue(resolvedYAML.contains("dns_refresh_rate: 300s"))
     XCTAssertTrue(resolvedYAML.contains("stats_flush_interval: 400s"))
+    XCTAssertTrue(resolvedYAML.contains("device_os: iOS"))
   }
 
   func testReturnsNilWhenUnresolvedValueInTemplate() {
     let config = EnvoyConfiguration(domain: "api.foo.com",
+                                    statsDomain: "stats.foo.com",
                                     connectTimeoutSeconds: 200,
                                     dnsRefreshSeconds: 300,
                                     statsFlushSeconds: 400)

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -97,7 +97,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
-    func testAddingDNSRefreshSecondsAddsToConfigurationWhenRunningEnvoy() throws {
+  func testAddingDNSRefreshSecondsAddsToConfigurationWhenRunningEnvoy() throws {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
       XCTAssertEqual(23, config.dnsRefreshSeconds)
@@ -111,7 +111,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
-    func testAddingStatsFlushSecondsAddsToConfigurationWhenRunningEnvoy() throws {
+  func testAddingStatsFlushSecondsAddsToConfigurationWhenRunningEnvoy() throws {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
       XCTAssertEqual(42, config.statsFlushSeconds)
@@ -124,6 +124,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
       .build()
     self.waitForExpectations(timeout: 0.01)
   }
+
   func testResolvesYAMLWithIndividuallySetValues() throws {
     let config = EnvoyConfiguration(domain: "api.foo.com",
                                     statsDomain: "stats.foo.com",

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -69,6 +69,61 @@ final class EnvoyClientBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
+  func testAddingStatsDomainAddsToConfigurationWhenRunningEnvoy() throws {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual("stats.foo.com", config.statsDomain)
+      expectation.fulfill()
+    }
+
+    _ = try EnvoyClientBuilder(domain: "api.foo.com")
+      .addEngineType(MockEnvoyEngine.self)
+      .addStatsDomain("stats.foo.com")
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
+  func testAddingConnectTimeoutSecondsAddsToConfigurationWhenRunningEnvoy() throws {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(12345, config.connectTimeoutSeconds)
+      expectation.fulfill()
+    }
+
+    _ = try EnvoyClientBuilder(domain: "api.foo.com")
+      .addEngineType(MockEnvoyEngine.self)
+      .addConnectTimeoutSeconds(12345)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
+    func testAddingDNSRefreshSecondsAddsToConfigurationWhenRunningEnvoy() throws {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(23, config.dnsRefreshSeconds)
+      expectation.fulfill()
+    }
+
+    _ = try EnvoyClientBuilder(domain: "api.foo.com")
+      .addEngineType(MockEnvoyEngine.self)
+      .addDNSRefreshSeconds(23)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
+    func testAddingStatsFlushSecondsAddsToConfigurationWhenRunningEnvoy() throws {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(42, config.statsFlushSeconds)
+      expectation.fulfill()
+    }
+
+    _ = try EnvoyClientBuilder(domain: "api.foo.com")
+      .addEngineType(MockEnvoyEngine.self)
+      .addStatsFlushSeconds(42)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
   func testResolvesYAMLWithIndividuallySetValues() throws {
     let config = EnvoyConfiguration(domain: "api.foo.com",
                                     statsDomain: "stats.foo.com",


### PR DESCRIPTION
Description: this PR adds configuration to flush metrics from Envoy Mobile to a backend metrics service via Envoy's metrics_service API.
Risk Level: low - with respect to the library, higher risk for orgs using the library and ingesting metrics from their mobile clients.
Testing: locally, and with e2e with Lyft's infrastructure. Added unit tests for the new config templating.

Signed-off-by: Jose Nino <jnino@lyft.com>