### PR TITLE
stream reset: higher layers expect calling resetStream() to immediately raise reset callbacks

### DIFF
--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -195,7 +195,14 @@ Dispatcher::DirectStream::~DirectStream() {
 
 // TODO(junr03): map from StreamResetReason to Envoy Mobile's error types. Right now all resets
 // will be ENVOY_STREAM_RESET.
-void Dispatcher::DirectStream::resetStream(StreamResetReason) { callbacks_->onReset(); }
+void Dispatcher::DirectStream::resetStream(StreamResetReason reason) {
+  // The Http::ConnectionManager does not destroy the stream in doEndStream() when it calls
+  // resetStream on the response_encoder_'s Stream. It is up to the response_encoder_ to
+  // runResetCallbacks in order to have the Http::ConnectionManager call doDeferredStreamDestroy in
+  // ConnectionManagerImpl::ActiveStream::onResetStream.
+  runResetCallbacks(reason);
+  callbacks_->onReset();
+}
 
 void Dispatcher::DirectStream::closeLocal(bool end_stream) {
   // TODO: potentially guard against double local closure.


### PR DESCRIPTION
Description: Envoy's HCM expects calling resetStream() to immediately raise rest callbacks. Thus it does not do a stream destroy in `doEndStream` if it fires a reset. Instead it waits for the reset to come back. This is how the H1/2 codecs work. e.g in h2: https://github.com/envoyproxy/envoy/blob/abb1f969fe131c7a47da5c1ad1577be142e1ea8a/source/common/http/http2/codec_impl.cc#L301 and similarly in h1 (although through some indirection): https://github.com/envoyproxy/envoy/blob/abb1f969fe131c7a47da5c1ad1577be142e1ea8a/source/common/http/http1/codec_impl.cc#L798.

Previously Envoy Mobile's DirectStreams were not propagating the reset back to the HCM. Thus the HCM's ActiveStream was not getting destroyed when the App was receiving upstream resets. This would result in for example idle timers not getting disarmed, and thus firing on streams where the Envoy Mobile's DirectStream had already been destroyed. 

This change accommodates Envoy's expectations. 
Risk Level: med
Testing: #654. Run with local version of the Lyft Alpha app to verify stream destruction.

Signed-off-by: Jose Nino <jnino@lyft.com>