### PR TITLE
config: delete redundant fields

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -68,8 +68,6 @@ static_resources:
         keepalive_interval: 10
         keepalive_probes: 1
         keepalive_time: 5
-    transport_socket: *base_transport_socket
-    upstream_connection_options: *upstream_opts
   - name: base_wlan
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED


### PR DESCRIPTION
Description: this PR deletes previously duplicated fields in the base cluster.
Risk Level: low
Testing: CI

Signed-off-by: Jose Nino <jnino@lyft.com>