### PR TITLE
ios: fix podspec for v0.2.0 support

### DIFF
--- a/EnvoyMobile.podspec
+++ b/EnvoyMobile.podspec
@@ -6,12 +6,12 @@ Pod::Spec.new do |s|
     s.homepage = 'https://envoy-mobile.github.io'
     s.documentation_url = 'https://envoy-mobile.github.io/docs/envoy-mobile/latest/index.html'
     s.social_media_url = 'https://twitter.com/EnvoyProxy'
-    s.license = { :type => 'Apache-2.0', :file => 'envoy_ios_cocoapods/LICENSE' }
+    s.license = { type: 'Apache-2.0', file: 'envoy_ios_cocoapods/LICENSE' }
     s.platform = :ios, '10.0'
     s.swift_version = '5.1'
     s.libraries = 'resolv.9', 'c++'
     s.frameworks = 'SystemConfiguration'
-    s.source = { :http => "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_cocoapods.zip" }
+    s.source = { http: "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_cocoapods.zip" }
     s.vendored_frameworks = 'envoy_ios_cocoapods/Envoy.framework'
     s.source_files = 'envoy_ios_cocoapods/Envoy.framework/Headers/*.h', 'envoy_ios_cocoapods/Envoy.framework/Swift/*.swift'
 end

--- a/EnvoyMobile.podspec
+++ b/EnvoyMobile.podspec
@@ -1,17 +1,17 @@
 Pod::Spec.new do |s|
-    s.name                = 'EnvoyMobile'
-    s.version             = '0.2.0'
-    s.author              = 'Lyft, Inc.'
-    s.summary             = 'Client networking libraries based on the Envoy project'
-    s.homepage            = 'https://envoy-mobile.github.io'
-    s.documentation_url   = 'https://envoy-mobile.github.io/docs/envoy-mobile/latest/index.html'
-    s.social_media_url    = 'https://twitter.com/EnvoyProxy'
-    s.license             = { :type => 'Apache-2.0', :file => 'envoy_ios_cocoapods/LICENSE' }
-    s.platform            = :ios, '10.0'
-    s.swift_version       = '5.1'
-    s.libraries           = 'resolv.9', 'c++'
-    s.frameworks          = 'SystemConfiguration'
-    s.source              = { :http => "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_cocoapods.zip" }
+    s.name = 'EnvoyMobile'
+    s.version = '0.2.0'
+    s.author = 'Lyft, Inc.'
+    s.summary = 'Client networking libraries based on the Envoy project'
+    s.homepage = 'https://envoy-mobile.github.io'
+    s.documentation_url = 'https://envoy-mobile.github.io/docs/envoy-mobile/latest/index.html'
+    s.social_media_url = 'https://twitter.com/EnvoyProxy'
+    s.license = { :type => 'Apache-2.0', :file => 'envoy_ios_cocoapods/LICENSE' }
+    s.platform = :ios, '10.0'
+    s.swift_version = '5.1'
+    s.libraries = 'resolv.9', 'c++'
+    s.frameworks = 'SystemConfiguration'
+    s.source = { :http => "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_cocoapods.zip" }
     s.vendored_frameworks = 'envoy_ios_cocoapods/Envoy.framework'
-    s.source_files        = 'envoy_ios_cocoapods/Envoy.framework/Headers/*.h', 'envoy_ios_cocoapods/Envoy.framework/Swift/*.swift'
+    s.source_files = 'envoy_ios_cocoapods/Envoy.framework/Headers/*.h', 'envoy_ios_cocoapods/Envoy.framework/Swift/*.swift'
 end

--- a/EnvoyMobile.podspec
+++ b/EnvoyMobile.podspec
@@ -1,16 +1,17 @@
 Pod::Spec.new do |s|
-    s.name              = 'EnvoyMobile'
-    s.version           = '0.2.0'
-    s.author            = 'Lyft, Inc.'
-    s.summary           = 'Client networking libraries based on the Envoy project'
-    s.homepage          = 'https://envoy-mobile.github.io'
-    s.documentation_url = 'https://envoy-mobile.github.io/docs/envoy-mobile/latest/index.html'
-    s.social_media_url  = 'https://twitter.com/EnvoyProxy'
-    s.license           = { :type => 'Apache-2.0', :file => 'LICENSE' }
-    s.platform          = :ios
-    s.source            = { :http => "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_framework.zip",
-                            :sha256 => 'efb14c917286daccd26aecb999c7a0ef3f547742156662f2545bcdd71484646f' }
-    s.libraries         = 'resolv.9', 'c++'
-    s.ios.framework     = 'SystemConfiguration'
-    s.ios.vendored_frameworks = 'Envoy.framework'
+    s.name                = 'EnvoyMobile'
+    s.version             = '0.2.0'
+    s.author              = 'Lyft, Inc.'
+    s.summary             = 'Client networking libraries based on the Envoy project'
+    s.homepage            = 'https://envoy-mobile.github.io'
+    s.documentation_url   = 'https://envoy-mobile.github.io/docs/envoy-mobile/latest/index.html'
+    s.social_media_url    = 'https://twitter.com/EnvoyProxy'
+    s.license             = { :type => 'Apache-2.0', :file => 'envoy_ios_cocoapods/LICENSE' }
+    s.platform            = :ios, '10.0'
+    s.swift_version       = '5.1'
+    s.libraries           = 'resolv.9', 'c++'
+    s.frameworks          = 'SystemConfiguration'
+    s.source              = { :http => "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_cocoapods.zip" }
+    s.vendored_frameworks = 'envoy_ios_cocoapods/Envoy.framework'
+    s.ios.source_files    = 'envoy_ios_cocoapods/Envoy.framework/Headers/*.h', 'envoy_ios_cocoapods/Envoy.framework/Swift/*.swift'
 end

--- a/EnvoyMobile.podspec
+++ b/EnvoyMobile.podspec
@@ -8,6 +8,9 @@ Pod::Spec.new do |s|
     s.social_media_url  = 'https://twitter.com/EnvoyProxy'
     s.license           = { :type => 'Apache-2.0', :file => 'LICENSE' }
     s.platform          = :ios
-    s.source            = { :http => "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_framework.zip" }
+    s.source            = { :http => "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_framework.zip",
+                            :sha256 => 'efb14c917286daccd26aecb999c7a0ef3f547742156662f2545bcdd71484646f' }
+    s.libraries         = 'resolv.9', 'c++'
+    s.ios.framework     = 'SystemConfiguration'
     s.ios.vendored_frameworks = 'Envoy.framework'
 end

--- a/EnvoyMobile.podspec
+++ b/EnvoyMobile.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
     s.frameworks          = 'SystemConfiguration'
     s.source              = { :http => "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_cocoapods.zip" }
     s.vendored_frameworks = 'envoy_ios_cocoapods/Envoy.framework'
-    s.ios.source_files    = 'envoy_ios_cocoapods/Envoy.framework/Headers/*.h', 'envoy_ios_cocoapods/Envoy.framework/Swift/*.swift'
+    s.source_files        = 'envoy_ios_cocoapods/Envoy.framework/Headers/*.h', 'envoy_ios_cocoapods/Envoy.framework/Swift/*.swift'
 end


### PR DESCRIPTION
Makes several updates to our podspec in order to fix CocoaPods integration with v0.2.0:

- Link `resolv.9` and `c++` which is being done with Bazel today
- Link `SystemConfiguration` which is being done with Bazel today
- Specify Swift version and platform version
- Specify `source_files` **with an empty `.swift` file** in order to ensure that Swift libraries are linked when building (i.e., `swiftFoundation`)

**Important notes:**
Releasing new versions of the pod requires the following manual changes:
- Unzipping `envoy_ios_framework.zip`
- Renaming the directory to `envoy_ios_cocoapods`
- Creating an empty file at `envoy_ios_cocoapods/Envoy.framework/Swift/Empty.swift`. This forces CocoaPods to link Swift libraries as necessary. We worked around this in Bazel similarly in the past [here](https://github.com/lyft/envoy-mobile/commit/94ada57a23b5e3769adbd1623b3bf863e22d9fdd#diff-6dc94efb18b54c46a32898ba3a5a0756R15)
- Copying the repo's `LICENSE` file and placing it at `envoy_ios_cocoapods/LICENSE`
- Re-zipping `envoy_ios_cocoapods` and uploading `envoy_ios_cocoapods.zip`

In the future, we should see if this can be simplified or at the very least add a script that uploads this artifact with each commit to master just like we do with other artifacts. This is being tracked in https://github.com/lyft/envoy-mobile/issues/578.

Note: There is a similar problem reported in CocoaPods that requires this empty Swift file workaround: https://github.com/CocoaPods/CocoaPods/issues/8649.

I tested this PR by using this podspec for building an app against Envoy Mobile with CocoaPods. This spec is currently published as v0.2.0.

Signed-off-by: Michael Rebello <me@michaelrebello.com>