### PR TITLE
android: remove domain from engine configuration

### DIFF
--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -9,7 +9,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import io.envoyproxy.envoymobile.AndroidEnvoyClientBuilder;
-import io.envoyproxy.envoymobile.Domain;
 import io.envoyproxy.envoymobile.Envoy;
 import io.envoyproxy.envoymobile.Request;
 import io.envoyproxy.envoymobile.RequestBuilder;
@@ -45,7 +44,7 @@ public class MainActivity extends Activity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    envoy = new AndroidEnvoyClientBuilder(getBaseContext(), new Domain(REQUEST_AUTHORITY)).build();
+    envoy = new AndroidEnvoyClientBuilder(getBaseContext()).build();
 
     recyclerView = findViewById(R.id.recycler_view);
     recyclerView.setLayoutManager(new LinearLayoutManager(this));

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -9,7 +9,6 @@ import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.util.Log
 import io.envoyproxy.envoymobile.AndroidEnvoyClientBuilder
-import io.envoyproxy.envoymobile.Domain
 import io.envoyproxy.envoymobile.Envoy
 import io.envoyproxy.envoymobile.RequestBuilder
 import io.envoyproxy.envoymobile.RequestMethod
@@ -41,7 +40,7 @@ class MainActivity : Activity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
 
-    envoy = AndroidEnvoyClientBuilder(baseContext, Domain(REQUEST_AUTHORITY)).build()
+    envoy = AndroidEnvoyClientBuilder(baseContext).build()
 
     recyclerView = findViewById(R.id.recycler_view) as RecyclerView
     recyclerView.layoutManager = LinearLayoutManager(this)

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -59,7 +59,6 @@ static_resources:
 )"
 #include "certificates.inc"
                               R"(
-        sni: {{ domain }}
     upstream_connection_options: &upstream_opts
       tcp_keepalive:
         keepalive_interval: 10

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -2,7 +2,6 @@ package io.envoyproxy.envoymobile.engine;
 
 public class EnvoyConfiguration {
 
-  public final String domain;
   public final String statsDomain;
   public final Integer connectTimeoutSeconds;
   public final Integer dnsRefreshSeconds;
@@ -11,18 +10,14 @@ public class EnvoyConfiguration {
   /**
    * Create an EnvoyConfiguration with a user provided configuration values.
    *
-   * @param domain                The domain to use with Envoy (i.e.,
-   *                              `api.foo.com`). TODO:
-   *                              https://github.com/lyft/envoy-mobile/issues/433
    * @param statsDomain           The domain to flush stats to.
    * @param connectTimeoutSeconds timeout for new network connections to hosts in
    *                              the cluster.
    * @param dnsRefreshSeconds     rate in seconds to refresh DNS.
    * @param statsFlushSeconds     interval at which to flush Envoy stats.
    */
-  public EnvoyConfiguration(String domain, String statsDomain, int connectTimeoutSeconds,
+  public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds,
                             int dnsRefreshSeconds, int statsFlushSeconds) {
-    this.domain = domain;
     this.statsDomain = statsDomain;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.dnsRefreshSeconds = dnsRefreshSeconds;
@@ -40,8 +35,7 @@ public class EnvoyConfiguration {
    */
   String resolveTemplate(String templateYAML) {
     String resolvedConfiguration =
-        templateYAML.replace("{{ domain }}", domain)
-            .replace("{{ stats_domain }}", String.format("%s", statsDomain))
+        templateYAML.replace("{{ stats_domain }}", String.format("%s", statsDomain))
             .replace("{{ connect_timeout_seconds }}", String.format("%s", connectTimeoutSeconds))
             .replace("{{ dns_refresh_rate_seconds }}", String.format("%s", dnsRefreshSeconds))
             .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -16,8 +16,8 @@ public class EnvoyConfiguration {
    * @param dnsRefreshSeconds     rate in seconds to refresh DNS.
    * @param statsFlushSeconds     interval at which to flush Envoy stats.
    */
-  public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds,
-                            int dnsRefreshSeconds, int statsFlushSeconds) {
+  public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds, int dnsRefreshSeconds,
+                            int statsFlushSeconds) {
     this.statsDomain = statsDomain;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.dnsRefreshSeconds = dnsRefreshSeconds;

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.api.Assertions.assertThat
 private const val TEST_CONFIG = """
 mock_template:
 - name: mock
-  domain: {{ domain }}
   stats_domain: {{ stats_domain }}
   connect_timeout: {{ connect_timeout_seconds }}s
   dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
@@ -19,10 +18,9 @@ class EnvoyConfigurationTest {
 
   @Test
   fun `resolving with default configuration resolves with values`() {
-    val envoyConfiguration = EnvoyConfiguration("api.foo.com", "stats.foo.com", 123, 234, 345)
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345)
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG)
-    assertThat(resolvedTemplate).contains("domain: api.foo.com")
     assertThat(resolvedTemplate).contains("stats_domain: stats.foo.com")
     assertThat(resolvedTemplate).contains("connect_timeout: 123s")
     assertThat(resolvedTemplate).contains("dns_refresh_rate: 234s")
@@ -33,7 +31,7 @@ class EnvoyConfigurationTest {
 
   @Test(expected = EnvoyConfiguration.ConfigurationException::class)
   fun `resolve templates with invalid templates will throw on build`() {
-    val envoyConfiguration = EnvoyConfiguration("api.foo.com", "stats.foo.com", 123, 234, 345)
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345)
 
     envoyConfiguration.resolveTemplate("{{ }}")
   }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/AndroidEnvoyClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/AndroidEnvoyClientBuilder.kt
@@ -5,7 +5,7 @@ import io.envoyproxy.envoymobile.engine.AndroidEngineImpl
 
 class AndroidEnvoyClientBuilder(
     context: Context,
-    baseConfiguration: BaseConfiguration
+    baseConfiguration: BaseConfiguration = Standard()
 ) : EnvoyClientBuilder(baseConfiguration) {
 
   init {

--- a/library/kotlin/src/io/envoyproxy/envoymobile/AndroidEnvoyClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/AndroidEnvoyClientBuilder.kt
@@ -3,7 +3,7 @@ package io.envoyproxy.envoymobile
 import android.content.Context
 import io.envoyproxy.envoymobile.engine.AndroidEngineImpl
 
-class AndroidEnvoyClientBuilder(
+class AndroidEnvoyClientBuilder @JvmOverloads constructor (
     context: Context,
     baseConfiguration: BaseConfiguration = Standard()
 ) : EnvoyClientBuilder(baseConfiguration) {

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
@@ -10,7 +10,7 @@ class Standard : BaseConfiguration()
 class Custom(val yaml: String) : BaseConfiguration()
 
 open class EnvoyClientBuilder(
-    private val configuration: BaseConfiguration
+    private val configuration: BaseConfiguration = Standard()
 ) {
   private var logLevel = LogLevel.INFO
   private var engineType: () -> EnvoyEngine = { EnvoyEngineImpl() }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
@@ -4,12 +4,10 @@ import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyEngineImpl
 
-sealed class BaseConfiguration(
-    val value: String
-)
-
-class Domain(domain: String) : BaseConfiguration(domain)
-class Yaml(yaml: String) : BaseConfiguration(yaml)
+sealed class BaseConfiguration {
+  class Standard : BaseConfiguration()
+  class Custom(val yaml: String) : BaseConfiguration()
+}
 
 open class EnvoyClientBuilder(
     private val configuration: BaseConfiguration
@@ -77,11 +75,11 @@ open class EnvoyClientBuilder(
    */
   fun build(): Envoy {
     return when (configuration) {
-      is Yaml -> {
-        return Envoy(engineType(), configuration.value, logLevel)
+      is BaseConfiguration.Custom -> {
+        return Envoy(engineType(), configuration.yaml, logLevel)
       }
-      is Domain -> {
-        Envoy(engineType(), EnvoyConfiguration(configuration.value, statsDomain, connectTimeoutSeconds, dnsRefreshSeconds, statsFlushSeconds), logLevel)
+      is BaseConfiguration.Standard -> {
+        Envoy(engineType(), EnvoyConfiguration(statsDomain, connectTimeoutSeconds, dnsRefreshSeconds, statsFlushSeconds), logLevel)
       }
     }
   }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
@@ -4,10 +4,10 @@ import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyEngineImpl
 
-sealed class BaseConfiguration {
-  class Standard : BaseConfiguration()
-  class Custom(val yaml: String) : BaseConfiguration()
-}
+sealed class BaseConfiguration
+
+class Standard : BaseConfiguration()
+class Custom(val yaml: String) : BaseConfiguration()
 
 open class EnvoyClientBuilder(
     private val configuration: BaseConfiguration
@@ -75,10 +75,10 @@ open class EnvoyClientBuilder(
    */
   fun build(): Envoy {
     return when (configuration) {
-      is BaseConfiguration.Custom -> {
+      is Custom -> {
         return Envoy(engineType(), configuration.yaml, logLevel)
       }
-      is BaseConfiguration.Standard -> {
+      is Standard -> {
         Envoy(engineType(), EnvoyConfiguration(statsDomain, connectTimeoutSeconds, dnsRefreshSeconds, statsFlushSeconds), logLevel)
       }
     }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
@@ -23,7 +23,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `adding log level builder uses log level for running Envoy`() {
-    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Custom(TEST_CONFIG))
+    clientBuilder = EnvoyClientBuilder(Custom(TEST_CONFIG))
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addLogLevel(LogLevel.DEBUG)
@@ -33,7 +33,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `specifying stats domain overrides default`() {
-    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Standard())
+    clientBuilder = EnvoyClientBuilder(Standard())
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addStatsDomain("stats.foo.com")
@@ -43,7 +43,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `specifying connection timeout overrides default`() {
-    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Standard())
+    clientBuilder = EnvoyClientBuilder(Standard())
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addConnectTimeoutSeconds(1234)
@@ -53,7 +53,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `specifying DNS refresh overrides default`() {
-    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Standard())
+    clientBuilder = EnvoyClientBuilder(Standard())
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addDNSRefreshSeconds(1234)
@@ -63,7 +63,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `specifying stats flush overrides default`() {
-    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Standard())
+    clientBuilder = EnvoyClientBuilder(Standard())
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addStatsFlushSeconds(1234)

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
@@ -23,7 +23,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `adding log level builder uses log level for running Envoy`() {
-    clientBuilder = EnvoyClientBuilder(Yaml(TEST_CONFIG))
+    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Custom(TEST_CONFIG))
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addLogLevel(LogLevel.DEBUG)
@@ -33,7 +33,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `specifying stats domain overrides default`() {
-    clientBuilder = EnvoyClientBuilder(Domain("api.foo.com"))
+    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Standard())
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addStatsDomain("stats.foo.com")
@@ -43,7 +43,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `specifying connection timeout overrides default`() {
-    clientBuilder = EnvoyClientBuilder(Domain("api.foo.com"))
+    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Standard())
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addConnectTimeoutSeconds(1234)
@@ -53,7 +53,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `specifying DNS refresh overrides default`() {
-    clientBuilder = EnvoyClientBuilder(Domain("api.foo.com"))
+    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Standard())
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addDNSRefreshSeconds(1234)
@@ -63,7 +63,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `specifying stats flush overrides default`() {
-    clientBuilder = EnvoyClientBuilder(Domain("api.foo.com"))
+    clientBuilder = EnvoyClientBuilder(BaseConfiguration.Standard())
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addStatsFlushSeconds(1234)

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -17,7 +17,7 @@ class EnvoyClientTest {
 
   private val engine = mock(EnvoyEngine::class.java)
   private val stream = mock(EnvoyHTTPStream::class.java)
-  private val config = EnvoyConfiguration("api.foo.com", "stats.foo.com", 0, 0, 0)
+  private val config = EnvoyConfiguration("stats.foo.com", 0, 0, 0)
 
   @Test
   fun `starting a stream on envoy sends headers`() {


### PR DESCRIPTION
Description: Removes domain from Envoy engine configuration on Android. Dynamic forwarding is now default, and so a proper `:authority` header is all that's needed.
Risk Level: Low
Testing: Pending

Signed-off-by: Mike Schore <mike.schore@gmail.com>