### PR TITLE
android: remove kotlin bundling from aar

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,9 +131,9 @@ http_archive(
     urls = ["https://github.com/google/bazel-common/archive/413b433b91f26dbe39cdbc20f742ad6555dd1e27.zip"],
 )
 
-rules_kotlin_version = "legacy-1.3.0-rc1"
+rules_kotlin_version = "legacy-1.3.0-rc2"
 
-rules_kotlin_sha = "9de078258235ea48021830b1669bbbb678d7c3bdffd3435f4c0817c921a88e42"
+rules_kotlin_sha = "dc1c76f91228ddaf4f7ca4190b82d61939e95369f61dea715e8be28792072b1b"
 
 http_archive(
     name = "io_bazel_rules_kotlin",

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -137,7 +137,7 @@ echo "Constructing aar..."
 final_dir=$$(mktemp -d)
 cp $$classes_dir/classes.jar $$final_dir
 cd $$final_dir
-unzip $$orig_dir/$(location {jni_apk}) lib/ > /dev/null
+unzip $$orig_dir/$(location {jni_apk}) lib/* > /dev/null
 mv lib jni
 cp $$orig_dir/$(location {proguard_rules}) ./proguard.txt
 cp $$orig_dir/$(location {manifest}) AndroidManifest.xml

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -126,16 +126,23 @@ EOF
         ],
         visibility = visibility,
         cmd = """
-origdir=$$PWD
-cd $$(mktemp -d)
-unzip $$origdir/$(location :{jni_apk}) > /dev/null
+orig_dir=$$PWD
+classes_dir=$$(mktemp -d)
+echo "Creating classes.jar from {jar}"
+cd $$classes_dir
+unzip $$orig_dir/$(location {jar}) "io/envoyproxy/*" "META-INF/" > /dev/null
+zip -r classes.jar * > /dev/null
+cd $$orig_dir
+echo "Constructing aar..."
+final_dir=$$(mktemp -d)
+cp $$classes_dir/classes.jar $$final_dir
+cd $$final_dir
+unzip $$orig_dir/$(location {jni_apk}) lib/ > /dev/null
 mv lib jni
-cp $$origdir/$(location {jar}) classes.jar
-cp $$origdir/$(location {proguard_rules}) ./proguard.txt
-rm AndroidManifest.xml
-cp $$origdir/$(location {manifest}) AndroidManifest.xml
+cp $$orig_dir/$(location {proguard_rules}) ./proguard.txt
+cp $$orig_dir/$(location {manifest}) AndroidManifest.xml
 zip -r tmp.aar * > /dev/null
-cp tmp.aar $$origdir/$@
+cp tmp.aar $$orig_dir/$@
 """.format(
             manifest = manifest_name + ".xml",
             jar = android_binary_name + "_deploy.jar",


### PR DESCRIPTION
We're packaging kotlin with our aar classes.jar and in the aar itself.

This change is to remove that by manually excluding specific directories from the `deploy.jar`. Additionally, we removed some unnecessary artifacts from the aar itself. Here's what it looks like now:
```
Archive:  envoy.aar
  AndroidManifest.xml     
  classes.jar             
  jni/
  jni/armeabi-v7a/
  jni/armeabi-v7a/libenvoy_jni.so  
  jni/x86/
  jni/x86/libenvoy_jni.so  
  jni/arm64-v8a/
  jni/arm64-v8a/libenvoy_jni.so  
  proguard.txt     
```

https://developer.android.com/studio/projects/android-library
Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: remove kotlin bundling from aar
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
