### PR TITLE
ci: only build artifacts on commits that affect the VERSION file

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - VERSION
 
 jobs:
   master_android_dist:


### PR DESCRIPTION
Description: only version bumps are used on clients. Therefore, this PR makes it so that the jobs on the artifacts.yml workflow only run when the VERSION file changes. This should save some CI time.
Risk Level: low

Signed-off-by: Jose Nino <jnino@lyft.com>