### PR TITLE
ci: change runs-on: from macOS-10.14 to -latest

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,7 +35,7 @@ jobs:
           bazel build --fat_apk_cpu=x86 //examples/kotlin/hello_world:hello_envoy_kt
   macdist:
     name: mac_dist
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
@@ -52,7 +52,7 @@ jobs:
   macjava:
     name: mac_java_helloworld
     needs: macdist
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
@@ -74,7 +74,7 @@ jobs:
   mackotlin:
     name: mac_kotlin_helloworld
     needs: macdist
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -34,7 +34,7 @@ jobs:
           path: dist/envoy_aar_sources.zip
   master_ios_dist:
     name: master_ios_dist
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
@@ -54,7 +54,7 @@ jobs:
           path: dist/ios_artifact
   master_ios_cocoapods:
     name: master_ios_cocoapods
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     needs: [master_ios_dist]
     steps:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unittests:
     name: unit_tests
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,7 +27,7 @@ jobs:
           ./tools/check_format.sh
   precommit:
     name: precommit
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   macdist:
     name: mac_dist
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
@@ -29,7 +29,7 @@ jobs:
   macswift:
     name: mac_swift_helloworld
     needs: macdist
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
@@ -57,7 +57,7 @@ jobs:
   macobjc:
     name: mac_objc_helloworld
     needs: macdist
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
@@ -84,7 +84,7 @@ jobs:
         run: 'cat /tmp/envoy.log'
   swifttests:
     name: swift_tests
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Description:

Some CI jobs for #638 failed with the cause given as:

> The macOS virtual environment has been updated to Catalina (v10.15). Starting January 15th, jobs that include the line 'runs-on: macOS-10.14' will fail to run and return a failed check suite. Please update your workflow and change the line 'runs-on: macOS-10.14' to 'runs-on: macOS-latest'.

This makes the specified changes, moving from `runs-on: macOS-10.14` to `runs-on: macOS-latest`.

Risk Level:

Maybe Low? I'd have to hear from others. It also seems like an upstream requirement.

Testing:

This PR will test mac CI jobs.

Docs Changes: N/A
Release Notes: N/A
