### PR TITLE
ci: run on external PRs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,8 @@
 name: android
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   linuxdist:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,6 +1,8 @@
 name: core
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   unittests:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,8 @@
 name: format
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   formatall:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,6 +1,8 @@
 name: ios
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   macdist:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,6 +1,8 @@
 name: perf
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   sizecurrent:


### PR DESCRIPTION
This should make CI run on externally contributed PRs, rather than just PRs made from branches within this repo.

Signed-off-by: Michael Rebello <me@michaelrebello.com>