### PR TITLE
Apply warnting fixits to EnvoyEngine.h

### DIFF
--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -57,7 +57,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  * response is already complete. It will fire no more than once, and no other callbacks for the
  * stream will be issued afterwards.
  */
-@property (nonatomic, strong) void (^onCancel)();
+@property (nonatomic, strong) void (^onCancel)(void);
 
 @end
 
@@ -172,7 +172,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 /**
  Run the Envoy engine with the provided configuration and log level.
 
- @param configuration The EnvoyConfiguration used to start Envoy.
+ @param config The EnvoyConfiguration used to start Envoy.
  @param logLevel The log level to use when starting Envoy.
  @return A status indicating if the action was successful.
  */


### PR DESCRIPTION
Description:

After opening `EnvoyEngine.h` in Xcode, these two warnings were shown. Applying the fixit suggestion resulted in these changes.

For the block declaration, the diagnostic was:

> This block declaration is not a prototype

I don't think that's a clear explanation. In C and ObjC, these two declarations are **not** the same:

```c
f();
f(void);
```

In C and ObjC, the first function can take _any_ arguments, so you need to use `void` to indicate the function accepts no arguments.

In C++ and ObjC++, `f()` and `f(void)` are the same, so this issue only applies to C/ObjC.

Risk Level: Low
Testing: None
Docs Changes: N/A
Release Notes: N/A
