### PR TITLE
docs: update weekly erlease versioning

### DIFF
--- a/docs/root/development/releasing/releasing.rst
+++ b/docs/root/development/releasing/releasing.rst
@@ -43,5 +43,5 @@ Note: This last step is slated to be automated in :issue:`#624 <624>`.
 Pre-release versioning
 ======================
 
-Pre-releases are published on a weekly basis. The versioning scheme we use is ``X.Y.Z.{ddmmyy}``.
-For example: January 25, 2020: ``0.3.1.250120``.
+Pre-releases are published on a weekly basis. The versioning scheme we use is ``X.Y.Z.{mmddyy}``.
+For example: January 25, 2020: ``0.3.1.012520``.


### PR DESCRIPTION
`ddmmyy` is not monotonically increasing as months progress during the year (i.e., `January 25th, 2020` yields a version "lower" than `February 3, 2020`).

Starting with `v0.2.2`, we'll be changing the format to a monotonically increasing format of `mmddyy`.

Signed-off-by: Michael Rebello <me@michaelrebello.com>