### PR TITLE
core: remove envoy_stream_options

### DIFF
--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -286,8 +286,7 @@ Dispatcher::Dispatcher(std::atomic<envoy_network_t>& preferred_network)
       address_(std::make_shared<Network::Address::SyntheticAddressImpl>()) {}
 
 envoy_status_t Dispatcher::startStream(envoy_stream_t new_stream_handle,
-                                       envoy_http_callbacks bridge_callbacks,
-                                       envoy_stream_options) {
+                                       envoy_http_callbacks bridge_callbacks) {
   post([this, new_stream_handle, bridge_callbacks]() -> void {
     Dispatcher::DirectStreamSharedPtr direct_stream{new DirectStream(new_stream_handle, *this)};
     direct_stream->callbacks_ =

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -37,11 +37,9 @@ public:
    * there is no guarantee it will ever functionally represent an open stream.
    * @param stream, the stream to start.
    * @param bridge_callbacks, wrapper for callbacks for events on this stream.
-   * @param stream_options, the config options to start the stream with.
    * @return envoy_stream_t handle to the stream being created.
    */
-  envoy_status_t startStream(envoy_stream_t stream, envoy_http_callbacks bridge_callbacks,
-                             envoy_stream_options stream_options);
+  envoy_status_t startStream(envoy_stream_t stream, envoy_http_callbacks bridge_callbacks);
 
   /**
    * Send headers over an open HTTP stream. This method can be invoked once and needs to be called

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -293,7 +293,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_startStream(
-    JNIEnv* env, jclass, jlong stream_handle, jobject j_context, jboolean buffer_for_retry) {
+    JNIEnv* env, jclass, jlong stream_handle, jobject j_context) {
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
 
@@ -302,9 +302,8 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   envoy_http_callbacks native_callbacks = {jvm_on_headers,  jvm_on_data,     jvm_on_metadata,
                                            jvm_on_trailers, jvm_on_error,    jvm_on_complete,
                                            jvm_on_cancel,   retained_context};
-  envoy_stream_options stream_options = {buffer_for_retry == JNI_TRUE ? true : false};
   envoy_status_t result =
-      start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks, stream_options);
+      start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks);
   if (result != ENVOY_SUCCESS) {
     env->DeleteGlobalRef(retained_context); // No callbacks are fired and we need to release
   }

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -13,10 +13,9 @@ static std::atomic<envoy_network_t> preferred_network_{ENVOY_NET_GENERIC};
 
 envoy_stream_t init_stream(envoy_engine_t) { return current_stream_handle_++; }
 
-envoy_status_t start_stream(envoy_stream_t stream, envoy_http_callbacks callbacks,
-                            envoy_stream_options stream_options) {
+envoy_status_t start_stream(envoy_stream_t stream, envoy_http_callbacks callbacks) {
   if (auto e = engine_.lock()) {
-    return e->httpDispatcher().startStream(stream, callbacks, stream_options);
+    return e->httpDispatcher().startStream(stream, callbacks);
   }
   return ENVOY_FAILURE;
 }

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -30,11 +30,9 @@ envoy_stream_t init_stream(envoy_engine_t);
  * can occur.
  * @param stream, handle to the stream to be started.
  * @param callbacks, the callbacks that will run the stream callbacks.
- * @param options, DEPRECATED.
  * @return envoy_stream, with a stream handle and a success status, or a failure status.
  */
-envoy_status_t start_stream(envoy_stream_t, envoy_http_callbacks callbacks,
-                            envoy_stream_options stream_options);
+envoy_status_t start_stream(envoy_stream_t, envoy_http_callbacks callbacks);
 
 /**
  * Send headers over an open HTTP stream. This method can be invoked once and needs to be called

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -140,10 +140,6 @@ typedef struct {
   envoy_data message;
 } envoy_error;
 
-typedef struct {
-  bool buffer_body_for_retry;
-} envoy_stream_options;
-
 #ifdef __cplusplus
 extern "C" { // function pointers
 #endif

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -6,13 +6,10 @@ public interface EnvoyEngine {
   /**
    * Creates a new stream with the provided callbacks.
    *
-   * @param callbacks      The callbacks for receiving callbacks from the stream.
-   * @param bufferForRetry Whether this stream should be buffered to support
-   *                       future retries. Must be true for requests that support
-   *                       retrying.
+   * @param callbacks The callbacks for receiving callbacks from the stream.
    * @return A stream that may be used for sending data.
    */
-  EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks, boolean bufferForRetry);
+  EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks);
 
   /**
    * Run the Envoy engine with the provided yaml string and log level.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -14,16 +14,13 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   /**
    * Creates a new stream with the provided callbacks.
    *
-   * @param callbacks      The callbacks for the stream.
-   * @param bufferForRetry Whether this stream should be buffered to support
-   *                       future retries. Must be true for requests that support
-   *                       retrying.
+   * @param callbacks The callbacks for the stream.
    * @return A stream that may be used for sending data.
    */
   @Override
-  public EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks, boolean bufferForRetry) {
+  public EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks) {
     long streamHandle = JniLibrary.initStream(engineHandle);
-    return new EnvoyHTTPStream(streamHandle, callbacks, bufferForRetry);
+    return new EnvoyHTTPStream(streamHandle, callbacks);
   }
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -13,10 +13,10 @@ public class EnvoyHTTPStream {
   private final long streamHandle;
   private final JvmCallbackContext callbacksContext;
 
-  EnvoyHTTPStream(long streamHandle, EnvoyHTTPCallbacks callbacks, boolean bufferForRetry) {
+  EnvoyHTTPStream(long streamHandle, EnvoyHTTPCallbacks callbacks) {
     this.streamHandle = streamHandle;
     callbacksContext = new JvmCallbackContext(callbacks);
-    JniLibrary.startStream(streamHandle, callbacksContext, bufferForRetry);
+    JniLibrary.startStream(streamHandle, callbacksContext);
   }
 
   /**
@@ -77,7 +77,9 @@ public class EnvoyHTTPStream {
    *
    * @return int, success unless the stream has already been canceled.
    */
-  public int cancel() { return JniLibrary.resetStream(streamHandle); }
+  public int cancel() {
+    return JniLibrary.resetStream(streamHandle);
+  }
 
   private static byte[][] toJniLibraryHeaders(Map<String, List<String>> headers) {
     // Create array with some room for potential headers that have more than one

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -77,9 +77,7 @@ public class EnvoyHTTPStream {
    *
    * @return int, success unless the stream has already been canceled.
    */
-  public int cancel() {
-    return JniLibrary.resetStream(streamHandle);
-  }
+  public int cancel() { return JniLibrary.resetStream(streamHandle); }
 
   private static byte[][] toJniLibraryHeaders(Map<String, List<String>> headers) {
     // Create array with some room for potential headers that have more than one

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -35,9 +35,7 @@ class JniLibrary {
   // dependencies are loaded and initialized at most once.
   private static class JavaLoader {
 
-    private JavaLoader() {
-      System.loadLibrary(ENVOY_JNI);
-    }
+    private JavaLoader() { System.loadLibrary(ENVOY_JNI); }
   }
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -35,7 +35,9 @@ class JniLibrary {
   // dependencies are loaded and initialized at most once.
   private static class JavaLoader {
 
-    private JavaLoader() { System.loadLibrary(ENVOY_JNI); }
+    private JavaLoader() {
+      System.loadLibrary(ENVOY_JNI);
+    }
   }
 
   /**
@@ -50,17 +52,13 @@ class JniLibrary {
    * Open an underlying HTTP stream. Note: Streams must be started before other
    * other interaction can can occur.
    *
-   * @param stream,        handle to the stream to be started.
-   * @param context,       context that contains dispatch logic to fire callbacks
-   *                       callbacks.
-   * @param bufferForRetry Whether this stream should be buffered to support
-   *                       future retries. Must be true for requests that support
-   *                       retrying.
+   * @param stream,  handle to the stream to be started.
+   * @param context, context that contains dispatch logic to fire callbacks
+   *                 callbacks.
    * @return envoy_stream, with a stream handle and a success status, or a failure
    *         status.
    */
-  protected static native int startStream(long stream, JvmCallbackContext context,
-                                          boolean bufferForRetry);
+  protected static native int startStream(long stream, JvmCallbackContext context);
 
   /**
    * Send headers over an open HTTP stream. This method can be invoked once and

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClient.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClient.kt
@@ -21,10 +21,10 @@ enum class LogLevel(internal val level: String) {
  * Wrapper class that allows for easy calling of Envoy's JNI interface in native Java.
  */
 class Envoy private constructor(
-    private val engine: EnvoyEngine,
-    internal val envoyConfiguration: EnvoyConfiguration?,
-    internal val configurationYAML: String?,
-    internal val logLevel: LogLevel
+  private val engine: EnvoyEngine,
+  internal val envoyConfiguration: EnvoyConfiguration?,
+  internal val configurationYAML: String?,
+  internal val logLevel: LogLevel
 ) : HTTPClient {
 
   constructor(engine: EnvoyEngine, envoyConfiguration: EnvoyConfiguration, logLevel: LogLevel = LogLevel.INFO) : this(engine, envoyConfiguration, null, logLevel)
@@ -36,13 +36,13 @@ class Envoy private constructor(
   init {
     if (envoyConfiguration == null) {
       engine.runWithConfig(configurationYAML, logLevel.level)
-    }else {
+    } else {
       engine.runWithConfig(envoyConfiguration, logLevel.level)
     }
   }
 
   override fun send(request: Request, responseHandler: ResponseHandler): StreamEmitter {
-    val stream = engine.startStream(responseHandler.underlyingCallbacks, request.retryPolicy != null)
+    val stream = engine.startStream(responseHandler.underlyingCallbacks)
     stream.sendHeaders(request.outboundHeaders(), false)
     return EnvoyStreamEmitter(stream)
   }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -3,15 +3,14 @@ package io.envoyproxy.envoymobile
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyHTTPStream
+import java.nio.ByteBuffer
+import java.util.concurrent.Executor
 import org.junit.Test
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import java.nio.ByteBuffer
-import java.util.concurrent.Executor
 
 class EnvoyClientTest {
 
@@ -21,7 +20,7 @@ class EnvoyClientTest {
 
   @Test
   fun `starting a stream on envoy sends headers`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val expectedHeaders = mapOf(
@@ -46,7 +45,7 @@ class EnvoyClientTest {
 
   @Test
   fun `sending data on stream stream forwards data to the underlying stream`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val emitter = envoy.send(
@@ -67,7 +66,7 @@ class EnvoyClientTest {
 
   @Test
   fun `sending metadata on stream forwards metadata to the underlying stream`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val metadata = mapOf("key_1" to listOf("value_a"))
@@ -87,7 +86,7 @@ class EnvoyClientTest {
 
   @Test
   fun `closing stream sends empty data to the underlying stream`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val emitter = envoy.send(
@@ -106,7 +105,7 @@ class EnvoyClientTest {
 
   @Test
   fun `closing stream with trailers sends trailers to the underlying stream `() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val trailers = mapOf("key_1" to listOf("value_a"))
@@ -126,7 +125,7 @@ class EnvoyClientTest {
 
   @Test
   fun `sending request on envoy sends headers`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val expectedHeaders = mapOf(
@@ -152,7 +151,7 @@ class EnvoyClientTest {
 
   @Test
   fun `sending request on envoy passes the body buffer`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val body = ByteBuffer.allocate(0)
@@ -171,7 +170,7 @@ class EnvoyClientTest {
 
   @Test
   fun `sending request on envoy without trailers sends empty trailers`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val body = ByteBuffer.allocate(0)
@@ -190,7 +189,7 @@ class EnvoyClientTest {
 
   @Test
   fun `sending request on envoy sends trailers`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val trailers = mapOf("key_1" to listOf("value_a"))
@@ -210,7 +209,7 @@ class EnvoyClientTest {
 
   @Test
   fun `sending request with retryPolicy creates a stream with buffering`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val trailers = mapOf("key_1" to listOf("value_a"))
@@ -232,7 +231,7 @@ class EnvoyClientTest {
 
   @Test
   fun `sending request without retryPolicy creates a stream without buffering`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val trailers = mapOf("key_1" to listOf("value_a"))
@@ -253,7 +252,7 @@ class EnvoyClientTest {
 
   @Test
   fun `cancelling stream cancels the underlying stream`() {
-    `when`(engine.startStream(any(), anyBoolean())).thenReturn(stream)
+    `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
     val trailers = mapOf("key_1" to listOf("value_a"))

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -7,7 +7,6 @@ import java.nio.ByteBuffer
 import java.util.concurrent.Executor
 import org.junit.Test
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
@@ -205,49 +204,6 @@ class EnvoyClientTest {
         ResponseHandler(Executor {}))
 
     verify(stream).sendTrailers(trailers)
-  }
-
-  @Test
-  fun `sending request with retryPolicy creates a stream with buffering`() {
-    `when`(engine.startStream(any())).thenReturn(stream)
-    val envoy = Envoy(engine, config)
-
-    val trailers = mapOf("key_1" to listOf("value_a"))
-    envoy.send(
-        RequestBuilder(
-            method = RequestMethod.POST,
-            scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
-            .addRetryPolicy(RetryPolicy(23, listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), 1234))
-            .build(),
-        ByteBuffer.allocate(0),
-        trailers,
-        ResponseHandler(Executor {}))
-
-    verify(stream).sendTrailers(trailers)
-    verify(engine).startStream(any(), eq(true))
-  }
-
-  @Test
-  fun `sending request without retryPolicy creates a stream without buffering`() {
-    `when`(engine.startStream(any())).thenReturn(stream)
-    val envoy = Envoy(engine, config)
-
-    val trailers = mapOf("key_1" to listOf("value_a"))
-    envoy.send(
-        RequestBuilder(
-            method = RequestMethod.POST,
-            scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
-            .build(),
-        ByteBuffer.allocate(0),
-        trailers,
-        ResponseHandler(Executor {}))
-
-    verify(stream).sendTrailers(trailers)
-    verify(engine).startStream(any(), eq(false))
   }
 
   @Test

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -70,12 +70,8 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
  @param handle Underlying handle of the HTTP stream owned by an Envoy engine.
  @param callbacks The callbacks for the stream.
- @param bufferForRetry Whether this stream should be buffered to support future retries. Must be
- true for requests that support retrying.
  */
-- (instancetype)initWithHandle:(intptr_t)handle
-                     callbacks:(EnvoyHTTPCallbacks *)callbacks
-                bufferForRetry:(BOOL)bufferForRetry;
+- (instancetype)initWithHandle:(intptr_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks;
 
 /**
  Send headers over the provided stream.
@@ -189,11 +185,8 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  Opens a new HTTP stream attached to this engine.
 
  @param callbacks Handler for observing stream events.
- @param bufferForRetry Whether this stream should be buffered to support future retries. Must be
- true for requests that support retrying.
  */
-- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks
-                                 bufferForRetry:(BOOL)bufferForRetry;
+- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks;
 
 @end
 

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -47,11 +47,9 @@ static void ios_on_exit() {
   }
 }
 
-- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks
-                                 bufferForRetry:(BOOL)bufferForRetry {
+- (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks {
   return [[EnvoyHTTPStreamImpl alloc] initWithHandle:init_stream(_engineHandle)
-                                           callbacks:callbacks
-                                      bufferForRetry:bufferForRetry];
+                                           callbacks:callbacks];
 }
 
 @end

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -181,9 +181,7 @@ static void ios_on_error(envoy_error error, void *context) {
   envoy_stream_t _streamHandle;
 }
 
-- (instancetype)initWithHandle:(envoy_stream_t)handle
-                     callbacks:(EnvoyHTTPCallbacks *)callbacks
-                bufferForRetry:(BOOL)bufferForRetry {
+- (instancetype)initWithHandle:(envoy_stream_t)handle callbacks:(EnvoyHTTPCallbacks *)callbacks {
   self = [super init];
   if (!self) {
     return nil;
@@ -209,8 +207,7 @@ static void ios_on_error(envoy_error error, void *context) {
   // We need create the native-held strong ref on this stream before we call start_stream because
   // start_stream could result in a reset that would release the native ref.
   _strongSelf = self;
-  envoy_stream_options stream_options = {bufferForRetry};
-  envoy_status_t result = start_stream(_streamHandle, native_callbacks, stream_options);
+  envoy_status_t result = start_stream(_streamHandle, native_callbacks);
   if (result != ENVOY_SUCCESS) {
     _strongSelf = nil;
     return nil;

--- a/library/swift/src/EnvoyClient.swift
+++ b/library/swift/src/EnvoyClient.swift
@@ -43,8 +43,7 @@ public final class EnvoyClient: NSObject {
 
 extension EnvoyClient: HTTPClient {
   public func send(_ request: Request, handler: ResponseHandler) -> StreamEmitter {
-    let httpStream = self.engine.startStream(
-      with: handler.underlyingCallbacks, bufferForRetry: request.retryPolicy != nil)
+    let httpStream = self.engine.startStream(with: handler.underlyingCallbacks)
     httpStream.sendHeaders(request.outboundHeaders(), close: false)
     return EnvoyStreamEmitter(stream: httpStream)
   }

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -26,11 +26,8 @@ private final class MockEnvoyEngine: NSObject, EnvoyEngine {
     return 0
   }
 
-  func startStream(with callbacks: EnvoyHTTPCallbacks, bufferForRetry: Bool)
-    -> EnvoyHTTPStream
-  {
-    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks,
-                               bufferForRetry: bufferForRetry)
+  func startStream(with callbacks: EnvoyHTTPCallbacks) -> EnvoyHTTPStream {
+    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
   }
 }
 

--- a/library/swift/test/EnvoyClientTests.swift
+++ b/library/swift/test/EnvoyClientTests.swift
@@ -11,11 +11,8 @@ private final class MockEnvoyEngine: EnvoyEngine {
     return 0
   }
 
-  func startStream(with callbacks: EnvoyHTTPCallbacks, bufferForRetry: Bool)
-    -> EnvoyHTTPStream
-  {
-    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks,
-                               bufferForRetry: bufferForRetry)
+  func startStream(with callbacks: EnvoyHTTPCallbacks) -> EnvoyHTTPStream {
+    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
   }
 }
 
@@ -60,30 +57,5 @@ final class EnvoyClientTests: XCTestCase {
                handler: ResponseHandler())
     self.wait(for: [requestExpectation, dataExpectation, closeExpectation],
               timeout: 0.1, enforceOrder: true)
-  }
-
-  func testBuffersForRetriesWhenRetryPolicyIsSet() throws {
-    let request = RequestBuilder(
-      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
-      .addRetryPolicy(RetryPolicy(maxRetryCount: 3, retryOn: RetryRule.allCases))
-      .build()
-    let envoy = try EnvoyClientBuilder()
-      .addEngineType(MockEnvoyEngine.self)
-      .build()
-    envoy.send(request, body: Data(), trailers: [:], handler: ResponseHandler())
-
-    XCTAssertEqual(true, MockEnvoyHTTPStream.bufferForRetry)
-  }
-
-  func testDoesNotBufferForRetriesWhenRetryPolicyIsNil() throws {
-    let request = RequestBuilder(
-      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
-      .build()
-    let envoy = try EnvoyClientBuilder()
-      .addEngineType(MockEnvoyEngine.self)
-      .build()
-    envoy.send(request, body: Data(), trailers: [:], handler: ResponseHandler())
-
-    XCTAssertEqual(false, MockEnvoyHTTPStream.bufferForRetry)
   }
 }

--- a/library/swift/test/MockEnvoyHTTPStream.swift
+++ b/library/swift/test/MockEnvoyHTTPStream.swift
@@ -5,18 +5,14 @@ final class MockEnvoyHTTPStream {
   static var onHeaders: (([String: [String]], Bool) -> Void)?
   static var onData: ((Data, Bool) -> Void)?
   static var onTrailers: (([String: [String]]) -> Void)?
-  private(set) static var bufferForRetry: Bool?
 
-  init(handle: Int, callbacks: EnvoyHTTPCallbacks, bufferForRetry: Bool) {
-    MockEnvoyHTTPStream.bufferForRetry = bufferForRetry
-  }
+  init(handle: Int, callbacks: EnvoyHTTPCallbacks) {}
 
   /// Reset the current state of the stream. Should be called between tests.
   static func reset() {
     self.onHeaders = nil
     self.onData = nil
     self.onTrailers = nil
-    self.bufferForRetry = nil
   }
 }
 

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -71,7 +71,7 @@ TEST_F(DispatcherTest, PreferredNetwork) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -184,7 +184,7 @@ TEST_F(DispatcherTest, BasicStreamHeadersOnly) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -255,7 +255,7 @@ TEST_F(DispatcherTest, BasicStream) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the
@@ -341,7 +341,7 @@ TEST_F(DispatcherTest, MultipleDataStream) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -426,7 +426,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream1, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream1, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -537,7 +537,7 @@ TEST_F(DispatcherTest, ResetStreamLocal) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -600,7 +600,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -662,7 +662,7 @@ TEST_F(DispatcherTest, StreamResetAfterOnComplete) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -734,7 +734,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRaceLocalWins) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -823,7 +823,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWinsDeletesStream) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -911,7 +911,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWins) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -1001,7 +1001,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRaceLocalWins) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -1087,7 +1087,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWinsDeletesStream) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -1172,7 +1172,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWins) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
@@ -1243,7 +1243,7 @@ TEST_F(DispatcherTest, ResetWhenRemoteClosesBeforeLocal) {
   // Create a stream.
   Event::PostCb start_stream_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -474,7 +474,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   // Create a stream.
   Event::PostCb start_stream_post_cb2;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb2));
-  EXPECT_EQ(http_dispatcher_.startStream(stream2, bridge_callbacks2, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream2, bridge_callbacks2), ENVOY_SUCCESS);
 
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -142,7 +142,7 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   envoy_headers c_headers = Http::Utility::toBridgeHeaders(headers);
 
   // Create a stream.
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
   http_dispatcher_.sendHeaders(stream, c_headers, true);
 
   terminal_callback.waitReady();
@@ -202,7 +202,7 @@ TEST_P(DispatcherIntegrationTest, RaceDoesNotCauseDoubleDeletion) {
   envoy_headers c_headers = Http::Utility::toBridgeHeaders(headers);
 
   // Create a stream.
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks, {}), ENVOY_SUCCESS);
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
   http_dispatcher_.synchronizer().waitOn("dispatch_encode_final_data");
   http_dispatcher_.sendHeaders(stream, c_headers, true);
   http_dispatcher_.synchronizer().barrierOn("dispatch_encode_final_data");


### PR DESCRIPTION
As of https://github.com/lyft/envoy-mobile/pull/616, this is no longer used or necessary since it's handled by the router.

Resolves https://github.com/lyft/envoy-mobile/issues/643.

Signed-off-by: Michael Rebello <me@michaelrebello.com>