### PR TITLE
ios: fix leaking of http streams

### DIFF
--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -57,9 +57,9 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 @property (nonatomic, strong) void (^onCancel)();
 
 /**
- * Called when the async HTTP stream is completed gracefully (without cancelation or error).
+ * Called when the async HTTP stream is closed (with completion, cancelation, or error).
  */
-@property (nonatomic, strong) void (^onComplete)();
+@property (nonatomic, strong) void (^onStreamClose)();
 
 @end
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -118,6 +118,11 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  */
 - (int)cancel;
 
+/**
+ Clean up the stream after it's closed (by completion, cancellation, or error).
+ */
+- (void)cleanUp;
+
 @end
 
 #pragma mark - EnvoyHTTPStreamImpl

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -56,12 +56,6 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  */
 @property (nonatomic, strong) void (^onCancel)();
 
-/**
- * Internal use only.
- * Called when the stream has closed (by completion, cancellation, or error).
- */
-@property (nonatomic, strong) void (^_onStreamClose)();
-
 @end
 
 #pragma mark - EnvoyHTTPStream

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -56,6 +56,11 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  */
 @property (nonatomic, strong) void (^onCancel)();
 
+/**
+ * Called when the async HTTP stream is completed gracefully (without cancelation or error).
+ */
+@property (nonatomic, strong) void (^onComplete)();
+
 @end
 
 #pragma mark - EnvoyHTTPStream

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -56,11 +56,6 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  */
 @property (nonatomic, strong) void (^onCancel)();
 
-/**
- * Called when the async HTTP stream is closed (with completion, cancelation, or error).
- */
-@property (nonatomic, strong) void (^onStreamClose)();
-
 @end
 
 #pragma mark - EnvoyHTTPStream

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -56,6 +56,12 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  */
 @property (nonatomic, strong) void (^onCancel)();
 
+/**
+ * Internal use only.
+ * Called when the stream has closed (by completion, cancelation, or error).
+ */
+@property (nonatomic, strong) void (^_onStreamClose)();
+
 @end
 
 #pragma mark - EnvoyHTTPStream

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -58,7 +58,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
 /**
  * Internal use only.
- * Called when the stream has closed (by completion, cancelation, or error).
+ * Called when the stream has closed (by completion, cancellation, or error).
  */
 @property (nonatomic, strong) void (^_onStreamClose)();
 

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -8,8 +8,8 @@
 #pragma mark - Utility types and functions
 
 typedef struct {
-  EnvoyHTTPCallbacks *callbacks; // Weak
-  id<EnvoyHTTPStream> stream; // Weak
+  EnvoyHTTPCallbacks *callbacks;
+  id<EnvoyHTTPStream> stream;
   atomic_bool *canceled;
 } ios_context;
 
@@ -225,6 +225,7 @@ static void ios_on_error(envoy_error error, void *context) {
 - (void)dealloc {
   ios_context *context = _nativeCallbacks.context;
   context->callbacks = nil;
+  context->stream = nil;
   free(context->canceled);
   free(context);
 }

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -232,7 +232,8 @@ static void ios_on_error(envoy_error error, void *context) {
 }
 
 - (void)dealloc {
-  ios_context *context = self._nativeCallbacks.context;
+  envoy_http_callbacks native_callbacks = self._nativeCallbacks;
+  ios_context *context = native_callbacks.context;
   free(context->canceled);
   free(context);
 }

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -5,6 +5,17 @@
 
 #import <stdatomic.h>
 
+#pragma mark - Callback extension
+
+@interface EnvoyHTTPCallbacks ()
+
+/**
+ * Called when the stream has closed (by completion, cancelation, or error).
+ */
+@property (nonatomic, strong) void (^_onStreamClose)();
+
+@end
+
 #pragma mark - Utility types and functions
 
 typedef struct {
@@ -123,14 +134,13 @@ static void ios_on_trailers(envoy_headers trailers, void *context) {
 }
 
 static void ios_on_complete(void *context) {
-  NSLog(@"**on complete called");
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
-    if (atomic_load(c->canceled) || !callbacks.onStreamClose) {
+    if (atomic_load(c->canceled) || !callbacks._onStreamClose) {
       return;
     }
-    callbacks.onStreamClose();
+    callbacks._onStreamClose();
   });
 }
 
@@ -142,8 +152,8 @@ static void ios_on_cancel(void *context) {
     if (callbacks.onCancel) {
       callbacks.onCancel();
     }
-    if (callbacks.onStreamClose) {
-      callbacks.onStreamClose();
+    if (callbacks._onStreamClose) {
+      callbacks._onStreamClose();
     }
   });
 }
@@ -162,25 +172,24 @@ static void ios_on_error(envoy_error error, void *context) {
       error.message.release(error.message.context);
       callbacks.onError(error.error_code, errorMessage);
     }
-    if (callbacks.onStreamClose) {
-      callbacks.onStreamClose();
+    if (callbacks._onStreamClose) {
+      callbacks._onStreamClose();
     }
   });
 }
 
 #pragma mark - EnvoyHTTPStreamImpl
 
-@implementation EnvoyHTTPStreamImpl {
-  EnvoyHTTPStreamImpl *_strongSelf;
-  EnvoyHTTPCallbacks *_platformCallbacks;
-  envoy_http_callbacks _nativeCallbacks;
-  envoy_stream_t _streamHandle;
-}
+@interface EnvoyHTTPStreamImpl ()
 
-- (void)handleStreamClosed {
-  NSLog(@"**Handle stream closed");
-  _strongSelf = nil;
-}
+@property (nonatomic, strong) EnvoyHTTPStreamImpl *_strongSelf;
+@property (nonatomic, strong) EnvoyHTTPCallbacks *_platformCallbacks;
+@property (nonatomic, assign) envoy_http_callbacks _nativeCallbacks;
+@property (nonatomic, assign) envoy_stream_t _streamHandle;
+
+@end
+
+@implementation EnvoyHTTPStreamImpl
 
 - (instancetype)initWithHandle:(envoy_stream_t)handle
                      callbacks:(EnvoyHTTPCallbacks *)callbacks
@@ -190,14 +199,14 @@ static void ios_on_error(envoy_error error, void *context) {
     return nil;
   }
 
-  _streamHandle = handle;
+  __weak typeof(self) weakSelf = self;
+  callbacks._onStreamClose = ^void() {
+    weakSelf._strongSelf = nil;
+  };
 
   // Retain platform callbacks
-  __weak typeof(self) weakSelf = self;
-  callbacks.onStreamClose = ^void() {
-    [weakSelf handleStreamClosed];
-  };
-  _platformCallbacks = callbacks;
+  self._platformCallbacks = callbacks;
+  self._streamHandle = handle;
 
   // Create callback context
   ios_context *context = safe_malloc(sizeof(ios_context));
@@ -209,15 +218,15 @@ static void ios_on_error(envoy_error error, void *context) {
   envoy_http_callbacks native_callbacks = {ios_on_headers,  ios_on_data,  ios_on_trailers,
                                            ios_on_metadata, ios_on_error, ios_on_complete,
                                            context};
-  _nativeCallbacks = native_callbacks;
+  self._nativeCallbacks = native_callbacks;
 
   // We need create the native-held strong ref on this stream before we call start_stream because
   // start_stream could result in a reset that would release the native ref.
-  _strongSelf = self;
+  self._strongSelf = self;
   envoy_stream_options stream_options = {bufferForRetry};
-  envoy_status_t result = start_stream(_streamHandle, native_callbacks, stream_options);
+  envoy_status_t result = start_stream(self._streamHandle, native_callbacks, stream_options);
   if (result != ENVOY_SUCCESS) {
-    _strongSelf = nil;
+    self._strongSelf = nil;
     return nil;
   }
 
@@ -225,39 +234,36 @@ static void ios_on_error(envoy_error error, void *context) {
 }
 
 - (void)dealloc {
-  NSLog(@"**Envoy deallocating stream");
-  envoy_http_callbacks native_callbacks = _nativeCallbacks;
-  ios_context *context = native_callbacks.context;
-  context->callbacks = nil;
+  ios_context *context = self._nativeCallbacks.context;
   free(context->canceled);
   free(context);
 }
 
 - (void)sendHeaders:(EnvoyHeaders *)headers close:(BOOL)close {
-  send_headers(_streamHandle, toNativeHeaders(headers), close);
+  send_headers(self._streamHandle, toNativeHeaders(headers), close);
 }
 
 - (void)sendData:(NSData *)data close:(BOOL)close {
-  send_data(_streamHandle, toNativeData(data), close);
+  send_data(self._streamHandle, toNativeData(data), close);
 }
 
 - (void)sendMetadata:(EnvoyHeaders *)metadata {
-  send_metadata(_streamHandle, toNativeHeaders(metadata));
+  send_metadata(self._streamHandle, toNativeHeaders(metadata));
 }
 
 - (void)sendTrailers:(EnvoyHeaders *)trailers {
-  send_trailers(_streamHandle, toNativeHeaders(trailers));
+  send_trailers(self._streamHandle, toNativeHeaders(trailers));
 }
 
 - (int)cancel {
-  ios_context *context = _nativeCallbacks.context;
+  ios_context *context = self._nativeCallbacks.context;
   // Step 1: atomically and synchronously prevent the execution of further callbacks other than
   // on_cancel.
   if (!atomic_exchange(context->canceled, YES)) {
     // Step 2: directly fire the cancel callback.
     ios_on_cancel(context);
     // Step 3: propagate the reset into native code.
-    reset_stream(_streamHandle);
+    reset_stream(self._streamHandle);
     return 0;
   } else {
     return 1;

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -232,8 +232,7 @@ static void ios_on_error(envoy_error error, void *context) {
 }
 
 - (void)dealloc {
-  envoy_http_callbacks native_callbacks = self._nativeCallbacks;
-  ios_context *context = native_callbacks.context;
+  ios_context *context = self._nativeCallbacks.context;
   free(context->canceled);
   free(context);
 }

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -153,7 +153,7 @@ static void ios_on_error(envoy_error error, void *context) {
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
     if (atomic_load(c->canceled)) {
-      return
+      return;
     }
     if (callbacks.onError) {
       NSString *errorMessage = [[NSString alloc] initWithBytes:error.message.bytes
@@ -177,7 +177,7 @@ static void ios_on_error(envoy_error error, void *context) {
   envoy_stream_t _streamHandle;
 }
 
--(void)handleStreamClosed {
+- (void)handleStreamClosed {
   NSLog(@"**Handle stream closed");
   _strongSelf = nil;
 }

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -233,6 +233,7 @@ static void ios_on_error(envoy_error error, void *context) {
 
 - (void)dealloc {
   ios_context *context = self._nativeCallbacks.context;
+  context->callbacks = nil;
   free(context->canceled);
   free(context);
 }

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -199,6 +199,8 @@ static void ios_on_error(envoy_error error, void *context) {
     return nil;
   }
 
+  // Release the stream when the connection closes.
+  // It must be kept in memory while the stream is active in order to receive callbacks.
   __weak typeof(self) weakSelf = self;
   callbacks._onStreamClose = ^void() {
     weakSelf._strongSelf = nil;

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -5,17 +5,6 @@
 
 #import <stdatomic.h>
 
-#pragma mark - Callback extension
-
-@interface EnvoyHTTPCallbacks ()
-
-/**
- * Called when the stream has closed (by completion, cancelation, or error).
- */
-@property (nonatomic, strong) void (^_onStreamClose)();
-
-@end
-
 #pragma mark - Utility types and functions
 
 typedef struct {

--- a/library/swift/test/MockEnvoyHTTPStream.swift
+++ b/library/swift/test/MockEnvoyHTTPStream.swift
@@ -38,4 +38,6 @@ extension MockEnvoyHTTPStream: EnvoyHTTPStream {
   func cancel() -> Int32 {
     return 0
   }
+
+  func cleanUp() {}
 }


### PR DESCRIPTION
At the moment, we leak all `EnvoyHTTPStreamImpl` and `EnvoyHTTPCallbacks` instances with every stream due to the deliberate retain cycle used to keep the stream in memory and pass callbacks through to the platform layer while the stream is active. This ends up also leaking the callback closures specified by the end consumer, along with anything captured by those closures.

To resolve this problem, we will release the strong reference cycle that the stream holds to itself when the stream completes.

The state/callback for stream completion has to be stored somewhere in the `ios_context` type and retained since the `ios_context` is a struct and doesn't retain its members.

We considered having the `EnvoyHTTPCallbacks` hold a reference to the `EnvoyHTTPStreamImpl` rather than having `EnvoyHTTPStreamImpl` hold a strong reference to itself. However, this posed a few problems:
- `EnvoyHTTPCallbacks` is designed to support being shared by multiple streams, and thus cannot have only 1 reference to a stream
- `EnvoyHTTPCallbacks` is instantiated by the Swift layer, which means we'd have to leak implementation details of how the stream is kept in memory and shift logic out of the stream implementation

With these in mind, we decided to have `EnvoyHTTPStreamImpl` manage its own lifecycle based on the state of the network stream.

Signed-off-by: Michael Rebello <me@michaelrebello.com>