### PR TITLE
config: experiment with some moderately aggressive keepalive settings

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -28,6 +28,11 @@ R"(
             - {{ domain }}
       sni: {{ domain }}
     type: LOGICAL_DNS
+    upstream_connection_options: &upstream_opts
+      tcp_keepalive:
+        keepalive_interval: 10
+        keepalive_probes: 1
+        keepalive_time: 5
   - name: base_wlan # Note: the direct API depends on the existence of a cluster with this name.
     connect_timeout: {{ connect_timeout_seconds }}s
     dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
@@ -38,6 +43,7 @@ R"(
       endpoints: *base_endpoints
     tls_context: *base_tls_context
     type: LOGICAL_DNS
+    upstream_connection_options: *upstream_opts
   - name: base_wwan # Note: the direct API depends on the existence of a cluster with this name.
     connect_timeout: {{ connect_timeout_seconds }}s
     dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
@@ -48,6 +54,7 @@ R"(
       endpoints: *base_endpoints
     tls_context: *base_tls_context
     type: LOGICAL_DNS
+    upstream_connection_options: *upstream_opts
   - name: stats
     connect_timeout: {{ connect_timeout_seconds }}s
     dns_refresh_rate: {{ dns_refresh_rate_seconds }}s


### PR DESCRIPTION
Description: Because we associate connections to a network interface heuristically and because we don't currently have a good request-independent signal for connection health (like h2 pings), TCP keepalives may be the next best thing. This change aims to address reports of hung requests by setting fairly aggressive keepalive settings to detect dead connections.

After a connection is idle for 5 seconds, we'll begin sending keepalives on a 10 second interval. If any go unacked in that interval, we'll terminate the connection.

Eventually we'll want to tune this and/or make it configurable and/or rely on something at L7 (like h2 pings).

Risk Level: Low
Testing: In the wild

Signed-off-by: Mike Schore <mike.schore@gmail.com>