### PR TITLE
envoy: update envoy ref and move v3alpha to v3

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -19,7 +19,7 @@ static_resources:
     transport_socket: &base_transport_socket
       name: envoy.transport_sockets.tls
       typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3alpha.UpstreamTlsContext
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         common_tls_context:
           validation_context:
             trusted_ca:
@@ -74,7 +74,7 @@ stats_flush_interval: {{ stats_flush_interval_seconds }}s
 stats_sinks:
   - name: envoy.metrics_service
     typed_config:
-      "@type": type.googleapis.com/envoy.config.metrics.v3alpha.MetricsServiceConfig
+      "@type": type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig
       grpc_service:
         envoy_grpc:
           cluster_name: stats

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -37,7 +37,7 @@ public:
                 Router::ShadowWriterPtr{new NiceMock<Router::MockShadowWriter>()}, http_context_) {
     http_dispatcher_.ready(event_dispatcher_, cm_);
     ON_CALL(*cm_.conn_pool_.host_, locality())
-        .WillByDefault(ReturnRef(envoy::config::core::v3alpha::Locality().default_instance()));
+        .WillByDefault(ReturnRef(envoy::config::core::v3::Locality().default_instance()));
   }
 
   typedef struct {


### PR DESCRIPTION
Description: updating the envoy ref and moving the v3alpha config to v3.
Risk Level: low
Testing: CI and local

Signed-off-by: Jose Nino <jnino@lyft.com>