### PR TITLE
dispatcher: update to use new internal header map types

### DIFF
--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -318,7 +318,7 @@ envoy_status_t Dispatcher::sendHeaders(envoy_stream_t stream, envoy_headers head
     // from the caller.
     // https://github.com/lyft/envoy-mobile/issues/301
     if (direct_stream) {
-      HeaderMapPtr internal_headers = Utility::toInternalHeaders(headers);
+      RequestHeaderMapPtr internal_headers = Utility::toRequestHeaders(headers);
       ENVOY_LOG(debug, "[S{}] request headers for stream (end_stream={}):\n{}", stream, end_stream,
                 *internal_headers);
       attachPreferredNetwork(*internal_headers);
@@ -370,7 +370,7 @@ envoy_status_t Dispatcher::sendTrailers(envoy_stream_t stream, envoy_headers tra
     // from the caller.
     // https://github.com/lyft/envoy-mobile/issues/301
     if (direct_stream) {
-      HeaderMapPtr internal_trailers = Utility::toInternalHeaders(trailers);
+      RequestTrailerMapPtr internal_trailers = Utility::toRequestTrailers(trailers);
       ENVOY_LOG(debug, "[S{}] request trailers for stream:\n{}", stream, *internal_trailers);
       direct_stream->request_decoder_->decodeTrailers(std::move(internal_trailers));
       direct_stream->closeLocal(true);

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -21,15 +21,15 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
   return transformed_headers;
 }
 
-RequestTrailerMapPtr toRequestTrailers(envoy_headers headers) {
-  RequestTrailerMapPtr transformed_headers = std::make_unique<RequestTrailerMapImpl>();
-  for (envoy_header_size_t i = 0; i < headers.length; i++) {
-    transformed_headers->addCopy(LowerCaseString(convertToString(headers.headers[i].key)),
-                                 convertToString(headers.headers[i].value));
+RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
+  RequestTrailerMapPtr transformed_trailers = std::make_unique<RequestTrailerMapImpl>();
+  for (envoy_header_size_t i = 0; i < trailers.length; i++) {
+    transformed_trailers->addCopy(LowerCaseString(convertToString(trailers.headers[i].key)),
+                                 convertToString(trailers.headers[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
-  release_envoy_headers(headers);
-  return transformed_headers;
+  release_envoy_headers(trailers);
+  return transformed_trailers;
 }
 
 envoy_headers toBridgeHeaders(const HeaderMap& header_map) {

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -25,7 +25,7 @@ RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
   RequestTrailerMapPtr transformed_trailers = std::make_unique<RequestTrailerMapImpl>();
   for (envoy_header_size_t i = 0; i < trailers.length; i++) {
     transformed_trailers->addCopy(LowerCaseString(convertToString(trailers.headers[i].key)),
-                                 convertToString(trailers.headers[i].value));
+                                  convertToString(trailers.headers[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(trailers);

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -10,8 +10,19 @@ std::string convertToString(envoy_data s) {
   return std::string(reinterpret_cast<char*>(const_cast<uint8_t*>(s.bytes)), s.length);
 }
 
-HeaderMapPtr toInternalHeaders(envoy_headers headers) {
-  Http::HeaderMapPtr transformed_headers = std::make_unique<HeaderMapImpl>();
+RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
+  RequestHeaderMapPtr transformed_headers = std::make_unique<RequestHeaderMapImpl>();
+  for (envoy_header_size_t i = 0; i < headers.length; i++) {
+    transformed_headers->addCopy(LowerCaseString(convertToString(headers.headers[i].key)),
+                                 convertToString(headers.headers[i].value));
+  }
+  // The C envoy_headers struct can be released now because the headers have been copied.
+  release_envoy_headers(headers);
+  return transformed_headers;
+}
+
+RequestTrailerMapPtr toRequestTrailers(envoy_headers headers) {
+  RequestTrailerMapPtr transformed_headers = std::make_unique<RequestTrailerMapImpl>();
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(LowerCaseString(convertToString(headers.headers[i].key)),
                                  convertToString(headers.headers[i].value));

--- a/library/common/http/header_utility.h
+++ b/library/common/http/header_utility.h
@@ -20,7 +20,7 @@ std::string convertToString(envoy_data s);
  * Transform envoy_headers to RequestHeaderMap.
  * This function copies the content.
  * @param headers, the envoy_headers to transform.
- * @return HeaderMapPtr, the HeaderMap 1:1 transformation of the headers param.
+ * @return RequestHeaderMapPtr, the RequestHeaderMap 1:1 transformation of the headers param.
  */
 RequestHeaderMapPtr toRequestHeaders(envoy_headers headers);
 
@@ -28,7 +28,7 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers);
  * Transform envoy_headers to RequestHeaderMap.
  * This function copies the content.
  * @param headers, the envoy_headers to transform.
- * @return HeaderMapPtr, the HeaderMap 1:1 transformation of the headers param.
+ * @return RequestTrailerMapPtr, the RequestTrailerMap 1:1 transformation of the headers param.
  */
 RequestTrailerMapPtr toRequestTrailers(envoy_headers headers);
 

--- a/library/common/http/header_utility.h
+++ b/library/common/http/header_utility.h
@@ -17,12 +17,20 @@ namespace Utility {
 std::string convertToString(envoy_data s);
 
 /**
- * Transform envoy_headers to HeaderMap.
+ * Transform envoy_headers to RequestHeaderMap.
  * This function copies the content.
  * @param headers, the envoy_headers to transform.
  * @return HeaderMapPtr, the HeaderMap 1:1 transformation of the headers param.
  */
-HeaderMapPtr toInternalHeaders(envoy_headers headers);
+RequestHeaderMapPtr toRequestHeaders(envoy_headers headers);
+
+/**
+ * Transform envoy_headers to RequestHeaderMap.
+ * This function copies the content.
+ * @param headers, the envoy_headers to transform.
+ * @return HeaderMapPtr, the HeaderMap 1:1 transformation of the headers param.
+ */
+RequestTrailerMapPtr toRequestTrailers(envoy_headers headers);
 
 /**
  * Transform envoy_headers to HeaderMap.

--- a/library/common/http/header_utility.h
+++ b/library/common/http/header_utility.h
@@ -27,10 +27,10 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers);
 /**
  * Transform envoy_headers to RequestHeaderMap.
  * This function copies the content.
- * @param headers, the envoy_headers to transform.
+ * @param trailers, the envoy_headers (trailers) to transform.
  * @return RequestTrailerMapPtr, the RequestTrailerMap 1:1 transformation of the headers param.
  */
-RequestTrailerMapPtr toRequestTrailers(envoy_headers headers);
+RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers);
 
 /**
  * Transform envoy_headers to HeaderMap.

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -32,8 +32,8 @@ namespace Http {
 ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   ResponseHeaderMapPtr transformed_headers = std::make_unique<RequestHeaderMapImpl>();
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
-    transformed_headers->addCopy(LowerCaseString(convertToString(headers.headers[i].key)),
-                                 convertToString(headers.headers[i].value));
+    transformed_headers->addCopy(LowerCaseString(Utility::convertToString(headers.headers[i].key)),
+                                 Utility::convertToString(headers.headers[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -28,6 +28,18 @@ using testing::WithArg;
 namespace Envoy {
 namespace Http {
 
+// Based on Http::Utility::toRequestHeaders() but only used for these tests.
+ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
+  ResponseHeaderMapPtr transformed_headers = std::make_unique<RequestHeaderMapImpl>();
+  for (envoy_header_size_t i = 0; i < headers.length; i++) {
+    transformed_headers->addCopy(LowerCaseString(convertToString(headers.headers[i].key)),
+                                 convertToString(headers.headers[i].value));
+  }
+  // The C envoy_headers struct can be released now because the headers have been copied.
+  release_envoy_headers(headers);
+  return transformed_headers;
+}
+
 class DispatcherTest : public testing::Test {
 public:
   DispatcherTest() { http_dispatcher_.ready(event_dispatcher_, api_listener_); }
@@ -58,7 +70,7 @@ TEST_F(DispatcherTest, PreferredNetwork) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -166,7 +178,7 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -226,7 +238,7 @@ TEST_F(DispatcherTest, BasicStream) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_FALSE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -309,7 +321,7 @@ TEST_F(DispatcherTest, MultipleDataStream) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_FALSE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -408,7 +420,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -456,7 +468,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   bridge_callbacks2.on_headers = [](envoy_headers c_headers, bool end_stream,
                                     void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     bool* on_headers_called2 = static_cast<bool*>(context);
     *on_headers_called2 = true;
@@ -574,7 +586,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_FALSE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -644,7 +656,7 @@ TEST_F(DispatcherTest, StreamResetAfterOnComplete) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -706,7 +718,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRaceLocalWins) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -795,7 +807,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWinsDeletesStream) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -883,7 +895,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWins) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -973,7 +985,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRaceLocalWins) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -1059,7 +1071,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWinsDeletesStream) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -1144,7 +1156,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWins) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -1230,7 +1242,7 @@ TEST_F(DispatcherTest, ResetWhenRemoteClosesBeforeLocal) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_TRUE(end_stream);
-    HeaderMapPtr response_headers = Utility::toInternalHeaders(c_headers);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -30,7 +30,7 @@ namespace Http {
 
 // Based on Http::Utility::toRequestHeaders() but only used for these tests.
 ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
-  ResponseHeaderMapPtr transformed_headers = std::make_unique<RequestHeaderMapImpl>();
+  ResponseHeaderMapPtr transformed_headers = std::make_unique<ResponseHeaderMapImpl>();
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(LowerCaseString(Utility::convertToString(headers.headers[i].key)),
                                  Utility::convertToString(headers.headers[i].value));

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -51,7 +51,7 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
   }
 
   envoy_headers c_headers = {static_cast<envoy_header_size_t>(headers.size()), header_array};
-  // This copy is used for assertions given that envoy_headers are released when toInternalHeaders
+  // This copy is used for assertions given that envoy_headers are released when toRequestHeaders
   // is called.
   envoy_headers c_headers_copy = copy_envoy_headers(c_headers);
 
@@ -92,7 +92,7 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
   }
 
   envoy_headers c_trailers = {static_cast<envoy_header_size_t>(trailers.size()), header_array};
-  // This copy is used for assertions given that envoy_trailers are released when toInternalHeaders
+  // This copy is used for assertions given that envoy_trailers are released when toRequestTrailers
   // is called.
   envoy_headers c_trailers_copy = copy_envoy_headers(c_trailers);
 

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -16,16 +16,25 @@ envoy_data envoyTestString(std::string& s, uint32_t* sentinel) {
   return {s.size(), reinterpret_cast<const uint8_t*>(s.c_str()), envoy_test_release, sentinel};
 }
 
-TEST(HeaderDataConstructorTest, FromCToCppEmpty) {
+TEST(RequestHeaderDataConstructorTest, FromCToCppEmpty) {
   envoy_header* header_array = new envoy_header[0];
   envoy_headers empty_headers = {0, header_array};
 
-  HeaderMapPtr cpp_headers = Utility::toInternalHeaders(empty_headers);
+  RequestHeaderMapPtr cpp_headers = Utility::toRequestHeaders(empty_headers);
 
   ASSERT_TRUE(cpp_headers->empty());
 }
 
-TEST(HeaderDataConstructorTest, FromCToCpp) {
+TEST(RequestTrailerDataConstructorTest, FromCToCppEmpty) {
+  envoy_header* header_array = new envoy_header[0];
+  envoy_headers empty_trailers = {0, header_array};
+
+  RequestTrailerMapPtr cpp_trailers = Utility::toRequestTrailers(empty_trailers);
+
+  ASSERT_TRUE(cpp_trailers->empty());
+}
+
+TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
   // Backing strings for all the envoy_datas in the c_headers.
   std::vector<std::pair<std::string, std::string>> headers = {
       {":method", "GET"}, {":scheme", "https"}, {":authority", "api.lyft.com"}, {":path", "/ping"}};
@@ -46,7 +55,7 @@ TEST(HeaderDataConstructorTest, FromCToCpp) {
   // is called.
   envoy_headers c_headers_copy = copy_envoy_headers(c_headers);
 
-  HeaderMapPtr cpp_headers = Utility::toInternalHeaders(c_headers);
+  RequestHeaderMapPtr cpp_headers = Utility::toRequestHeaders(c_headers);
 
   // Check that the sentinel was advance due to c_headers being released;
   ASSERT_EQ(*sentinel, 2 * c_headers_copy.length);
@@ -63,6 +72,47 @@ TEST(HeaderDataConstructorTest, FromCToCpp) {
     EXPECT_EQ(cpp_headers->get(expected_key)->value().getStringView(), expected_value);
   }
   release_envoy_headers(c_headers_copy);
+  delete sentinel;
+}
+
+TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
+  // Backing strings for all the envoy_datas in the c_trailers.
+  std::vector<std::pair<std::string, std::string>> trailers = {
+      {"processing-duration-ms", "25"}, {"response-compression-ratio", "0.61"}};
+
+  envoy_header* header_array = new envoy_header[trailers.size()];
+
+  uint32_t* sentinel = new uint32_t;
+  *sentinel = 0;
+  for (size_t i = 0; i < trailers.size(); i++) {
+    header_array[i] = {
+        envoyTestString(trailers[i].first, sentinel),
+        envoyTestString(trailers[i].second, sentinel),
+    };
+  }
+
+  envoy_headers c_trailers = {static_cast<envoy_header_size_t>(trailers.size()), header_array};
+  // This copy is used for assertions given that envoy_trailers are released when toInternalHeaders
+  // is called.
+  envoy_headers c_trailers_copy = copy_envoy_headers(c_trailers);
+
+  RequestTrailerMapPtr cpp_trailers = Utility::toRequestTrailers(c_trailers);
+
+  // Check that the sentinel was advance due to c_trailers being released;
+  ASSERT_EQ(*sentinel, 2 * c_trailers_copy.length);
+
+  ASSERT_EQ(cpp_trailers->size(), c_trailers_copy.length);
+
+  for (envoy_header_size_t i = 0; i < c_trailers_copy.length; i++) {
+    auto expected_key = LowerCaseString(Utility::convertToString(c_trailers_copy.headers[i].key));
+    auto expected_value = Utility::convertToString(c_trailers_copy.headers[i].value);
+
+    // Key is present.
+    EXPECT_NE(cpp_trailers->get(expected_key), nullptr);
+    // Value for the key is the same.
+    EXPECT_EQ(cpp_trailers->get(expected_key)->value().getStringView(), expected_value);
+  }
+  release_envoy_headers(c_trailers_copy);
   delete sentinel;
 }
 

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -20,8 +20,9 @@ namespace {
 Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   Http::ResponseHeaderMapPtr transformed_headers = std::make_unique<Http::ResponseHeaderMapImpl>();
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
-    transformed_headers->addCopy(Http::LowerCaseString(Http::Utility::convertToString(headers.headers[i].key)),
-                                 Http::Utility::convertToString(headers.headers[i].value));
+    transformed_headers->addCopy(
+        Http::LowerCaseString(Http::Utility::convertToString(headers.headers[i].key)),
+        Http::Utility::convertToString(headers.headers[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -16,6 +16,18 @@ using testing::ReturnRef;
 namespace Envoy {
 namespace {
 
+// Based on Http::Utility::toRequestHeaders() but only used for these tests.
+Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
+  Http::ResponseHeaderMapPtr transformed_headers = std::make_unique<Http::ResponseHeaderMapImpl>();
+  for (envoy_header_size_t i = 0; i < headers.length; i++) {
+    transformed_headers->addCopy(Http::LowerCaseString(Http::Utility::convertToString(headers.headers[i].key)),
+                                 Http::Utility::convertToString(headers.headers[i].value));
+  }
+  // The C envoy_headers struct can be released now because the headers have been copied.
+  release_envoy_headers(headers);
+  return transformed_headers;
+}
+
 typedef struct {
   uint32_t on_headers_calls;
   uint32_t on_data_calls;
@@ -115,7 +127,7 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_FALSE(end_stream);
-    Http::HeaderMapPtr response_headers = Http::Utility::toInternalHeaders(c_headers);
+    Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
@@ -172,7 +184,7 @@ TEST_P(DispatcherIntegrationTest, RaceDoesNotCauseDoubleDeletion) {
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void {
     ASSERT_FALSE(end_stream);
-    Http::HeaderMapPtr response_headers = Http::Utility::toInternalHeaders(c_headers);
+    Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;


### PR DESCRIPTION
Description: Update to use new internal types in Envoy.
Risk: Low
Testing: Unit and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
