### PR TITLE
upstream: update Envoy to include new fixes

### DIFF
--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -262,7 +262,7 @@ envoy_status_t Dispatcher::startStream(envoy_stream_t new_stream_handle,
         std::make_unique<DirectStreamCallbacks>(*direct_stream, bridge_callbacks, *this);
 
     // Only the initial setting of the api_listener_ is guarded.
-    direct_stream->stream_decoder_ =
+    direct_stream->request_decoder_ =
         &TS_UNCHECKED_READ(api_listener_)->newStream(*direct_stream->callbacks_);
 
     Thread::ReleasableLockGuard lock(streams_lock_);
@@ -290,7 +290,7 @@ envoy_status_t Dispatcher::sendHeaders(envoy_stream_t stream, envoy_headers head
       ENVOY_LOG(debug, "[S{}] request headers for stream (end_stream={}):\n{}", stream, end_stream,
                 *internal_headers);
       attachPreferredNetwork(*internal_headers);
-      direct_stream->stream_decoder_->decodeHeaders(std::move(internal_headers), end_stream);
+      direct_stream->request_decoder_->decodeHeaders(std::move(internal_headers), end_stream);
       direct_stream->closeLocal(end_stream);
     }
   });
@@ -315,7 +315,7 @@ envoy_status_t Dispatcher::sendData(envoy_stream_t stream, envoy_data data, bool
 
       ENVOY_LOG(debug, "[S{}] request data for stream (length={} end_stream={})\n", stream,
                 data.length, end_stream);
-      direct_stream->stream_decoder_->decodeData(*buf, end_stream);
+      direct_stream->request_decoder_->decodeData(*buf, end_stream);
       direct_stream->closeLocal(end_stream);
     }
   });
@@ -339,7 +339,7 @@ envoy_status_t Dispatcher::sendTrailers(envoy_stream_t stream, envoy_headers tra
     if (direct_stream) {
       HeaderMapPtr internal_trailers = Utility::toInternalHeaders(trailers);
       ENVOY_LOG(debug, "[S{}] request trailers for stream:\n{}", stream, *internal_trailers);
-      direct_stream->stream_decoder_->decodeTrailers(std::move(internal_trailers));
+      direct_stream->request_decoder_->decodeTrailers(std::move(internal_trailers));
       direct_stream->closeLocal(true);
     }
   });

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -99,7 +99,9 @@ private:
    * DirectStreamCallbacks can continue to receive events until the remote to local stream is
    * closed, or resetStream is called.
    */
-  class DirectStreamCallbacks : public StreamEncoder, public Logger::Loggable<Logger::Id::http> {
+  class DirectStreamCallbacks : public RequestEncoder,
+                                public ResponseEncoder,
+                                public Logger::Loggable<Logger::Id::http> {
   public:
     DirectStreamCallbacks(DirectStream& direct_stream, envoy_http_callbacks bridge_callbacks,
                           Dispatcher& http_dispatcher);
@@ -108,7 +110,7 @@ private:
     void onCancel();
     void closeRemote(bool end_stream);
 
-    // StreamEncoder
+    // RequestEncoder
     void encodeHeaders(const HeaderMap& headers, bool end_stream) override;
     void encodeData(Buffer::Instance& data, bool end_stream) override;
     void encodeTrailers(const HeaderMap& trailers) override;
@@ -181,7 +183,7 @@ private:
     bool local_closed_{};
 
     // Used to issue outgoing HTTP stream operations.
-    StreamDecoder* stream_decoder_;
+    RequestDecoder* request_decoder_;
     // Used to receive incoming HTTP stream operations.
     DirectStreamCallbacksPtr callbacks_;
     Dispatcher& parent_;

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -99,9 +99,7 @@ private:
    * DirectStreamCallbacks can continue to receive events until the remote to local stream is
    * closed, or resetStream is called.
    */
-  class DirectStreamCallbacks : public RequestEncoder,
-                                public ResponseEncoder,
-                                public Logger::Loggable<Logger::Id::http> {
+  class DirectStreamCallbacks : public ResponseEncoder, public Logger::Loggable<Logger::Id::http> {
   public:
     DirectStreamCallbacks(DirectStream& direct_stream, envoy_http_callbacks bridge_callbacks,
                           Dispatcher& http_dispatcher);

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -108,7 +108,7 @@ private:
     void onCancel();
     void closeRemote(bool end_stream);
 
-    // RequestEncoder
+    // ResponseEncoder
     void encodeHeaders(const HeaderMap& headers, bool end_stream) override;
     void encodeData(Buffer::Instance& data, bool end_stream) override;
     void encodeTrailers(const HeaderMap& trailers) override;

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -42,7 +42,7 @@ public:
 
   MockApiListener api_listener_;
   MockRequestDecoder request_decoder_;
-  StreamEncoder* response_encoder_{};
+  ResponseEncoder* response_encoder_{};
   NiceMock<Event::MockDispatcher> event_dispatcher_;
   envoy_http_callbacks bridge_callbacks_;
   std::atomic<envoy_network_t> preferred_network_{ENVOY_NET_GENERIC};
@@ -77,7 +77,7 @@ TEST_F(DispatcherTest, PreferredNetwork) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -190,7 +190,7 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -261,7 +261,7 @@ TEST_F(DispatcherTest, BasicStream) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the
   // dispatcher API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -347,7 +347,7 @@ TEST_F(DispatcherTest, MultipleDataStream) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -432,7 +432,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -449,7 +449,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   // Start stream2.
   // Setup bridge_callbacks to handle the response headers.
   NiceMock<MockRequestDecoder> request_decoder2;
-  StreamEncoder* response_encoder2{};
+  ResponseEncoder* response_encoder2{};
   envoy_http_callbacks bridge_callbacks2;
   callbacks_called cc2 = {0, 0, 0, 0, 0};
   bridge_callbacks2.context = &cc2;
@@ -480,7 +480,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder2 = &encoder;
         return request_decoder2;
       }));
@@ -543,7 +543,7 @@ TEST_F(DispatcherTest, ResetStreamLocal) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -606,7 +606,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -668,7 +668,7 @@ TEST_F(DispatcherTest, StreamResetAfterOnComplete) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -740,7 +740,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRaceLocalWins) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -829,7 +829,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWinsDeletesStream) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -917,7 +917,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWins) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -1007,7 +1007,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRaceLocalWins) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -1093,7 +1093,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWinsDeletesStream) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -1178,7 +1178,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWins) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -1249,7 +1249,7 @@ TEST_F(DispatcherTest, ResetWhenRemoteClosesBeforeLocal) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -41,7 +41,7 @@ public:
   } callbacks_called;
 
   MockApiListener api_listener_;
-  MockStreamDecoder request_decoder_;
+  MockRequestDecoder request_decoder_;
   StreamEncoder* response_encoder_{};
   NiceMock<Event::MockDispatcher> event_dispatcher_;
   envoy_http_callbacks bridge_callbacks_;
@@ -77,7 +77,7 @@ TEST_F(DispatcherTest, PreferredNetwork) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -190,7 +190,7 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -261,7 +261,7 @@ TEST_F(DispatcherTest, BasicStream) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the
   // dispatcher API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -347,7 +347,7 @@ TEST_F(DispatcherTest, MultipleDataStream) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -432,7 +432,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -448,7 +448,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
 
   // Start stream2.
   // Setup bridge_callbacks to handle the response headers.
-  NiceMock<MockStreamDecoder> request_decoder2;
+  NiceMock<MockRequestDecoder> request_decoder2;
   StreamEncoder* response_encoder2{};
   envoy_http_callbacks bridge_callbacks2;
   callbacks_called cc2 = {0, 0, 0, 0, 0};
@@ -480,7 +480,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder2 = &encoder;
         return request_decoder2;
       }));
@@ -543,7 +543,7 @@ TEST_F(DispatcherTest, ResetStreamLocal) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -606,7 +606,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -668,7 +668,7 @@ TEST_F(DispatcherTest, StreamResetAfterOnComplete) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -740,7 +740,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRaceLocalWins) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -829,7 +829,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWinsDeletesStream) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -917,7 +917,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWins) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -1007,7 +1007,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRaceLocalWins) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -1093,7 +1093,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWinsDeletesStream) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -1178,7 +1178,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWins) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
@@ -1249,7 +1249,7 @@ TEST_F(DispatcherTest, ResetWhenRemoteClosesBeforeLocal) {
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
   EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
+      .WillOnce(Invoke([&](StreamEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));


### PR DESCRIPTION
Bumping to include the following fixes:
- `dns: destroy/reinitialize c-ares channel on ARES_ECONNREFUSED`: https://github.com/envoyproxy/envoy/pull/9899. This should resolve the issues we've been seeing with Envoy Mobile hanging on startup and never properly issuing requests if started in the offline state on iOS. Fixes https://github.com/lyft/envoy-mobile/issues/672, though more improvements to DNS resolution will be investigated in lyft/envoy-mobile#673
- `gzip: add force load factory declaration`: https://github.com/envoyproxy/envoy/pull/9942. This will allow us to use the gzip filter with Envoy Mobile
- `api listener: add shutdown method and call during server termination`: https://github.com/envoyproxy/envoy/pull/9959. Fixes https://github.com/lyft/envoy-mobile/issues/667. Fixes https://github.com/lyft/envoy-mobile/issues/674

Includes the following PRs to fix iOS liveliness tests as well:
- `metrics service: force link v2 config`: https://github.com/envoyproxy/envoy/pull/9875
- `config: remove ApiTypeOracle assert`: https://github.com/envoyproxy/envoy/pull/9973

Also contains necessary updates to accommodate [this change](https://github.com/envoyproxy/envoy/commit/dea4eb001f78b5beeab234c2c481fd4d28af0f3b).

Signed-off-by: Michael Rebello <me@michaelrebello.com>