### PR TITLE
ci: increase timeout for android master release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   android_aar_sonatype_deploy:
     name: android_deploy
     runs-on: ubuntu-18.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Description: this job keeps timing out #634 for long term solution
Risk Level: low

Signed-off-by: Jose Nino <jnino@lyft.com>