### PR TITLE
git: ignore certificates file for repo language composition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+library/common/certificates.inc linguist-vendored


### PR DESCRIPTION
Description: remove certificates.inc from language composition.
Risk Level: low
Testing: locally ran github-linguist

Signed-off-by: Jose Nino <jnino@lyft.com>
