### PR TITLE
ci: fix docs publishing

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -6,10 +6,12 @@ set -e
 
 # We need to set ENVOY_DOCS_VERSION_STRING and ENVOY_DOCS_RELEASE_LEVEL for Sphinx.
 # We also validate that the tag and version match at this point if needed.
-if [ -n "$CIRCLE_TAG" ]
+VERSION_NUMBER=$(cat VERSION)
+# Docs for release tags are reserved for vX.Y.Z versions.
+# vX.Y.Z.ddmmyy do not publish tagged docs.
+if [[ -n "$CIRCLE_TAG" ]] && [[ "${VERSION_NUMBER}" =~ ^[0-9]+\.[0-9]+\.[0-9]$ ]]
 then
   # Check the git tag matches the version number in the VERSION file.
-  VERSION_NUMBER=$(cat VERSION)
   if [ "v${VERSION_NUMBER}" != "${CIRCLE_TAG}" ]; then
     echo "Given git tag does not match the VERSION file content:"
     echo "${CIRCLE_TAG} vs $(cat VERSION)"

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -6,9 +6,10 @@ set -e
 
 # We need to set ENVOY_DOCS_VERSION_STRING and ENVOY_DOCS_RELEASE_LEVEL for Sphinx.
 # We also validate that the tag and version match at this point if needed.
-VERSION_NUMBER=$(cat VERSION)
+
 # Docs for release tags are reserved for vX.Y.Z versions.
 # vX.Y.Z.ddmmyy do not publish tagged docs.
+VERSION_NUMBER=$(cat VERSION)
 if [[ -n "$CIRCLE_TAG" ]] && [[ "${VERSION_NUMBER}" =~ ^[0-9]+\.[0-9]+\.[0-9]$ ]]
 then
   # Check the git tag matches the version number in the VERSION file.
@@ -27,8 +28,7 @@ then
   export ENVOY_BLOB_SHA="$CIRCLE_TAG"
 else
   BUILD_SHA=$(git rev-parse HEAD)
-  VERSION_NUM=$(cat VERSION)
-  export ENVOY_DOCS_VERSION_STRING="${VERSION_NUM}"-"${BUILD_SHA:0:6}"
+  export ENVOY_DOCS_VERSION_STRING="${VERSION_NUMBER}"-"${BUILD_SHA:0:6}"
   export ENVOY_DOCS_RELEASE_LEVEL=pre-release
   export ENVOY_BLOB_SHA="$BUILD_SHA"
 fi


### PR DESCRIPTION
Description: reserve tagged docs publishing for vX.Y.Z versions.
Risk Level: low. Can fix if broken without adverse consequences.
Testing: locally running the script with different conditions.

Fixes #644 

Signed-off-by: Jose Nino <jnino@lyft.com>
