### PR TITLE
ci: use env variables from android

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -18,6 +18,10 @@ jobs:
         run: ./ci/linux_ci_setup.sh
       - name: 'Build envoy.aar distributable'
         run: |
+          export PATH=/usr/lib/llvm-8/bin:$PATH
+          export CC=clang
+          export CXX=clang++
+          export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
           current_short_commit=$(git rev-parse --short HEAD)
           ./bazelw build \
               --config=release-android \

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - ci-use-env-variables-from-android
 
 jobs:
   master_android_dist:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ci-use-env-variables-from-android
 
 jobs:
   master_android_dist:


### PR DESCRIPTION
use env variables from android

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: use env variables from android
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
