### PR TITLE
ios/android: allow zero for total upstream timeouts

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
@@ -8,18 +8,17 @@ package io.envoyproxy.envoymobile
  * @param perRetryTimeoutMS Timeout (in milliseconds) to apply to each retry. Must be <= `totalUpstreamTimeoutMS` if it is non-zero.
  * @param totalUpstreamTimeoutMS Total timeout (in milliseconds) that includes all retries.
  * Spans the point at which the entire downstream request has been processed and when the
- * upstream response has been completely processed. Zero may be specified to disable the upstream timeout.
+ * upstream response has been completely processed. Null may be specified to disable the upstream timeout.
  */
 data class RetryPolicy(
   val maxRetryCount: Int,
   val retryOn: List<RetryRule>,
   val perRetryTimeoutMS: Long? = null,
-  val totalUpstreamTimeoutMS: Long = 15000
+  val totalUpstreamTimeoutMS: Long? = 15000
 ) {
   init {
-    if (perRetryTimeoutMS != null && perRetryTimeoutMS > totalUpstreamTimeoutMS && totalUpstreamTimeoutMS != 0L) {
-      throw IllegalArgumentException(
-        "Per-retry timeout must be <= total timeout if total timeout != 0")
+    if (perRetryTimeoutMS != null && totalUpstreamTimeoutMS != null && perRetryTimeoutMS > totalUpstreamTimeoutMS) {
+      throw IllegalArgumentException("Per-retry timeout must be <= total timeout")
     }
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
@@ -5,10 +5,10 @@ package io.envoyproxy.envoymobile
  *
  * @param maxRetryCount Maximum number of retries that a request may be performed.
  * @param retryOn Whitelist of rules used for retrying.
- * @param perRetryTimeoutMS Timeout (in milliseconds) to apply to each retry. Must be <= `totalUpstreamTimeoutMS` if it is non-zero.
+ * @param perRetryTimeoutMS Timeout (in milliseconds) to apply to each retry. Must be <= `totalUpstreamTimeoutMS` if it's a positive number.
  * @param totalUpstreamTimeoutMS Total timeout (in milliseconds) that includes all retries.
  * Spans the point at which the entire downstream request has been processed and when the
- * upstream response has been completely processed. Null or 0 may be specified to disable the upstream timeout.
+ * upstream response has been completely processed. Null or 0 may be specified to disable it.
  */
 data class RetryPolicy(
   val maxRetryCount: Int,

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
@@ -19,7 +19,7 @@ data class RetryPolicy(
   init {
     if (perRetryTimeoutMS != null && totalUpstreamTimeoutMS != null &&
         perRetryTimeoutMS > totalUpstreamTimeoutMS && totalUpstreamTimeoutMS != 0L) {
-      throw IllegalArgumentException("Per-retry timeout must be <= total timeout when != 0")
+      throw IllegalArgumentException("Per-retry timeout cannot be less than total timeout")
     }
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
@@ -8,7 +8,7 @@ package io.envoyproxy.envoymobile
  * @param perRetryTimeoutMS Timeout (in milliseconds) to apply to each retry. Must be <= `totalUpstreamTimeoutMS` if it is non-zero.
  * @param totalUpstreamTimeoutMS Total timeout (in milliseconds) that includes all retries.
  * Spans the point at which the entire downstream request has been processed and when the
- * upstream response has been completely processed. Null may be specified to disable the upstream timeout.
+ * upstream response has been completely processed. Null or 0 may be specified to disable the upstream timeout.
  */
 data class RetryPolicy(
   val maxRetryCount: Int,
@@ -17,8 +17,9 @@ data class RetryPolicy(
   val totalUpstreamTimeoutMS: Long? = 15000
 ) {
   init {
-    if (perRetryTimeoutMS != null && totalUpstreamTimeoutMS != null && perRetryTimeoutMS > totalUpstreamTimeoutMS) {
-      throw IllegalArgumentException("Per-retry timeout must be <= total timeout")
+    if (perRetryTimeoutMS != null && totalUpstreamTimeoutMS != null &&
+        perRetryTimeoutMS > totalUpstreamTimeoutMS && totalUpstreamTimeoutMS != 0L) {
+      throw IllegalArgumentException("Per-retry timeout must be <= total timeout when != 0")
     }
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
@@ -5,11 +5,10 @@ package io.envoyproxy.envoymobile
  *
  * @param maxRetryCount Maximum number of retries that a request may be performed.
  * @param retryOn Whitelist of rules used for retrying.
- * @param perRetryTimeoutMS Timeout (in milliseconds) to apply to each retry.
- *                          Must be <= `totalUpstreamTimeoutMS`.
+ * @param perRetryTimeoutMS Timeout (in milliseconds) to apply to each retry. Must be <= `totalUpstreamTimeoutMS` if it is non-zero.
  * @param totalUpstreamTimeoutMS Total timeout (in milliseconds) that includes all retries.
  * Spans the point at which the entire downstream request has been processed and when the
- * upstream response has been completely processed.
+ * upstream response has been completely processed. Zero may be specified to disable the upstream timeout.
  */
 data class RetryPolicy(
   val maxRetryCount: Int,
@@ -18,8 +17,9 @@ data class RetryPolicy(
   val totalUpstreamTimeoutMS: Long = 15000
 ) {
   init {
-    if (perRetryTimeoutMS != null && perRetryTimeoutMS > totalUpstreamTimeoutMS) {
-      throw IllegalArgumentException("Per-retry timeout must be <= total timeout")
+    if (perRetryTimeoutMS != null && perRetryTimeoutMS > totalUpstreamTimeoutMS && totalUpstreamTimeoutMS != 0L) {
+      throw IllegalArgumentException(
+        "Per-retry timeout must be <= total timeout if total timeout != 0")
     }
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicyMapper.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicyMapper.kt
@@ -6,11 +6,11 @@ package io.envoyproxy.envoymobile
  * @return The header representation of the retry policy.
  */
 internal fun RetryPolicy.outboundHeaders(): Map<String, List<String>> {
-
+  val upstreamTimeoutMS = totalUpstreamTimeoutMS ?: 0L
   val headers = mutableMapOf(
       "x-envoy-max-retries" to listOf("$maxRetryCount"),
       "x-envoy-retry-on" to retryOn.map { elm -> elm.stringValue() },
-      "x-envoy-upstream-rq-timeout-ms" to listOf("$totalUpstreamTimeoutMS")
+      "x-envoy-upstream-rq-timeout-ms" to listOf("$upstreamTimeoutMS")
   )
 
   if (perRetryTimeoutMS != null) {

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -44,12 +44,13 @@ class RetryPolicyMapperTest {
   fun `retry policy without totalUpstreamTimeoutMS should include zero ms header`() {
     val retryPolicy = RetryPolicy(
         maxRetryCount = 123,
-        retryOn = listOf(RetryRule.STATUS_5XX))
+        retryOn = listOf(RetryRule.STATUS_5XX),
+        totalUpstreamTimeoutMS = null)
 
         assertThat(retryPolicy.outboundHeaders()).isEqualTo(mapOf(
           "x-envoy-max-retries" to listOf("3"),
           "x-envoy-retry-on" to listOf("5xx"),
-          "x-envoy-upstream-rq-per-try-timeout-ms" to listOf("0"),
+          "x-envoy-upstream-rq-per-try-timeout-ms" to listOf("0")
       ))
   }
 

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -40,7 +40,20 @@ class RetryPolicyMapperTest {
     assertThat(retryPolicy.outboundHeaders()).doesNotContainKey("x-envoy-upstream-rq-per-try-timeout-ms")
   }
 
-  @Test(expected=IllegalArgumentException::class)
+  @Test
+  fun `retry policy without totalUpstreamTimeoutMS should include zero ms header`() {
+    val retryPolicy = RetryPolicy(
+        maxRetryCount = 123,
+        retryOn = listOf(RetryRule.STATUS_5XX))
+
+        assertThat(retryPolicy.outboundHeaders()).isEqualTo(mapOf(
+          "x-envoy-max-retries" to listOf("3"),
+          "x-envoy-retry-on" to listOf("5xx"),
+          "x-envoy-upstream-rq-per-try-timeout-ms" to listOf("0"),
+      ))
+  }
+
+  @Test(expected = IllegalArgumentException::class)
   fun `throws error when per-retry timeout is larger than total timeout`() {
     val retryPolicy = RetryPolicy(
         maxRetryCount = 3,

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -48,7 +48,7 @@ class RetryPolicyMapperTest {
         totalUpstreamTimeoutMS = null)
 
         assertThat(retryPolicy.outboundHeaders()).isEqualTo(mapOf(
-          "x-envoy-max-retries" to listOf("3"),
+          "x-envoy-max-retries" to listOf("123"),
           "x-envoy-retry-on" to listOf("5xx"),
           "x-envoy-upstream-rq-per-try-timeout-ms" to listOf("0")
       ))

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -50,7 +50,7 @@ class RetryPolicyMapperTest {
         assertThat(retryPolicy.outboundHeaders()).isEqualTo(mapOf(
           "x-envoy-max-retries" to listOf("123"),
           "x-envoy-retry-on" to listOf("5xx"),
-          "x-envoy-upstream-rq-per-try-timeout-ms" to listOf("0")
+          "x-envoy-upstream-rq-timeout-ms" to listOf("0")
       ))
   }
 

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -41,7 +41,7 @@ class RetryPolicyMapperTest {
   }
 
   @Test
-  fun `retry policy without totalUpstreamTimeoutMS should include zero ms header`() {
+  fun `retry policy with null totalUpstreamTimeoutMS should include zero ms header`() {
     val retryPolicy = RetryPolicy(
         maxRetryCount = 123,
         retryOn = listOf(RetryRule.STATUS_5XX),

--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -47,15 +47,15 @@ public final class RetryPolicy: NSObject {
   ///                                     retries. Spans the point at which the entire downstream
   ///                                     request has been processed and when the upstream
   ///                                     response has been completely processed.
-  ///                                     Nil may be specified to disable the upstream timeout.
+  ///                                     Nil or 0 may be specified to disable the upstream timeout.
   public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutMS: UInt? = nil,
               totalUpstreamTimeoutMS: UInt? = 15_000)
   {
     if let perRetryTimeoutMS = perRetryTimeoutMS,
       let totalUpstreamTimeoutMS = totalUpstreamTimeoutMS
     {
-      assert(perRetryTimeoutMS <= totalUpstreamTimeoutMS,
-             "Per-retry timeout must be <= total timeout")
+      assert(perRetryTimeoutMS <= totalUpstreamTimeoutMS || totalUpstreamTimeoutMS == 0,
+             "Per-retry timeout must be <= total timeout when != 0")
     }
 
     self.maxRetryCount = maxRetryCount

--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -42,12 +42,12 @@ public final class RetryPolicy: NSObject {
   ///                                     performed.
   /// - parameter retryOn:                Whitelist of rules used for retrying.
   /// - parameter perRetryTimeoutMS:      Timeout (in milliseconds) to apply to each retry. Must
-  ///                                     be <= `totalUpstreamTimeoutMS` if it is non-zero.
+  ///                                     be <= `totalUpstreamTimeoutMS` if it's a positive number.
   /// - parameter totalUpstreamTimeoutMS: Total timeout (in milliseconds) that includes all
   ///                                     retries. Spans the point at which the entire downstream
   ///                                     request has been processed and when the upstream
   ///                                     response has been completely processed.
-  ///                                     Nil or 0 may be specified to disable the upstream timeout.
+  ///                                     Nil or 0 may be specified to disable it.
   public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutMS: UInt? = nil,
               totalUpstreamTimeoutMS: UInt? = 15_000)
   {

--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -34,7 +34,7 @@ public final class RetryPolicy: NSObject {
   public let maxRetryCount: UInt
   public let retryOn: [RetryRule]
   public let perRetryTimeoutMS: UInt?
-  public let totalUpstreamTimeoutMS: UInt
+  public let totalUpstreamTimeoutMS: UInt?
 
   /// Designated initializer.
   ///
@@ -47,13 +47,15 @@ public final class RetryPolicy: NSObject {
   ///                                     retries. Spans the point at which the entire downstream
   ///                                     request has been processed and when the upstream
   ///                                     response has been completely processed.
-  ///                                     Zero may be specified to disable the upstream timeout.
+  ///                                     Nil may be specified to disable the upstream timeout.
   public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutMS: UInt? = nil,
-              totalUpstreamTimeoutMS: UInt = 15_000)
+              totalUpstreamTimeoutMS: UInt? = 15_000)
   {
-    if let perRetryTimeoutMS = perRetryTimeoutMS {
-      assert(perRetryTimeoutMS <= totalUpstreamTimeoutMS || totalUpstreamTimeoutMS == 0,
-             "Per-retry timeout must be <= total timeout if total timeout != 0")
+    if let perRetryTimeoutMS = perRetryTimeoutMS,
+      let totalUpstreamTimeoutMS = totalUpstreamTimeoutMS
+    {
+      assert(perRetryTimeoutMS <= totalUpstreamTimeoutMS,
+             "Per-retry timeout must be <= total timeout")
     }
 
     self.maxRetryCount = maxRetryCount

--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -42,17 +42,18 @@ public final class RetryPolicy: NSObject {
   ///                                     performed.
   /// - parameter retryOn:                Whitelist of rules used for retrying.
   /// - parameter perRetryTimeoutMS:      Timeout (in milliseconds) to apply to each retry. Must
-  ///                                     be <= `totalUpstreamTimeoutMS` or it will be ignored.
+  ///                                     be <= `totalUpstreamTimeoutMS` if it is non-zero.
   /// - parameter totalUpstreamTimeoutMS: Total timeout (in milliseconds) that includes all
   ///                                     retries. Spans the point at which the entire downstream
   ///                                     request has been processed and when the upstream
   ///                                     response has been completely processed.
+  ///                                     Zero may be specified to disable the upstream timeout.
   public init(maxRetryCount: UInt, retryOn: [RetryRule], perRetryTimeoutMS: UInt? = nil,
               totalUpstreamTimeoutMS: UInt = 15_000)
   {
     if let perRetryTimeoutMS = perRetryTimeoutMS {
-      assert(perRetryTimeoutMS <= totalUpstreamTimeoutMS,
-             "Per-retry timeout must be <= total timeout")
+      assert(perRetryTimeoutMS <= totalUpstreamTimeoutMS || totalUpstreamTimeoutMS == 0,
+             "Per-retry timeout must be <= total timeout if total timeout != 0")
     }
 
     self.maxRetryCount = maxRetryCount

--- a/library/swift/src/RetryPolicy.swift
+++ b/library/swift/src/RetryPolicy.swift
@@ -55,7 +55,7 @@ public final class RetryPolicy: NSObject {
       let totalUpstreamTimeoutMS = totalUpstreamTimeoutMS
     {
       assert(perRetryTimeoutMS <= totalUpstreamTimeoutMS || totalUpstreamTimeoutMS == 0,
-             "Per-retry timeout must be <= total timeout when != 0")
+             "Per-retry timeout cannot be less than total timeout")
     }
 
     self.maxRetryCount = maxRetryCount

--- a/library/swift/src/RetryPolicyMapper.swift
+++ b/library/swift/src/RetryPolicyMapper.swift
@@ -8,7 +8,7 @@ extension RetryPolicy {
       "x-envoy-retry-on": self.retryOn
         .lazy
         .map { $0.stringValue },
-      "x-envoy-upstream-rq-timeout-ms": ["\(self.totalUpstreamTimeoutMS)"],
+      "x-envoy-upstream-rq-timeout-ms": ["\(self.totalUpstreamTimeoutMS ?? 0)"],
     ]
 
     if let perRetryTimeoutMS = self.perRetryTimeoutMS {

--- a/library/swift/test/RetryPolicyMapperTests.swift
+++ b/library/swift/test/RetryPolicyMapperTests.swift
@@ -23,4 +23,9 @@ final class RetryPolicyMapperTests: XCTestCase {
     let policy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases)
     XCTAssertNil(policy.outboundHeaders()["x-envoy-upstream-rq-per-try-timeout-ms"])
   }
+
+  func testConvertingToHeadersWithoutUpstreamTimeoutIncludesZeroForTimeoutHeader() {
+    let policy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases)
+    XCTAssertEqual(["0"], policy.outboundHeaders()["x-envoy-upstream-rq-timeout-ms"])
+  }
 }

--- a/library/swift/test/RetryPolicyMapperTests.swift
+++ b/library/swift/test/RetryPolicyMapperTests.swift
@@ -25,7 +25,8 @@ final class RetryPolicyMapperTests: XCTestCase {
   }
 
   func testConvertingToHeadersWithoutUpstreamTimeoutIncludesZeroForTimeoutHeader() {
-    let policy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases)
+    let policy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases,
+                             totalUpstreamTimeoutMS: nil)
     XCTAssertEqual(["0"], policy.outboundHeaders()["x-envoy-upstream-rq-timeout-ms"])
   }
 }


### PR DESCRIPTION
We should allow zero to be specified for `totalUpstreamTimeoutMS`, which effectively [disables the upstream timeout per Envoy's docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout).

This can be useful for consumers who only want to timeout on a per-request basis (rather than timing out all retries in aggregate).

Signed-off-by: Michael Rebello <me@michaelrebello.com>