### PR TITLE
envoy: move ref back to stable

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -53,7 +53,7 @@ jobs:
         run: sleep 120
       # Check for the sentinel value that shows the app is alive and well.
       - name: 'Check liveliness'
-        run: 'cat /tmp/envoy.log'
+        run: 'cat /tmp/envoy.log | grep "Response status (1): 200"'
   macobjc:
     name: mac_objc_helloworld
     needs: macdist
@@ -81,7 +81,7 @@ jobs:
         run: sleep 120
       # Check for the sentinel value that shows the app is alive and well.
       - name: 'Check liveliness'
-        run: 'cat /tmp/envoy.log'
+        run: 'cat /tmp/envoy.log | grep "Response status (1): 200"'
   swifttests:
     name: swift_tests
     runs-on: macOS-latest


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>
Description: https://github.com/envoyproxy/envoy/pull/9618 broke the iOS build due to missing symbols. https://github.com/envoyproxy/envoy/pull/9875 fixes. However, in order to expedite a clean master branch this PR moves the Envoy ref back to a stable place. Note that [Android logging](https://github.com/envoyproxy/envoy/pull/9767) is reverted. Also note that CI for iOS was not testing for liveliness, which is how the breakage went through in the first place. This PR also fixes that.
Risk Level: low
Testing: CI

Fixes https://github.com/lyft/envoy-mobile/issues/646

Signed-off-by: Jose Nino <jnino@lyft.com>