### PR TITLE
android: add javadoc and sources jar generation for aar

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,10 +26,11 @@ jobs:
               --fat_apk_cpu=x86 \
               --define=pom_version=master-$current_short_commit \
               //:android_deploy
+
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_android_aar_sources
-          path: envoy_aar_sources.zip
+          path: dist/envoy_aar_sources.zip
     # TODO: parallelize these two jobs
       - name: 'Build Java app'
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
           current_short_commit=$(git rev-parse --short HEAD)
           ./bazelw build \
               --config=release-android \
-              --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a \
+              --fat_apk_cpu=x86 \
               --define=pom_version=master-$current_short_commit \
               //:android_deploy
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,17 @@ jobs:
           export CC=clang
           export CXX=clang++
           export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-          ./bazelw build --fat_apk_cpu=x86 //:android_dist
+          current_release_tag=$(git describe --tags `git rev-list --tags --max-count=1`) # this is for releases
+          current_short_commit=$(git rev-parse --short HEAD)
+          ./bazelw build \
+              --config=release-android \
+              --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a \
+              --define=pom_version=master-$current_short_commit \
+              //:android_deploy
+      - uses: actions/upload-artifact@v1
+        with:
+          name: envoy_android_aar_sources
+          path: envoy_aar_sources.zip
     # TODO: parallelize these two jobs
       - name: 'Build Java app'
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,18 +19,7 @@ jobs:
           export CC=clang
           export CXX=clang++
           export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-          current_release_tag=$(git describe --tags `git rev-list --tags --max-count=1`) # this is for releases
-          current_short_commit=$(git rev-parse --short HEAD)
-          ./bazelw build \
-              --config=release-android \
-              --fat_apk_cpu=x86 \
-              --define=pom_version=master-$current_short_commit \
-              //:android_deploy
-
-      - uses: actions/upload-artifact@v1
-        with:
-          name: envoy_android_aar_sources
-          path: dist/envoy_aar_sources.zip
+          ./bazelw build --fat_apk_cpu=x86 //:android_dist
     # TODO: parallelize these two jobs
       - name: 'Build Java app'
         run: |

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_android_aar_sources
-          path: envoy_aar_sources.zip
+          path: dist/envoy_aar_sources.zip
   master_ios_dist:
     name: master_ios_dist
     runs-on: macOS-10.14

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -20,8 +20,8 @@ jobs:
         run: ./bazelw build --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_deploy
       - uses: actions/upload-artifact@v1
         with:
-          name: envoy_android_aar
-          path: dist/envoy.aar
+          name: envoy_android_aar_sources
+          path: envoy_aar_sources.zip
   master_ios_dist:
     name: master_ios_dist
     runs-on: macOS-10.14

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,9 +1,9 @@
 name: artifacts
 
-on: [push]
-#  push:
-#    branches:
-#      - master
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   master_android_dist:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -18,7 +18,6 @@ jobs:
         run: ./ci/linux_ci_setup.sh
       - name: 'Build envoy.aar distributable'
         run: |
-          current_release_tag=$(git describe --tags `git rev-list --tags --max-count=1`) # this is for releases
           current_short_commit=$(git rev-parse --short HEAD)
           ./bazelw build \
               --config=release-android \

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -17,7 +17,14 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/linux_ci_setup.sh
       - name: 'Build envoy.aar distributable'
-        run: ./bazelw build --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_deploy
+        run: |
+          current_release_tag=$$(git describe --tags `git rev-list --tags --max-count=1`)
+          ./bazelw build \
+              --config=release-android \
+              --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a \
+              --define=pom_version=$$current_release_tag \
+              //:android_deploy
+
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_android_aar_sources

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,9 +1,9 @@
 name: artifacts
 
-on:
-  push:
-    branches:
-      - master
+on: [push]
+#  push:
+#    branches:
+#      - master
 
 jobs:
   master_android_dist:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -18,13 +18,13 @@ jobs:
         run: ./ci/linux_ci_setup.sh
       - name: 'Build envoy.aar distributable'
         run: |
-          current_release_tag=$$(git describe --tags `git rev-list --tags --max-count=1`)
+          current_release_tag=$(git describe --tags `git rev-list --tags --max-count=1`) # this is for releases
+          current_short_commit=$(git rev-parse --short HEAD)
           ./bazelw build \
               --config=release-android \
               --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a \
-              --define=pom_version=$$current_release_tag \
+              --define=pom_version=master-$current_short_commit \
               //:android_deploy
-
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_android_aar_sources

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -8,16 +8,16 @@ on:
 jobs:
   master_android_dist:
     name: master_android_dist
-    runs-on: macOS-10.14
+    runs-on: ubuntu-18.04
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
           submodules: true
       - name: 'Install dependencies'
-        run: ./ci/mac_ci_setup.sh
+        run: ./ci/linux_ci_setup.sh
       - name: 'Build envoy.aar distributable'
-        run: ./bazelw build --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_dist
+        run: ./bazelw build --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a //:android_deploy
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_android_aar

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist/*pom.xml
 /dist/*.aar
 /dist/*.jar
+/dist/envoy_aar_sources.zip
 /dist/Envoy.framework
 .DS_Store
 /generated

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build_*
 /dist/*pom.xml
 /dist/*.aar
+/dist/*.jar
 /dist/Envoy.framework
 .DS_Store
 /generated

--- a/BUILD
+++ b/BUILD
@@ -72,7 +72,7 @@ chmod 755 dist/envoy-javadoc.jar
 chmod 755 dist/envoy-sources.jar
 orig_dir=$$PWD
 pushd dist
-zip -r envoy_aar_sources.zip envoy.aar envoy-pom.xml envoy-javadoc.jar envoy-sources.jar
+zip -r envoy_aar_sources.zip envoy.aar envoy-pom.xml envoy-javadoc.jar envoy-sources.jar > /dev/null
 popd
 touch $@
 """,

--- a/BUILD
+++ b/BUILD
@@ -70,6 +70,10 @@ chmod 755 dist/envoy.aar
 chmod 755 dist/envoy-pom.xml
 chmod 755 dist/envoy-javadoc.jar
 chmod 755 dist/envoy-sources.jar
+orig_dir=$$PWD
+pushd dist
+zip -r envoy_aar_sources.zip envoy.aar envoy-pom.xml envoy-javadoc.jar envoy-sources.jar
+popd
 touch $@
 """,
     stamp = True,

--- a/BUILD
+++ b/BUILD
@@ -44,7 +44,7 @@ genrule(
     cmd = """
 cp $(location :android_aar) dist/envoy.aar
 cp $(location :android_pom) dist/envoy-pom.xml
-cp $(location :javadocs) dist/envoy-javadoc.jar
+cp $(location :android_javadocs) dist/envoy-javadoc.jar
 chmod 755 dist/envoy.aar
 chmod 755 dist/envoy-pom.xml
 chmod 755 dist/envoy-javadoc.jar

--- a/BUILD
+++ b/BUILD
@@ -60,7 +60,7 @@ genrule(
         "android_javadocs",
         "android_sources",
     ],
-    outs = ["stub_android_dist_output"],
+    outs = ["stub_android_deploy_output"],
     cmd = """
 cp $(location :android_aar) dist/envoy.aar
 cp $(location :android_pom) dist/envoy-pom.xml

--- a/BUILD
+++ b/BUILD
@@ -33,21 +33,29 @@ alias(
     actual = "//library:javadocs",
 )
 
+alias(
+    name = "android_sources",
+    actual = "//library:sources_jar",
+)
+
 genrule(
     name = "android_dist",
     srcs = [
         "android_aar",
         "android_pom",
         "android_javadocs",
+        "android_sources",
     ],
     outs = ["stub_android_dist_output"],
     cmd = """
 cp $(location :android_aar) dist/envoy.aar
 cp $(location :android_pom) dist/envoy-pom.xml
 cp $(location :android_javadocs) dist/envoy-javadoc.jar
+cp $(location :android_sources) dist/envoy-sources.jar
 chmod 755 dist/envoy.aar
 chmod 755 dist/envoy-pom.xml
 chmod 755 dist/envoy-javadoc.jar
+chmod 755 dist/envoy-sources.jar
 touch $@
 """,
     stamp = True,

--- a/BUILD
+++ b/BUILD
@@ -28,18 +28,26 @@ alias(
     actual = "//library/kotlin/src/io/envoyproxy/envoymobile:android_aar",
 )
 
+alias(
+    name = "android_javadocs",
+    actual = "//library:javadocs",
+)
+
 genrule(
     name = "android_dist",
     srcs = [
         "android_aar",
         "android_pom",
+        "android_javadocs",
     ],
     outs = ["stub_android_dist_output"],
     cmd = """
 cp $(location :android_aar) dist/envoy.aar
 cp $(location :android_pom) dist/envoy-pom.xml
+cp $(location :javadocs) dist/envoy-javadoc.jar
 chmod 755 dist/envoy.aar
 chmod 755 dist/envoy-pom.xml
+chmod 755 dist/envoy-javadoc.jar
 touch $@
 """,
     stamp = True,

--- a/BUILD
+++ b/BUILD
@@ -42,6 +42,20 @@ genrule(
     name = "android_dist",
     srcs = [
         "android_aar",
+    ],
+    outs = ["stub_android_dist_output"],
+    cmd = """
+cp $(location :android_aar) dist/envoy.aar
+chmod 755 dist/envoy.aar
+touch $@
+""",
+    stamp = True,
+)
+
+genrule(
+    name = "android_deploy",
+    srcs = [
+        "android_aar",
         "android_pom",
         "android_javadocs",
         "android_sources",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file", "http_jar")
 
 # Patch upstream Abseil to prevent Foundation dependency from leaking into Android builds.
 # Workaround for https://github.com/abseil/abseil-cpp/issues/326.
@@ -183,3 +183,9 @@ rules_proto_grpc_toolchains()
 load("@rules_proto_grpc//java:repositories.bzl", rules_proto_grpc_java_repos = "java_repos")
 
 rules_proto_grpc_java_repos()
+
+http_jar(
+    name = "kotlin_dokka",
+    url = "https://github.com/Kotlin/dokka/releases/download/0.9.18/dokka-fatjar-0.9.18.jar",
+    sha256 = "4c73eee92dd652ea8e2afd7b20732cf863d4938a30f634d12c88fe64def89fd8",
+)

--- a/library/BUILD
+++ b/library/BUILD
@@ -13,15 +13,30 @@ genrule(
     cmd = """
 curl -L -o dokka.jar "https://github.com/Kotlin/dokka/releases/download/{version}/dokka-fatjar-{version}.jar"
 echo "{sha256} dokka.jar" | sha256sum --check
-origdir=$$PWD
+orig_dir=$$PWD
 tmp_dir=$$(mktemp -d)
-java -jar $$origdir/dokka.jar $$origdir/library/java/src/ -format javadoc -output $$tmp_dir
-java -jar $$origdir/dokka.jar $$origdir/library/kotlin/src/ -format javadoc -output $$tmp_dir
+java -jar $$orig_dir/dokka.jar $$orig_dir/library/java/src/ -format javadoc -output $$tmp_dir
+java -jar $$orig_dir/dokka.jar $$orig_dir/library/kotlin/src/ -format javadoc -output $$tmp_dir
 cd $$tmp_dir
-zip -r $$origdir/$@ .
+zip -r $$orig_dir/$@ .
     """.format(
         sha256 = "4c73eee92dd652ea8e2afd7b20732cf863d4938a30f634d12c88fe64def89fd8",
         version = "0.9.18",
     ),
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "sources_jar",
+    srcs = [],
+    outs = ["envoy-sources.jar"],
+    cmd = """
+orig_dir=$$PWD
+tmp_dir=$$(mktemp -d)
+cp -r library/java/src/io/envoyproxy/envoymobile/ $$tmp_dir
+cp -r library/kotlin/src/io/envoyproxy/envoymobile/ $$tmp_dir
+cd $$tmp_dir
+zip -r $$orig_dir/$@ .
+    """,
     visibility = ["//visibility:public"],
 )

--- a/library/BUILD
+++ b/library/BUILD
@@ -19,9 +19,9 @@ java -jar $$origdir/dokka.jar $$origdir/{path} -format javadoc -output $$tmp_dir
 cd $$tmp_dir
 zip -r $$origdir/$@ .
     """.format(
-        sha256="4c73eee92dd652ea8e2afd7b20732cf863d4938a30f634d12c88fe64def89fd8",
-        version="0.9.18",
-        path="./library" # This is a shortcut since we should more ideally inspect the source files from the src
+        sha256 = "4c73eee92dd652ea8e2afd7b20732cf863d4938a30f634d12c88fe64def89fd8",
+        version = "0.9.18",
+        path = "./library",  # This is a shortcut since we should more ideally inspect the source files from the src
     ),
     visibility = ["//visibility:public"],
 )

--- a/library/BUILD
+++ b/library/BUILD
@@ -13,8 +13,7 @@ genrule(
     cmd = """
 orig_dir=$$PWD
 tmp_dir=$$(mktemp -d)
-java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/java/src/ -format javadoc -output $$tmp_dir
-java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/kotlin/src/ -format javadoc -output $$tmp_dir
+java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/java/src/ $$orig_dir/library/kotlin/src/ -format javadoc -output $$tmp_dir > /dev/null
 cd $$tmp_dir
 zip -r $$orig_dir/$@ . > /dev/null
     """,

--- a/library/BUILD
+++ b/library/BUILD
@@ -13,9 +13,6 @@ genrule(
     cmd = """
 orig_dir=$$PWD
 tmp_dir=$$(mktemp -d)
-echo "~~~~~~~~~~"
-java -version
-echo "~~~~~~~~~~"
 java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/java/src/ -format javadoc -output $$tmp_dir
 java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/kotlin/src/ -format javadoc -output $$tmp_dir
 cd $$tmp_dir

--- a/library/BUILD
+++ b/library/BUILD
@@ -13,7 +13,11 @@ genrule(
     cmd = """
 orig_dir=$$PWD
 tmp_dir=$$(mktemp -d)
-java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/java/src/ $$orig_dir/library/kotlin/src/ -format javadoc -output $$tmp_dir > /dev/null
+java -jar $(location @kotlin_dokka//jar) \
+    $$orig_dir/library/java/src/ \
+    $$orig_dir/library/kotlin/src/ \
+    -format javadoc \
+    -output $$tmp_dir > /dev/null
 cd $$tmp_dir
 zip -r $$orig_dir/$@ . > /dev/null
     """,

--- a/library/BUILD
+++ b/library/BUILD
@@ -11,18 +11,14 @@ genrule(
     srcs = [],
     outs = ["envoy-javadoc.jar"],
     cmd = """
-curl -L -o dokka.jar "https://github.com/Kotlin/dokka/releases/download/{version}/dokka-fatjar-{version}.jar"
-echo "{sha256} dokka.jar" | sha256sum --check
 orig_dir=$$PWD
 tmp_dir=$$(mktemp -d)
-java -jar $$orig_dir/dokka.jar $$orig_dir/library/java/src/ -format javadoc -output $$tmp_dir
-java -jar $$orig_dir/dokka.jar $$orig_dir/library/kotlin/src/ -format javadoc -output $$tmp_dir
+java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/java/src/ -format javadoc -output $$tmp_dir
+java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/kotlin/src/ -format javadoc -output $$tmp_dir
 cd $$tmp_dir
-zip -r $$orig_dir/$@ .
-    """.format(
-        sha256 = "4c73eee92dd652ea8e2afd7b20732cf863d4938a30f634d12c88fe64def89fd8",
-        version = "0.9.18",
-    ),
+zip -r $$orig_dir/$@ . > /dev/null
+    """,
+    tools = ["@kotlin_dokka//jar"],
     visibility = ["//visibility:public"],
 )
 
@@ -36,7 +32,7 @@ tmp_dir=$$(mktemp -d)
 cp -r library/java/src/io/envoyproxy/envoymobile/ $$tmp_dir
 cp -r library/kotlin/src/io/envoyproxy/envoymobile/ $$tmp_dir
 cd $$tmp_dir
-zip -r $$orig_dir/$@ .
+zip -r $$orig_dir/$@ . > /dev/null
     """,
     visibility = ["//visibility:public"],
 )

--- a/library/BUILD
+++ b/library/BUILD
@@ -13,6 +13,9 @@ genrule(
     cmd = """
 orig_dir=$$PWD
 tmp_dir=$$(mktemp -d)
+echo "~~~~~~~~~~"
+java -version
+echo "~~~~~~~~~~"
 java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/java/src/ -format javadoc -output $$tmp_dir
 java -jar $(location @kotlin_dokka//jar) $$orig_dir/library/kotlin/src/ -format javadoc -output $$tmp_dir
 cd $$tmp_dir

--- a/library/BUILD
+++ b/library/BUILD
@@ -5,3 +5,23 @@ filegroup(
     srcs = ["proguard.txt"],
     visibility = ["//visibility:public"],
 )
+
+genrule(
+    name = "javadocs",
+    srcs = [],
+    outs = ["envoy-javadoc.jar"],
+    cmd = """
+curl -L -o dokka.jar "https://github.com/Kotlin/dokka/releases/download/{version}/dokka-fatjar-{version}.jar"
+echo "{sha256} dokka.jar" | sha256sum --check
+origdir=$$PWD
+tmp_dir=$$(mktemp -d)
+java -jar $$origdir/dokka.jar $$origdir/{path} -format javadoc -output $$tmp_dir
+cd $$tmp_dir
+zip -r $$origdir/$@ .
+    """.format(
+        sha256="4c73eee92dd652ea8e2afd7b20732cf863d4938a30f634d12c88fe64def89fd8",
+        version="0.9.18",
+        path="./library" # This is a shortcut since we should more ideally inspect the source files from the src
+    ),
+    visibility = ["//visibility:public"],
+)

--- a/library/BUILD
+++ b/library/BUILD
@@ -15,13 +15,13 @@ curl -L -o dokka.jar "https://github.com/Kotlin/dokka/releases/download/{version
 echo "{sha256} dokka.jar" | sha256sum --check
 origdir=$$PWD
 tmp_dir=$$(mktemp -d)
-java -jar $$origdir/dokka.jar $$origdir/{path} -format javadoc -output $$tmp_dir
+java -jar $$origdir/dokka.jar $$origdir/library/java/src/ -format javadoc -output $$tmp_dir
+java -jar $$origdir/dokka.jar $$origdir/library/kotlin/src/ -format javadoc -output $$tmp_dir
 cd $$tmp_dir
 zip -r $$origdir/$@ .
     """.format(
         sha256 = "4c73eee92dd652ea8e2afd7b20732cf863d4938a30f634d12c88fe64def89fd8",
         version = "0.9.18",
-        path = "./library",  # This is a shortcut since we should more ideally inspect the source files from the src
     ),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
- Using https://github.com/Kotlin/dokka/releases/tag/0.9.18 to generate `javadocs.jar` based on the `library/` directory. 
- Copying our source files into a single jar for `envoy-sources.jar`
- Zipping up the sources jar, javadocs, pom xml, and aar on `artifact.yaml`

I am using a bit of a shortcut as we are indiscriminately generating javadocs for all kotlin/java files in our directory to generate these files

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: add javadoc generation for aar
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
