### PR TITLE
cocoapods: fix podspec file paths

### DIFF
--- a/EnvoyMobile.podspec
+++ b/EnvoyMobile.podspec
@@ -6,12 +6,12 @@ Pod::Spec.new do |s|
     s.homepage = 'https://envoy-mobile.github.io'
     s.documentation_url = 'https://envoy-mobile.github.io/docs/envoy-mobile/latest/index.html'
     s.social_media_url = 'https://twitter.com/EnvoyProxy'
-    s.license = { type: 'Apache-2.0', file: 'envoy_ios_cocoapods/LICENSE' }
+    s.license = { type: 'Apache-2.0', file: 'LICENSE' }
     s.platform = :ios, '10.0'
     s.swift_version = '5.1'
     s.libraries = 'resolv.9', 'c++'
     s.frameworks = 'SystemConfiguration'
     s.source = { http: "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_cocoapods.zip" }
-    s.vendored_frameworks = 'envoy_ios_cocoapods/Envoy.framework'
-    s.source_files = 'envoy_ios_cocoapods/Envoy.framework/Headers/*.h', 'envoy_ios_cocoapods/Envoy.framework/Swift/*.swift'
+    s.vendored_frameworks = 'Envoy.framework'
+    s.source_files = 'Envoy.framework/Headers/*.h', 'Envoy.framework/Swift/*.swift'
 end


### PR DESCRIPTION
The podspec currently expects a nested directory inside of the zip artifact generated by CI for CocoaPods. For example:

`envoy_ios_cocoapods.zip` unzips to:
`envoy_ios_cocoapods > envoy_ios_cocoapods > Envoy.framework...`

The artifact generated from CI (correctly) does not have this extra `envoy_ios_cocoapods` path.

Thus, we need to fix the podspec to reflect this file structure. The spec in this PR is what has been published as `v0.2.2`.

Signed-off-by: Michael Rebello <me@michaelrebello.com>