### PR TITLE
android: extend timeout for master artifact

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -9,7 +9,7 @@ jobs:
   master_android_dist:
     name: master_android_dist
     runs-on: ubuntu-18.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Description: the android master artifact is running out of time to build. Extending the timeout to allow it to build. Ultimately we need to track this time down #634 
Risk Level: low
Testing: CI run

Signed-off-by: Jose Nino <jnino@lyft.com>