### PR TITLE
ios: remove domain from engine configuration

### DIFF
--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -36,7 +36,7 @@ NSString *_REQUEST_SCHEME = @"https";
 - (void)startEnvoy {
   NSLog(@"Starting Envoy...");
   NSError *error;
-  EnvoyClientBuilder *builder = [[EnvoyClientBuilder alloc] initWithDomain:_REQUEST_AUTHORITY];
+  EnvoyClientBuilder *builder = [[EnvoyClientBuilder alloc] init];
   self.envoy = [builder buildAndReturnError:&error];
   if (error) {
     NSLog(@"Starting Envoy failed: %@", error);

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -16,8 +16,7 @@ final class ViewController: UITableViewController {
     super.viewDidLoad()
     do {
       NSLog("Starting Envoy...")
-      self.envoy = try EnvoyClientBuilder(domain: kRequestAuthority)
-        .build()
+      self.envoy = try EnvoyClientBuilder().build()
     } catch let error {
       NSLog("Starting Envoy failed: \(error)")
     }

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -59,7 +59,6 @@ static_resources:
 )"
 #include "certificates.inc"
                               R"(
-        sni: {{ domain }}
     upstream_connection_options: &upstream_opts
       tcp_keepalive:
         keepalive_interval: 10

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -4,17 +4,15 @@
 
 @implementation EnvoyConfiguration
 
-- (instancetype)initWithDomain:(NSString *)domain
-                   statsDomain:(NSString *)statsDomain
-         connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
-             dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
-             statsFlushSeconds:(UInt32)statsFlushSeconds {
+- (instancetype)initWithStatsDomain:(NSString *)statsDomain
+              connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
+                  dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
+                  statsFlushSeconds:(UInt32)statsFlushSeconds {
   self = [super init];
   if (!self) {
     return nil;
   }
 
-  self.domain = domain;
   self.statsDomain = statsDomain;
   self.connectTimeoutSeconds = connectTimeoutSeconds;
   self.dnsRefreshSeconds = dnsRefreshSeconds;
@@ -24,7 +22,6 @@
 
 - (nullable NSString *)resolveTemplate:(NSString *)templateYAML {
   NSDictionary<NSString *, NSString *> *templateKeysToValues = @{
-    @"domain" : self.domain,
     @"stats_domain" : self.statsDomain,
     @"connect_timeout_seconds" :
         [NSString stringWithFormat:@"%lu", (unsigned long)self.connectTimeoutSeconds],

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -134,7 +134,6 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 /// Typed configuration that may be used for starting Envoy.
 @interface EnvoyConfiguration : NSObject
 
-@property (nonatomic, strong) NSString *domain;
 @property (nonatomic, strong) NSString *statsDomain;
 @property (nonatomic, assign) UInt32 connectTimeoutSeconds;
 @property (nonatomic, assign) UInt32 dnsRefreshSeconds;
@@ -143,11 +142,10 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 /**
  Create a new instance of the configuration.
  */
-- (instancetype)initWithDomain:(NSString *)domain
-                   statsDomain:(NSString *)statsDomain
-         connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
-             dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
-             statsFlushSeconds:(UInt32)statsFlushSeconds;
+- (instancetype)initWithStatsDomain:(NSString *)statsDomain
+              connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
+                  dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
+                  statsFlushSeconds:(UInt32)statsFlushSeconds;
 
 /**
  Resolves the provided configuration template using properties on this configuration.

--- a/library/swift/src/EnvoyClientBuilder.swift
+++ b/library/swift/src/EnvoyClientBuilder.swift
@@ -8,8 +8,8 @@ public final class EnvoyClientBuilder: NSObject {
   private var logLevel: LogLevel = .info
 
   private enum BaseConfiguration {
-    case yaml(String)
-    case domain(String)
+    case standard
+    case custom(String)
   }
 
   private var statsDomain: String = "0.0.0.0"
@@ -19,20 +19,17 @@ public final class EnvoyClientBuilder: NSObject {
 
   // MARK: - Public
 
-  /// Initialize a new builder with the provided domain.
-  ///
-  /// - parameter domain: The domain to use with Envoy (i.e., `api.foo.com`).
-  ///                     TODO: https://github.com/lyft/envoy-mobile/issues/433
-  public init(domain: String) {
-    self.base = .domain(domain)
+  /// Initialize a new builder with standard HTTP library configuration.
+  override public init() {
+    self.base = .standard
   }
 
-  /// Initialize a new builder with a full YAML configuration.
+  /// Initialize a new builder with a custom full YAML configuration.
   /// Setting other attributes in this builder will have no effect.
   ///
   /// - parameter yaml: Contents of a YAML file to use for configuration.
   public init(yaml: String) {
-    self.base = .yaml(yaml)
+    self.base = .custom(yaml)
   }
 
   /// Add a stats domain for Envoy to flush stats to.
@@ -97,11 +94,10 @@ public final class EnvoyClientBuilder: NSObject {
   public func build() throws -> EnvoyClient {
     let engine = self.engineType.init()
     switch self.base {
-    case .yaml(let yaml):
+    case .custom(let yaml):
       return EnvoyClient(configYAML: yaml, logLevel: self.logLevel, engine: engine)
-    case .domain(let domain):
-      let config = EnvoyConfiguration(domain: domain,
-                                      statsDomain: self.statsDomain,
+    case .standard:
+      let config = EnvoyConfiguration(statsDomain: self.statsDomain,
                                       connectTimeoutSeconds: self.connectTimeoutSeconds,
                                       dnsRefreshSeconds: self.dnsRefreshSeconds,
                                       statsFlushSeconds: self.statsFlushSeconds)

--- a/library/swift/src/EnvoyClientBuilder.swift
+++ b/library/swift/src/EnvoyClientBuilder.swift
@@ -20,7 +20,7 @@ public final class EnvoyClientBuilder: NSObject {
   // MARK: - Public
 
   /// Initialize a new builder with standard HTTP library configuration.
-  override public init() {
+  public override init() {
     self.base = .standard
   }
 

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -5,7 +5,6 @@ import XCTest
 private let kMockTemplate = """
 mock_template:
 - name: mock
-  domain: {{ domain }}
   stats_domain: {{ stats_domain }}
   device_os: {{ device_os }}
   connect_timeout: {{ connect_timeout_seconds }}s
@@ -62,7 +61,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = try EnvoyClientBuilder(domain: "api.foo.com")
+    _ = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addLogLevel(.trace)
       .build()
@@ -76,7 +75,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = try EnvoyClientBuilder(domain: "api.foo.com")
+    _ = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addStatsDomain("stats.foo.com")
       .build()
@@ -90,7 +89,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = try EnvoyClientBuilder(domain: "api.foo.com")
+    _ = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addConnectTimeoutSeconds(12345)
       .build()
@@ -104,7 +103,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = try EnvoyClientBuilder(domain: "api.foo.com")
+    _ = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addDNSRefreshSeconds(23)
       .build()
@@ -118,7 +117,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = try EnvoyClientBuilder(domain: "api.foo.com")
+    _ = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addStatsFlushSeconds(42)
       .build()
@@ -126,8 +125,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
   }
 
   func testResolvesYAMLWithIndividuallySetValues() throws {
-    let config = EnvoyConfiguration(domain: "api.foo.com",
-                                    statsDomain: "stats.foo.com",
+    let config = EnvoyConfiguration(statsDomain: "stats.foo.com",
                                     connectTimeoutSeconds: 200,
                                     dnsRefreshSeconds: 300,
                                     statsFlushSeconds: 400)
@@ -136,7 +134,6 @@ final class EnvoyClientBuilderTests: XCTestCase {
       return
     }
 
-    XCTAssertTrue(resolvedYAML.contains("domain: api.foo.com"))
     XCTAssertTrue(resolvedYAML.contains("stats_domain: stats.foo.com"))
     XCTAssertTrue(resolvedYAML.contains("connect_timeout: 200s"))
     XCTAssertTrue(resolvedYAML.contains("dns_refresh_rate: 300s"))
@@ -145,8 +142,7 @@ final class EnvoyClientBuilderTests: XCTestCase {
   }
 
   func testReturnsNilWhenUnresolvedValueInTemplate() {
-    let config = EnvoyConfiguration(domain: "api.foo.com",
-                                    statsDomain: "stats.foo.com",
+    let config = EnvoyConfiguration(statsDomain: "stats.foo.com",
                                     connectTimeoutSeconds: 200,
                                     dnsRefreshSeconds: 300,
                                     statsFlushSeconds: 400)

--- a/library/swift/test/EnvoyClientTests.swift
+++ b/library/swift/test/EnvoyClientTests.swift
@@ -53,7 +53,7 @@ final class EnvoyClientTests: XCTestCase {
       closeExpectation.fulfill()
     }
 
-    let envoy = try EnvoyClientBuilder(domain: "api.foo.com")
+    let envoy = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .build()
     envoy.send(expectedRequest, body: expectedData, trailers: expectedTrailers,
@@ -67,7 +67,7 @@ final class EnvoyClientTests: XCTestCase {
       method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
       .addRetryPolicy(RetryPolicy(maxRetryCount: 3, retryOn: RetryRule.allCases))
       .build()
-    let envoy = try EnvoyClientBuilder(domain: "api.foo.com")
+    let envoy = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .build()
     envoy.send(request, body: Data(), trailers: [:], handler: ResponseHandler())
@@ -79,7 +79,7 @@ final class EnvoyClientTests: XCTestCase {
     let request = RequestBuilder(
       method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
       .build()
-    let envoy = try EnvoyClientBuilder(domain: "api.foo.com")
+    let envoy = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .build()
     envoy.send(request, body: Data(), trailers: [:], handler: ResponseHandler())


### PR DESCRIPTION
Description: Removes domain from Envoy engine configuration on iOS. Dynamic forwarding is now default, and so a proper `:authority` header is all that's needed.
Risk Level: Low
Testing: Pending

Signed-off-by: Mike Schore <mike.schore@gmail.com>