### PR TITLE
core: prevent race that causes double delete of HCM ActiveStreams

### DIFF
--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -179,6 +179,7 @@ private:
     Thread::MutexBasicLockable dispatch_lock_;
     std::atomic<bool> closed_{};
     bool local_closed_{};
+    bool pending_stream_deferred_delete_{};
 
     // Used to issue outgoing HTTP stream operations.
     StreamDecoder* stream_decoder_;

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -179,7 +179,7 @@ private:
     Thread::MutexBasicLockable dispatch_lock_;
     std::atomic<bool> closed_{};
     bool local_closed_{};
-    bool pending_stream_deferred_delete_{};
+    bool hcm_stream_pending_destroy_{};
 
     // Used to issue outgoing HTTP stream operations.
     StreamDecoder* stream_decoder_;

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -142,7 +142,6 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   envoy_headers c_headers = Http::Utility::toBridgeHeaders(headers);
 
   // Create a stream.
-  Event::PostCb start_stream_post_cb;
   EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
   http_dispatcher_.sendHeaders(stream, c_headers, true);
 
@@ -151,6 +150,73 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   ASSERT_EQ(cc.on_headers_calls, 1);
   ASSERT_EQ(cc.on_data_calls, 2);
   ASSERT_EQ(cc.on_complete_calls, 1);
+}
+
+TEST_P(DispatcherIntegrationTest, RaceDoesNotCauseDoubleDeletion) {
+  ConditionalInitializer ready_ran;
+  test_server_->server().dispatcher().post([this, &ready_ran]() -> void {
+    http_dispatcher_.ready(
+        test_server_->server().dispatcher(),
+        test_server_->server().listenerManager().apiListener()->get().http()->get());
+    ready_ran.setReady();
+  });
+  ready_ran.waitReady();
+
+  http_dispatcher_.synchronizer().enable();
+
+  envoy_stream_t stream = 1;
+  // Setup bridge_callbacks to handle the response.
+  envoy_http_callbacks bridge_callbacks;
+  callbacks_called cc = {0, 0, 0, 0, 0, nullptr};
+  bridge_callbacks.context = &cc;
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void {
+    ASSERT_FALSE(end_stream);
+    Http::HeaderMapPtr response_headers = Http::Utility::toInternalHeaders(c_headers);
+    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_headers_calls++;
+  };
+  bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void {
+    if (end_stream) {
+      ASSERT_EQ(Http::Utility::convertToString(c_data), "");
+    } else {
+      ASSERT_EQ(c_data.length, 10);
+    }
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_data_calls++;
+    c_data.release(c_data.context);
+  };
+  bridge_callbacks.on_complete = [](void* context) -> void {
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_complete_calls++;
+  };
+  bridge_callbacks.on_cancel = [](void* context) -> void {
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_cancel_calls++;
+  };
+
+  // Build a set of request headers.
+  Http::TestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  envoy_headers c_headers = Http::Utility::toBridgeHeaders(headers);
+
+  // Create a stream.
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  http_dispatcher_.synchronizer().waitOn("dispatch_encode_final_data");
+  http_dispatcher_.sendHeaders(stream, c_headers, true);
+  http_dispatcher_.synchronizer().barrierOn("dispatch_encode_final_data");
+  ASSERT_EQ(cc.on_headers_calls, 1);
+  ASSERT_EQ(cc.on_data_calls, 1);
+  ASSERT_EQ(cc.on_complete_calls, 0);
+
+  ASSERT_EQ(http_dispatcher_.resetStream(stream), ENVOY_SUCCESS);
+  ASSERT_EQ(cc.on_cancel_calls, 0);
+
+  http_dispatcher_.synchronizer().waitOn("resetStream_cleanup");
+  http_dispatcher_.synchronizer().signal("dispatch_encode_final_data");
+  http_dispatcher_.synchronizer().barrierOn("resetStream_cleanup");
+  http_dispatcher_.synchronizer().signal("resetStream_cleanup");
 }
 
 } // namespace

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -211,12 +211,9 @@ TEST_P(DispatcherIntegrationTest, RaceDoesNotCauseDoubleDeletion) {
   ASSERT_EQ(cc.on_complete_calls, 0);
 
   ASSERT_EQ(http_dispatcher_.resetStream(stream), ENVOY_SUCCESS);
-  ASSERT_EQ(cc.on_cancel_calls, 0);
+  ASSERT_EQ(cc.on_cancel_calls, 1);
 
-  http_dispatcher_.synchronizer().waitOn("resetStream_cleanup");
   http_dispatcher_.synchronizer().signal("dispatch_encode_final_data");
-  http_dispatcher_.synchronizer().barrierOn("resetStream_cleanup");
-  http_dispatcher_.synchronizer().signal("resetStream_cleanup");
 }
 
 } // namespace


### PR DESCRIPTION
Description: previously Envoy Mobile was not guarded against a race that resulted in a double deletion of an Http::ConnectionManagerImpl::ActiveStream. This PR creates state that protects against that race.
Risk Level: low, integration test reproe'd the stack trace, and then updated prod code fixed as expected.
Testing: new integration test.

Fixes #668 

Signed-off-by: Jose Nino <jnino@lyft.com>