### PR TITLE
swift: Make EnvoyError initializer public

### DIFF
--- a/library/swift/src/EnvoyError.swift
+++ b/library/swift/src/EnvoyError.swift
@@ -10,7 +10,7 @@ public final class EnvoyError: NSObject, Error {
   /// Optional cause for the error.
   public let cause: Error?
 
-  init(errorCode: UInt64, message: String, cause: Swift.Error?) {
+  public init(errorCode: UInt64, message: String, cause: Error?) {
     self.errorCode = errorCode
     self.message = message
     self.cause = cause


### PR DESCRIPTION
We have a few cases in tests where we want to allow creation of these
error types, which might warrant this being public.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>