### PR TITLE
config: set default retry back-off policies

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -25,6 +25,10 @@ static_resources:
                     prefix: "/"
                   route:
                     cluster_header: x-envoy-mobile-cluster
+                    retry_policy:
+                      retry_back_off:
+                        base_interval: 0.25s
+                        max_interval: 60s
         http_filters:
           - name: envoy.filters.http.dynamic_forward_proxy
             typed_config:


### PR DESCRIPTION
Envoy's current retry mechanism works relatively aggressively for mobile networks. Today, it defaults to a [base retry interval of `25ms`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-retrypolicy-retry-back-off) and a [max retry interval of 10x the base interval](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto#route-retrypolicy-retrybackoff).

In order for the retry mechanism to better suit mobile networks, we are tuning these values to match some reasonable defaults in Envoy Mobile using what Lyft has historically used in production:

- Exponential back off + jittering ([implemented in Envoy](https://github.com/envoyproxy/envoy/blob/b495c36e0c583ab673915abf0b06a6e9babac9f9/source/common/router/retry_state_impl.cc#L66-L77))
- `250ms` base retry interval
- `60s` max retry interval

For more details on Envoy's back-off algorithm, see [these docs](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#config-http-filters-router-x-envoy-max-retries).

We're merging this change instead of exposing `retry_back_off` on individual request retry policies, and thus this PR resolves https://github.com/lyft/envoy-mobile/issues/587.

At some point, it may make sense to make these values tune-able via startup configuration (similarly to DNS refresh times), but it's not required for now. I've filed https://github.com/lyft/envoy-mobile/issues/655 to track this future functionality on the backlog.

Signed-off-by: Michael Rebello <me@michaelrebello.com>