### PR TITLE
android: only fire a single 'terminal' callback per stream

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -78,7 +78,7 @@ public class EnvoyHTTPStream {
    * @return int, success unless the stream has already been canceled.
    */
   public int cancel() {
-    // Determine if this cancelation results in bidirectional signaling (i.e. if onCancel is being
+    // Determine if this cancellation results in bidirectional signaling (i.e. if onCancel is being
     // fired).
     boolean fullCancel = callbacksContext.cancel();
     // Propagate the reset into native code regardless.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -78,13 +78,12 @@ public class EnvoyHTTPStream {
    * @return int, success unless the stream has already been canceled.
    */
   public int cancel() {
-    if (callbacksContext.cancel()) {
-      // propagate the reset into native code.
-      JniLibrary.resetStream(streamHandle);
-      return 0;
-    } else {
-      return 1;
-    }
+    // Determine if this cancelation results in bidirectional signaling (i.e. if onCancel is being
+    // fired).
+    boolean fullCancel = callbacksContext.cancel();
+    // Propagate the reset into native code regardless.
+    JniLibrary.resetStream(streamHandle);
+    return fullCancel ? 0 : 1;
   }
 
   private static byte[][] toJniLibraryHeaders(Map<String, List<String>> headers) {


### PR DESCRIPTION
Description: Updates callback logic to ensure only one of any terminal callback is fired per stream/requests: one of final-onHeaders, final-onData, onTrailers, onError, and onCancel. Additionally ensures that it will be the last callback (iff provided callback dispatch is serial).
Risk: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
