### PR TITLE
ci: update format of master artifacts

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -34,9 +34,10 @@ jobs:
         run: ./ci/mac_ci_setup.sh
       - name: 'Build Envoy.framework distributable'
         run: ./bazelw build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 //:ios_dist
-      - name: 'Move artifact to directory to produce properly named zip'
-        run: mkdir -p dist/ios_artifact/Envoy.framework |
-             mv dist/Envoy.framework/* dist/ios_artifact/Envoy.framework
+      - name: 'Create temporary directory for artifact to produce properly named zip'
+        run: mkdir -p dist/ios_artifact/Envoy.framework
+      - name: 'Move artifact to directory for zipping'
+        run: mv dist/Envoy.framework/* dist/ios_artifact/Envoy.framework
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_ios_framework

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -20,7 +20,7 @@ jobs:
         run: ./bazelw build --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_dist
       - uses: actions/upload-artifact@v1
         with:
-          name: envoy_android_aar.zip
+          name: envoy_android_aar
           path: dist/envoy.aar
   master_ios_dist:
     name: master_ios_dist
@@ -34,7 +34,10 @@ jobs:
         run: ./ci/mac_ci_setup.sh
       - name: 'Build Envoy.framework distributable'
         run: ./bazelw build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 //:ios_dist
+      - name: 'Move artifact to directory to produce properly named zip'
+        run: mkdir -p dist/ios_artifact/Envoy.framework |
+             mv dist/Envoy.framework/* dist/ios_artifact/Envoy.framework
       - uses: actions/upload-artifact@v1
         with:
-          name: envoy_ios_framework.zip
-          path: dist/Envoy.framework
+          name: envoy_ios_framework
+          path: dist/ios_artifact


### PR DESCRIPTION
Previously, the artifacts would appear on GitHub Actions as:
- `envoy_android_aar.zip`
- `envoy_ios_framework.zip`

These would then unzip to:
- `envoy_android_aar.zip.zip`
- `envoy_android_aar.zip/envoy.aar`

And:
- `envoy_ios_framework.zip.zip`
- `envoy_ios_framework.zip/Envoy`
- `envoy_ios_framework.zip/Headers`
- `envoy_ios_framework.zip/Modules`

This was confusing and actually ended up mis-naming both the zip files and the framework.

With the changes in this PR, the new artifacts will be:
- `envoy_android_aar`
- `envoy_ios_framework`

And will unzip to:
- `envoy_android_aar.zip`
- `envoy_android_aar/envoy.aar`

And:
- `envoy_ios_framework.zip`
- `envoy_ios_framework/Envoy.framework/*`

Signed-off-by: Michael Rebello <me@michaelrebello.com>