### PR TITLE
ios: make stream cleanup (more) thread-safe

### DIFF
--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -53,6 +53,9 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
 /**
  * Called when the async HTTP stream is canceled.
+ * Note this callback will ALWAYS be fired if a stream is canceled, even if the request and/or
+ * response is already complete. It will fire no more than once, and no other callbacks for the
+ * stream will be issued afterwards.
  */
 @property (nonatomic, strong) void (^onCancel)();
 

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -146,7 +146,7 @@ static void ios_on_complete(void *context) {
 static void ios_on_cancel(void *context) {
   // This call is atomically gated at the call-site and will only happen once.
 
-  // The cancelation callback does not clean up the stream, since that will race with work Envoy's
+  // The cancellation callback does not clean up the stream, since that will race with work Envoy's
   // main thread may already be doing. Instead we rely on the reset that's dispatched to Envoy to
   // effect cleanup, with appropriate timing.
   ios_context *c = (ios_context *)context;

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -137,27 +137,25 @@ static void ios_on_complete(void *context) {
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
   dispatch_async(callbacks.dispatchQueue, ^{
-    if (atomic_load(c->canceled)) {
-      return;
-    }
-
+    // FIXME: If the callback queue is not serial, clean up is not currently thread-safe.
     assert(stream);
     [stream cleanUp];
   });
 }
 
 static void ios_on_cancel(void *context) {
+  // This call is atomically gated at the call-site and will only happen once.
+
+  // The cancelation callback does not clean up the stream, since that will race with work Envoy's
+  // main thread may already be doing. Instead we rely on the reset that's dispatched to Envoy to
+  // effect cleanup, with appropriate timing.
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
   dispatch_async(callbacks.dispatchQueue, ^{
-    // This call is atomically gated at the call-site and will only happen once.
     if (callbacks.onCancel) {
       callbacks.onCancel();
     }
-
-    assert(stream);
-    [stream cleanUp];
   });
 }
 
@@ -166,11 +164,7 @@ static void ios_on_error(envoy_error error, void *context) {
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
   dispatch_async(callbacks.dispatchQueue, ^{
-    if (atomic_load(c->canceled)) {
-      return;
-    }
-
-    if (callbacks.onError) {
+    if (!atomic_load(c->canceled) && callbacks.onError) {
       NSString *errorMessage = [[NSString alloc] initWithBytes:error.message.bytes
                                                         length:error.message.length
                                                       encoding:NSUTF8StringEncoding];
@@ -178,6 +172,7 @@ static void ios_on_error(envoy_error error, void *context) {
       callbacks.onError(error.error_code, errorMessage);
     }
 
+    // FIXME: If the callback queue is not serial, clean up is not currently thread-safe.
     assert(stream);
     [stream cleanUp];
   });


### PR DESCRIPTION
Description: Fixes a race in cleanup timing by ensuring cleanup is ALWAYS dispatched from Envoy's main thread to the callback thread for a given stream, AFTER reset or completion has been handled at the common layer.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
