### PR TITLE
update abseil to track envoy upstream

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,22 +9,26 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 http_archive(
     name = "com_google_protobuf",
     patch_args = ["-p1"],
-    patches = ["@envoy//bazel:protobuf.patch", "//bazel:protobuf.patch"],
+    patches = [
+        "@envoy//bazel:protobuf.patch",
+        "//bazel:protobuf.patch",
+    ],
     sha256 = "d7cfd31620a352b2ee8c1ed883222a0d77e44346643458e062e86b1d069ace3e",
     strip_prefix = "protobuf-3.10.1",
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protobuf-all-3.10.1.tar.gz"],
 )
 
 # Patch upstream Abseil to prevent Foundation dependency from leaking into Android builds.
-# Workaround for https://github.com/abseil/abseil-cpp/issues/326.
+# Workaround for https://gigit thub.com/abseil/abseil-cpp/issues/326.
 # TODO: Should be removed in https://github.com/lyft/envoy-mobile/issues/136 once rules_android
 # supports platform toolchains.
 http_archive(
     name = "com_google_absl",
     patches = ["//bazel:abseil.patch"],
-    sha256 = "7ddf863ddced6fa5bf7304103f9c7aa619c20a2fcf84475512c8d3834b9d14fa",
-    strip_prefix = "abseil-cpp-61c9bf3e3e1c28a4aa6d7f1be4b37fd473bb5529",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/61c9bf3e3e1c28a4aa6d7f1be4b37fd473bb5529.tar.gz"],
+    sha256 = "190b0c9e65ef0866b44c54b517b5a3e15b67a1001b34547f03f8f4d8553c2851",
+    strip_prefix = "abseil-cpp-63ee2f8877915a3565c29707dba8fe4d7822596a",
+    # 2020-01-08
+    urls = ["https://github.com/abseil/abseil-cpp/archive/63ee2f8877915a3565c29707dba8fe4d7822596a.tar.gz"],
 )
 
 # This should be kept in sync with Envoy itself, we just need to apply this patch

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ http_archive(
 )
 
 # Patch upstream Abseil to prevent Foundation dependency from leaking into Android builds.
-# Workaround for https://gigit thub.com/abseil/abseil-cpp/issues/326.
+# Workaround for https://github.com/abseil/abseil-cpp/issues/326.
 # TODO: Should be removed in https://github.com/lyft/envoy-mobile/issues/136 once rules_android
 # supports platform toolchains.
 http_archive(

--- a/bazel/abseil.patch
+++ b/bazel/abseil.patch
@@ -1,6 +1,6 @@
 --- absl/time/internal/cctz/BUILD.bazel
 +++ absl/time/internal/cctz/BUILD.bazel
-@@ -78,7 +78,7 @@ cc_library(
+@@ -76,7 +76,7 @@ cc_library(
      ],
      linkopts = select({
          ":osx": [


### PR DESCRIPTION
Description: update abseil to track upstream Envoy. This will also allow us to test @lizan's suggestion [here](https://github.com/envoyproxy/envoy/pull/9654#issuecomment-580870865)
Risk Level: low. keeps track with Envoy. 
Testing: CI

Signed-off-by: Jose Nino <jnino@lyft.com>