### PR TITLE
upsteam protocol: add the ability to decide what protocol to use for upstream requests

### DIFF
--- a/docs/root/api/http.rst
+++ b/docs/root/api/http.rst
@@ -17,7 +17,7 @@ a previously created :ref:`Envoy instance <api_starting_envoy>`.
 
 **Kotlin**::
 
-  val request = RequestBuilder(RequestMethod.POST, "https", "api.envoyproxy.io", "/foo")
+  val request = RequestBuilder(RequestMethod.POST, "https", "api.envoyproxy.io", "/foo", upstreamHttpProtocol = UpstreamRequestProtocol.HTTP2)
     .addRetryPolicy(RetryPolicy(...))
     .addHeader("x-custom-header", "foobar")
     ...
@@ -25,7 +25,7 @@ a previously created :ref:`Envoy instance <api_starting_envoy>`.
 
 **Swift**::
 
-  let request = RequestBuilder(method: .post, scheme: "https", authority: "api.envoyproxy.io", path: "/foo", upstreamHttpProtocol: true)
+  let request = RequestBuilder(method: .post, scheme: "https", authority: "api.envoyproxy.io", path: "/foo", upstreamHttpProtocol: .http2)
     .addRetryPolicy(RetryPolicy(...))
     .addHeader(name: "x-custom-header", value: "foobar")
     ...

--- a/docs/root/api/http.rst
+++ b/docs/root/api/http.rst
@@ -25,7 +25,7 @@ a previously created :ref:`Envoy instance <api_starting_envoy>`.
 
 **Swift**::
 
-  let request = RequestBuilder(method: .post, scheme: "https", authority: "api.envoyproxy.io", path: "/foo")
+  let request = RequestBuilder(method: .post, scheme: "https", authority: "api.envoyproxy.io", path: "/foo", upstreamHttpProtocol: true)
     .addRetryPolicy(RetryPolicy(...))
     .addHeader(name: "x-custom-header", value: "foobar")
     ...

--- a/docs/root/api/http.rst
+++ b/docs/root/api/http.rst
@@ -17,16 +17,18 @@ a previously created :ref:`Envoy instance <api_starting_envoy>`.
 
 **Kotlin**::
 
-  val request = RequestBuilder(RequestMethod.POST, "https", "api.envoyproxy.io", "/foo", upstreamHttpProtocol = UpstreamRequestProtocol.HTTP2)
+  val request = RequestBuilder(RequestMethod.POST, "https", "api.envoyproxy.io", "/foo")
     .addRetryPolicy(RetryPolicy(...))
+    .addUpstreamHttpProtocol(UpstreamRequestProtocol.HTTP2)
     .addHeader("x-custom-header", "foobar")
     ...
     .build()
 
 **Swift**::
 
-  let request = RequestBuilder(method: .post, scheme: "https", authority: "api.envoyproxy.io", path: "/foo", upstreamHttpProtocol: .http2)
+  let request = RequestBuilder(method: .post, scheme: "https", authority: "api.envoyproxy.io", path: "/foo")
     .addRetryPolicy(RetryPolicy(...))
+    .addUpstreamHttpProtocol(.http2)
     .addHeader(name: "x-custom-header", value: "foobar")
     ...
     .build()

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -74,6 +74,9 @@ public class MainActivity extends Activity {
   }
 
   private void makeRequest() {
+    // Note: this request will use an http/1.1 stream for the upstream request.
+    // The Kotlin example uses h2. This is done on purpose to test both paths in end-to-end tests
+    // in CI.
     Request request =
         new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH)
             .build();

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -14,6 +14,8 @@ import io.envoyproxy.envoymobile.Request;
 import io.envoyproxy.envoymobile.RequestBuilder;
 import io.envoyproxy.envoymobile.RequestMethod;
 import io.envoyproxy.envoymobile.ResponseHandler;
+import io.envoyproxy.envoymobile.UpstreamHttpProtocol;
+
 import io.envoyproxy.envoymobile.shared.Failure;
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter;
 import io.envoyproxy.envoymobile.shared.Success;
@@ -75,7 +77,7 @@ public class MainActivity extends Activity {
 
   private void makeRequest() {
     Request request =
-        new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH)
+        new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH, UpstreamHttpProtocol.HTTP2)
             .build();
     Map<String, List<String>> responseHeaders = new HashMap<>();
     AtomicInteger responseStatus = new AtomicInteger();

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -76,9 +76,9 @@ public class MainActivity extends Activity {
   }
 
   private void makeRequest() {
-    Request request =
-        new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH, UpstreamHttpProtocol.HTTP2)
-            .build();
+    Request request = new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY,
+                                         REQUEST_PATH, UpstreamHttpProtocol.HTTP2)
+                          .build();
     Map<String, List<String>> responseHeaders = new HashMap<>();
     AtomicInteger responseStatus = new AtomicInteger();
     ResponseHandler handler =

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -77,7 +77,7 @@ public class MainActivity extends Activity {
 
   private void makeRequest() {
     Request request = new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY,
-                                         REQUEST_PATH, UpstreamHttpProtocol.HTTP2)
+                                         REQUEST_PATH)
                           .build();
     Map<String, List<String>> responseHeaders = new HashMap<>();
     AtomicInteger responseStatus = new AtomicInteger();

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -75,8 +75,8 @@ public class MainActivity extends Activity {
 
   private void makeRequest() {
     Request request =
-      new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH)
-        .build();
+        new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH)
+            .build();
     Map<String, List<String>> responseHeaders = new HashMap<>();
     AtomicInteger responseStatus = new AtomicInteger();
     ResponseHandler handler =

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -14,8 +14,6 @@ import io.envoyproxy.envoymobile.Request;
 import io.envoyproxy.envoymobile.RequestBuilder;
 import io.envoyproxy.envoymobile.RequestMethod;
 import io.envoyproxy.envoymobile.ResponseHandler;
-import io.envoyproxy.envoymobile.UpstreamHttpProtocol;
-
 import io.envoyproxy.envoymobile.shared.Failure;
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter;
 import io.envoyproxy.envoymobile.shared.Success;
@@ -76,9 +74,9 @@ public class MainActivity extends Activity {
   }
 
   private void makeRequest() {
-    Request request = new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY,
-                                         REQUEST_PATH)
-                          .build();
+    Request request =
+      new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH)
+        .build();
     Map<String, List<String>> responseHeaders = new HashMap<>();
     AtomicInteger responseStatus = new AtomicInteger();
     ResponseHandler handler =

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -74,6 +74,9 @@ class MainActivity : Activity() {
   }
 
   private fun makeRequest() {
+    // Note: this request will use an h2 stream for the upstream request.
+    // The Java example uses http/1.1. This is done on purpose to test both paths in end-to-end
+    // tests in CI.
     val request = RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH)
         .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
         .build()

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -74,7 +74,8 @@ class MainActivity : Activity() {
   }
 
   private fun makeRequest() {
-    val request = RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH, UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH)
+        .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
         .build()
     val responseHeaders = HashMap<String, List<String>>()
     val responseStatus = AtomicInteger()

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -13,6 +13,7 @@ import io.envoyproxy.envoymobile.Envoy
 import io.envoyproxy.envoymobile.RequestBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.ResponseHandler
+import io.envoyproxy.envoymobile.UpstreamHttpProtocol
 
 import io.envoyproxy.envoymobile.shared.Failure
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter
@@ -73,7 +74,7 @@ class MainActivity : Activity() {
   }
 
   private fun makeRequest() {
-    val request = RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH)
+    val request = RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH, UpstreamHttpProtocol.HTTP2)
         .build()
     val responseHeaders = HashMap<String, List<String>>()
     val responseStatus = AtomicInteger()

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -66,6 +66,9 @@ NSString *_REQUEST_SCHEME = @"https";
   NSLog(@"Starting request to '%@'", _REQUEST_PATH);
 
   int requestID = self.requestCount;
+  // Note: this request will use an http/1.1 stream for the upstream request.
+  // The Swift example uses h2. This is done on purpose to test both paths in end-to-end tests
+  // in CI.
   RequestBuilder *builder = [[RequestBuilder alloc] initWithMethod:RequestMethodGet
                                                             scheme:_REQUEST_SCHEME
                                                          authority:_REQUEST_AUTHORITY

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -70,7 +70,7 @@ NSString *_REQUEST_SCHEME = @"https";
                                                             scheme:_REQUEST_SCHEME
                                                          authority:_REQUEST_AUTHORITY
                                                               path:_REQUEST_PATH
-                                              upstreamHttpProtocol:YES];
+                                              upstreamHttpProtocol:UpstreamHttpProtocolHttp2];
   Request *request = [builder build];
   ResponseHandler *handler = [[ResponseHandler alloc] initWithQueue:dispatch_get_main_queue()];
 

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -69,7 +69,8 @@ NSString *_REQUEST_SCHEME = @"https";
   RequestBuilder *builder = [[RequestBuilder alloc] initWithMethod:RequestMethodGet
                                                             scheme:_REQUEST_SCHEME
                                                          authority:_REQUEST_AUTHORITY
-                                                              path:_REQUEST_PATH];
+                                                              path:_REQUEST_PATH
+                                              upstreamHttpProtocol:YES];
   Request *request = [builder build];
   ResponseHandler *handler = [[ResponseHandler alloc] initWithQueue:dispatch_get_main_queue()];
 

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -69,8 +69,7 @@ NSString *_REQUEST_SCHEME = @"https";
   RequestBuilder *builder = [[RequestBuilder alloc] initWithMethod:RequestMethodGet
                                                             scheme:_REQUEST_SCHEME
                                                          authority:_REQUEST_AUTHORITY
-                                                              path:_REQUEST_PATH
-                                              upstreamHttpProtocol:UpstreamHttpProtocolHttp2];
+                                                              path:_REQUEST_PATH];
   Request *request = [builder build];
   ResponseHandler *handler = [[ResponseHandler alloc] initWithQueue:dispatch_get_main_queue()];
 

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -49,7 +49,7 @@ final class ViewController: UITableViewController {
     let requestID = self.requestCount
     let request = RequestBuilder(method: .get, scheme: kRequestScheme,
                                  authority: kRequestAuthority,
-                                 path: kRequestPath, upstreamHttpProtocol: true).build()
+                                 path: kRequestPath, upstreamHttpProtocol: .http2).build()
     let handler = ResponseHandler()
       .onHeaders { [weak self] headers, statusCode, _ in
         NSLog("Response status (\(requestID)): \(statusCode)\n\(headers)")

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -52,7 +52,7 @@ final class ViewController: UITableViewController {
     // end-to-end tests in CI.
     let request = RequestBuilder(method: .get, scheme: kRequestScheme,
                                  authority: kRequestAuthority,
-                                 path: kRequestPath, upstreamHttpProtocol: .http2)
+                                 path: kRequestPath)
         .addUpstreamHttpProtocol(.http2)
         .build()
     let handler = ResponseHandler()

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -49,7 +49,7 @@ final class ViewController: UITableViewController {
     let requestID = self.requestCount
     let request = RequestBuilder(method: .get, scheme: kRequestScheme,
                                  authority: kRequestAuthority,
-                                 path: kRequestPath).build()
+                                 path: kRequestPath, upstreamHttpProtocol: true).build()
     let handler = ResponseHandler()
       .onHeaders { [weak self] headers, statusCode, _ in
         NSLog("Response status (\(requestID)): \(statusCode)\n\(headers)")

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -49,7 +49,9 @@ final class ViewController: UITableViewController {
     let requestID = self.requestCount
     let request = RequestBuilder(method: .get, scheme: kRequestScheme,
                                  authority: kRequestAuthority,
-                                 path: kRequestPath, upstreamHttpProtocol: .http2).build()
+                                 path: kRequestPath, upstreamHttpProtocol: .http2)
+        .addUpstreamHttpProtocol(.http2)
+        .build()
     let handler = ResponseHandler()
       .onHeaders { [weak self] headers, statusCode, _ in
         NSLog("Response status (\(requestID)): \(statusCode)\n\(headers)")

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -47,6 +47,9 @@ final class ViewController: UITableViewController {
     NSLog("Starting request to '\(kRequestPath)'")
 
     let requestID = self.requestCount
+    // Note: this request will use an h2 stream for the upstream request.
+    // The Objective-C example uses http/1.1. This is done on purpose to test both paths in
+    // end-to-end tests in CI.
     let request = RequestBuilder(method: .get, scheme: kRequestScheme,
                                  authority: kRequestAuthority,
                                  path: kRequestPath, upstreamHttpProtocol: .http2)

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -96,6 +96,48 @@ static_resources:
           dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
+  - name: base_h2
+    http2_protocol_options: {}
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config:
+          name: dynamic_forward_proxy_cache_config
+          dns_lookup_family: AUTO
+          dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+    transport_socket: *base_transport_socket
+    upstream_connection_options: *upstream_opts
+  - name: base_wlan_h2
+    http2_protocol_options: {}
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config:
+          name: dynamic_forward_proxy_cache_config
+          dns_lookup_family: AUTO
+          dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+    transport_socket: *base_transport_socket
+    upstream_connection_options: *upstream_opts
+  - name: base_wwan_h2
+    http2_protocol_options: {}
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config:
+          name: dynamic_forward_proxy_cache_config
+          dns_lookup_family: AUTO
+          dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+    transport_socket: *base_transport_socket
+    upstream_connection_options: *upstream_opts
   - name: stats
     connect_timeout: {{ connect_timeout_seconds }}s
     dns_refresh_rate: {{ dns_refresh_rate_seconds }}s

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -320,7 +320,7 @@ envoy_status_t Dispatcher::sendHeaders(envoy_stream_t stream, envoy_headers head
       RequestHeaderMapPtr internal_headers = Utility::toRequestHeaders(headers);
       ENVOY_LOG(debug, "[S{}] request headers for stream (end_stream={}):\n{}", stream, end_stream,
                 *internal_headers);
-      attachPreferredNetwork(*internal_headers);
+      setDestinationCluster(*internal_headers);
       direct_stream->request_decoder_->decodeHeaders(std::move(internal_headers), end_stream);
       direct_stream->closeLocal(end_stream);
     }
@@ -477,19 +477,38 @@ const LowerCaseString ClusterHeader{"x-envoy-mobile-cluster"};
 const std::string BaseCluster = "base";
 const std::string BaseWlanCluster = "base_wlan";
 const std::string BaseWwanCluster = "base_wwan";
+const LowerCaseString H2UpstreamHeader{"x-envoy-mobile-upstream-protocol"};
+const std::string H2Suffix = "_h2";
+const std::string BaseClusterH2 = BaseCluster + H2Suffix;
+const std::string BaseWlanClusterH2 = BaseWlanCluster + H2Suffix;
+const std::string BaseWwanClusterH2 = BaseWwanCluster + H2Suffix;
 } // namespace
 
-void Dispatcher::attachPreferredNetwork(HeaderMap& headers) {
+void Dispatcher::setDestinationCluster(HeaderMap& headers) {
+
+  // Determine upstream protocol. Use http2 if selected for explicitly, otherwise (any other value,
+  // absence of value) select http1.
+  // TODO(junr03): once http3 is available this would probably benefit from some sort of struct that
+  // maps to appropriate cluster names. However, with only two options (http1/2) this suffices.
+  bool use_h2_cluster{};
+  const HeaderEntry* entry = headers.get(H2UpstreamHeader);
+  if (entry) {
+    if (entry->value() == "http2") {
+      use_h2_cluster = true;
+    }
+    headers.remove(H2UpstreamHeader);
+  }
+
   switch (preferred_network_.load()) {
   case ENVOY_NET_WLAN:
-    headers.addReference(ClusterHeader, BaseWlanCluster);
+    headers.addReference(ClusterHeader, use_h2_cluster ? BaseWlanClusterH2 : BaseWlanCluster);
     break;
   case ENVOY_NET_WWAN:
-    headers.addReference(ClusterHeader, BaseWwanCluster);
+    headers.addReference(ClusterHeader, use_h2_cluster ? BaseWwanClusterH2 : BaseWwanCluster);
     break;
   case ENVOY_NET_GENERIC:
   default:
-    headers.addReference(ClusterHeader, BaseCluster);
+    headers.addReference(ClusterHeader, use_h2_cluster ? BaseClusterH2 : BaseCluster);
   }
 }
 

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -496,6 +496,8 @@ void Dispatcher::setDestinationCluster(HeaderMap& headers) {
   if (entry) {
     if (entry->value() == "http2") {
       use_h2_cluster = true;
+    } else {
+      ASSERT(entry->value() == "http1", fmt::format("using unsupported protocol version {}", entry->value().getStringView()));
     }
     headers.remove(H2UpstreamHeader);
   }

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -497,7 +497,8 @@ void Dispatcher::setDestinationCluster(HeaderMap& headers) {
     if (entry->value() == "http2") {
       use_h2_cluster = true;
     } else {
-      ASSERT(entry->value() == "http1", fmt::format("using unsupported protocol version {}", entry->value().getStringView()));
+      ASSERT(entry->value() == "http1",
+             fmt::format("using unsupported protocol version {}", entry->value().getStringView()));
     }
     headers.remove(H2UpstreamHeader);
   }

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -195,7 +195,7 @@ private:
   void post(Event::PostCb callback);
   DirectStreamSharedPtr getStream(envoy_stream_t stream_handle);
   void cleanup(envoy_stream_t stream_handle);
-  void attachPreferredNetwork(HeaderMap& headers);
+  void setDestinationCluster(HeaderMap& headers);
 
   Thread::MutexBasicLockable ready_lock_;
   std::list<Event::PostCb> init_queue_ GUARDED_BY(ready_lock_);

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -52,6 +52,7 @@ envoy_mobile_kt_library(
         "RetryPolicy.kt",
         "RetryPolicyMapper.kt",
         "StreamEmitter.kt",
+        "UpstreamHttpProtocol.kt",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/library/kotlin/src/io/envoyproxy/envoymobile/GRPCRequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/GRPCRequestBuilder.kt
@@ -12,11 +12,10 @@ class GRPCRequestBuilder(
       method = RequestMethod.POST,
       scheme = if (useHTTPS) "https" else "http",
       authority = authority,
-      path = path,
-      upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+      path = path)
 
   init {
-    underlyingBuilder.addHeader("content-type", "application/grpc")
+    underlyingBuilder.addHeader("content-type", "application/grpc").addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
   }
 
   /**

--- a/library/kotlin/src/io/envoyproxy/envoymobile/GRPCRequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/GRPCRequestBuilder.kt
@@ -12,7 +12,8 @@ class GRPCRequestBuilder(
       method = RequestMethod.POST,
       scheme = if (useHTTPS) "https" else "http",
       authority = authority,
-      path = path)
+      path = path,
+      upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
 
   init {
     underlyingBuilder.addHeader("content-type", "application/grpc")

--- a/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
@@ -7,12 +7,14 @@ package io.envoyproxy.envoymobile
  * @param scheme The URL scheme for the request (i.e., "https").
  * @param authority The URL authority for the request (i.e., "api.foo.com").
  * @param path The URL path for the request (i.e., "/foo").
+ * @param upstreamHttpProtocol The protcol version to use for upstream requests.
  */
 data class Request internal constructor(
     val method: RequestMethod,
     val scheme: String,
     val authority: String,
     val path: String,
+    val upstreamHttpProtocol: UpstreamHttpProtocol,
     val headers: Map<String, List<String>>,
     val retryPolicy: RetryPolicy?
 ) {
@@ -24,7 +26,7 @@ data class Request internal constructor(
    * @return the builder.
    */
   fun toBuilder(): RequestBuilder {
-    return RequestBuilder(method, scheme, authority, path)
+    return RequestBuilder(method, scheme, authority, path, upstreamHttpProtocol)
         .setHeaders(headers)
         .addRetryPolicy(retryPolicy)
   }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Request.kt
@@ -7,16 +7,15 @@ package io.envoyproxy.envoymobile
  * @param scheme The URL scheme for the request (i.e., "https").
  * @param authority The URL authority for the request (i.e., "api.foo.com").
  * @param path The URL path for the request (i.e., "/foo").
- * @param upstreamHttpProtocol The protcol version to use for upstream requests.
  */
 data class Request internal constructor(
     val method: RequestMethod,
     val scheme: String,
     val authority: String,
     val path: String,
-    val upstreamHttpProtocol: UpstreamHttpProtocol,
     val headers: Map<String, List<String>>,
-    val retryPolicy: RetryPolicy?
+    val retryPolicy: RetryPolicy?,
+    val upstreamHttpProtocol: UpstreamHttpProtocol?
 ) {
 
   /**
@@ -26,8 +25,9 @@ data class Request internal constructor(
    * @return the builder.
    */
   fun toBuilder(): RequestBuilder {
-    return RequestBuilder(method, scheme, authority, path, upstreamHttpProtocol)
+    return RequestBuilder(method, scheme, authority, path)
         .setHeaders(headers)
         .addRetryPolicy(retryPolicy)
+        .addUpstreamHttpProtocol(upstreamHttpProtocol)
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
@@ -8,14 +8,12 @@ package io.envoyproxy.envoymobile
  * @param scheme The URL scheme for the request (i.e., "https").
  * @param authority The URL authority for the request (i.e., "api.foo.com").
  * @param path The URL path for the request (i.e., "/foo").
- * @param upstreamHttpProtocol Whether the request should be sent to the upstream via h2 or not.
  */
 class RequestBuilder(
     val method: RequestMethod,
     val scheme: String = "https",
     val authority: String,
-    val path: String,
-    val upstreamHttpProtocol: UpstreamHttpProtocol
+    val path: String
 ) {
   // Headers to send with the request.
   // Multiple values for a given name are valid, and will be sent as comma-separated values.
@@ -24,16 +22,8 @@ class RequestBuilder(
   // Retry policy to use for this request.
   private var retryPolicy: RetryPolicy? = null
 
-  /**
-   * Add a retry policy to use for this request.
-   *
-   * @param retryPolicy the {@link io.envoyproxy.envoymobile.RetryPolicy} for this request.
-   * @return this builder.
-   */
-  fun addRetryPolicy(retryPolicy: RetryPolicy?): RequestBuilder {
-    this.retryPolicy = retryPolicy
-    return this
-  }
+  // The protocol version to use for upstream requests.
+  private var upstreamHttpProtocol: UpstreamHttpProtocol? = null
 
   /**
    * Append a value to the header key.
@@ -80,6 +70,28 @@ class RequestBuilder(
   }
 
   /**
+   * Add a retry policy to use for this request.
+   *
+   * @param retryPolicy the {@link io.envoyproxy.envoymobile.RetryPolicy} for this request.
+   * @return this builder.
+   */
+  fun addRetryPolicy(retryPolicy: RetryPolicy?): RequestBuilder {
+    this.retryPolicy = retryPolicy
+    return this
+  }
+
+  /**
+   * Add a http protocol hint for this request.
+   *
+   * @param upstreamHttpProtocol the {@link io.envoyproxy.envoymobile.UpstreamHttpProtocol} for this request.
+   * @return this builder.
+   */
+  fun addUpstreamHttpProtocol(upstreamHttpProtocol: UpstreamHttpProtocol?): RequestBuilder {
+    this.upstreamHttpProtocol = upstreamHttpProtocol
+    return this
+  }
+
+  /**
    * Creates the {@link io.envoyproxy.envoymobile.Request} object using the data set in the builder.
    *
    * @return the {@link io.envoyproxy.envoymobile.Request} object.
@@ -90,9 +102,9 @@ class RequestBuilder(
         scheme,
         authority,
         path,
-        upstreamHttpProtocol,
         headers,
-        retryPolicy
+        retryPolicy,
+        upstreamHttpProtocol
     )
   }
 

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
@@ -81,7 +81,7 @@ class RequestBuilder(
   }
 
   /**
-   * Add a http protocol hint for this request.
+   * Add an HTTP protocol hint for this request.
    *
    * @param upstreamHttpProtocol the {@link io.envoyproxy.envoymobile.UpstreamHttpProtocol} for this request.
    * @return this builder.

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestBuilder.kt
@@ -8,12 +8,14 @@ package io.envoyproxy.envoymobile
  * @param scheme The URL scheme for the request (i.e., "https").
  * @param authority The URL authority for the request (i.e., "api.foo.com").
  * @param path The URL path for the request (i.e., "/foo").
+ * @param upstreamHttpProtocol Whether the request should be sent to the upstream via h2 or not.
  */
 class RequestBuilder(
     val method: RequestMethod,
     val scheme: String = "https",
     val authority: String,
-    val path: String
+    val path: String,
+    val upstreamHttpProtocol: UpstreamHttpProtocol
 ) {
   // Headers to send with the request.
   // Multiple values for a given name are valid, and will be sent as comma-separated values.
@@ -88,6 +90,7 @@ class RequestBuilder(
         scheme,
         authority,
         path,
+        upstreamHttpProtocol,
         headers,
         retryPolicy
     )

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestMapper.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestMapper.kt
@@ -4,7 +4,7 @@ internal fun Request.outboundHeaders(): Map<String, List<String>> {
   val retryPolicyHeaders = retryPolicy?.outboundHeaders() ?: emptyMap()
 
   val result = mutableMapOf<String, List<String>>()
-  result.putAll(headers.filter { entry -> !(entry.key.startsWith(":") || entry.key.startsWith("x-envoy-mobile"))})
+  result.putAll(headers.filter { entry -> !entry.key.startsWith(":") && !entry.key.startsWith("x-envoy-mobile")})
   result.putAll(retryPolicyHeaders)
   result[":method"] = listOf(method.stringValue())
   result[":scheme"] = listOf(scheme)

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestMapper.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestMapper.kt
@@ -4,12 +4,13 @@ internal fun Request.outboundHeaders(): Map<String, List<String>> {
   val retryPolicyHeaders = retryPolicy?.outboundHeaders() ?: emptyMap()
 
   val result = mutableMapOf<String, List<String>>()
-  result.putAll(headers.filter { entry -> !entry.key.startsWith(":") })
+  result.putAll(headers.filter { entry -> !(entry.key.startsWith(":") || entry.key.startsWith("x-envoy-mobile"))})
   result.putAll(retryPolicyHeaders)
   result[":method"] = listOf(method.stringValue())
   result[":scheme"] = listOf(scheme)
   result[":authority"] = listOf(authority)
   result[":path"] = listOf(path)
+  result["x-envoy-mobile-upstream-protocol"] = listOf(upstreamHttpProtocol.stringValue)
 
   return result
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RequestMapper.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RequestMapper.kt
@@ -10,7 +10,10 @@ internal fun Request.outboundHeaders(): Map<String, List<String>> {
   result[":scheme"] = listOf(scheme)
   result[":authority"] = listOf(authority)
   result[":path"] = listOf(path)
-  result["x-envoy-mobile-upstream-protocol"] = listOf(upstreamHttpProtocol.stringValue)
+
+  if (upstreamHttpProtocol != null) {
+    result["x-envoy-mobile-upstream-protocol"] = listOf(upstreamHttpProtocol.stringValue)
+  }
 
   return result
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/UpstreamHttpProtocol.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/UpstreamHttpProtocol.kt
@@ -1,0 +1,9 @@
+package io.envoyproxy.envoymobile
+
+/**
+ * Available upstream http protocols.
+ */
+enum class UpstreamHttpProtocol(internal val stringValue: String) {
+  HTTP1("http1"),
+  HTTP2("http2"),
+}

--- a/library/kotlin/src/io/envoyproxy/envoymobile/UpstreamHttpProtocol.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/UpstreamHttpProtocol.kt
@@ -1,7 +1,7 @@
 package io.envoyproxy.envoymobile
 
 /**
- * Available upstream http protocols.
+ * Available upstream HTTP protocols.
  */
 enum class UpstreamHttpProtocol(internal val stringValue: String) {
   HTTP1("http1"),

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -27,14 +27,16 @@ class EnvoyClientTest {
         ":method" to listOf("POST"),
         ":scheme" to listOf("https"),
         ":authority" to listOf("api.foo.com"),
-        ":path" to listOf("foo")
+        ":path" to listOf("foo"),
+        "x-envoy-mobile-upstream-protocol" to listOf(UpstreamHttpProtocol.HTTP2.stringValue)
     )
     envoy.send(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .setHeaders(mapOf("key_1" to listOf("value_a")))
             .build(),
         ResponseHandler(Executor {}))
@@ -52,7 +54,8 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .build(),
         ResponseHandler(Executor {}))
 
@@ -74,7 +77,8 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .build(),
         ResponseHandler(Executor {}))
 
@@ -93,7 +97,8 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .build(),
         ResponseHandler(Executor {}))
 
@@ -113,7 +118,8 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .build(),
         ResponseHandler(Executor {}))
 
@@ -132,14 +138,16 @@ class EnvoyClientTest {
         ":method" to listOf("POST"),
         ":scheme" to listOf("https"),
         ":authority" to listOf("api.foo.com"),
-        ":path" to listOf("foo")
+        ":path" to listOf("foo"),
+        "x-envoy-mobile-upstream-protocol" to listOf(UpstreamHttpProtocol.HTTP2.stringValue)
     )
     envoy.send(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .setHeaders(mapOf("key_1" to listOf("value_a")))
             .build(),
         ByteBuffer.allocate(0),
@@ -159,7 +167,8 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .build(),
         body,
         ResponseHandler(Executor {}))
@@ -178,7 +187,8 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .build(),
         body,
         ResponseHandler(Executor {}))
@@ -197,7 +207,8 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .build(),
         ByteBuffer.allocate(0),
         trailers,
@@ -217,7 +228,8 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo")
+            path = "foo",
+            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
             .build(),
         ByteBuffer.allocate(0),
         trailers,

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -27,16 +27,14 @@ class EnvoyClientTest {
         ":method" to listOf("POST"),
         ":scheme" to listOf("https"),
         ":authority" to listOf("api.foo.com"),
-        ":path" to listOf("foo"),
-        "x-envoy-mobile-upstream-protocol" to listOf(UpstreamHttpProtocol.HTTP2.stringValue)
+        ":path" to listOf("foo")
     )
     envoy.send(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .setHeaders(mapOf("key_1" to listOf("value_a")))
             .build(),
         ResponseHandler(Executor {}))
@@ -54,8 +52,7 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .build(),
         ResponseHandler(Executor {}))
 
@@ -77,8 +74,7 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .build(),
         ResponseHandler(Executor {}))
 
@@ -97,8 +93,7 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .build(),
         ResponseHandler(Executor {}))
 
@@ -118,8 +113,7 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .build(),
         ResponseHandler(Executor {}))
 
@@ -138,16 +132,14 @@ class EnvoyClientTest {
         ":method" to listOf("POST"),
         ":scheme" to listOf("https"),
         ":authority" to listOf("api.foo.com"),
-        ":path" to listOf("foo"),
-        "x-envoy-mobile-upstream-protocol" to listOf(UpstreamHttpProtocol.HTTP2.stringValue)
+        ":path" to listOf("foo")
     )
     envoy.send(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .setHeaders(mapOf("key_1" to listOf("value_a")))
             .build(),
         ByteBuffer.allocate(0),
@@ -167,8 +159,7 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .build(),
         body,
         ResponseHandler(Executor {}))
@@ -187,8 +178,7 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .build(),
         body,
         ResponseHandler(Executor {}))
@@ -207,8 +197,7 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .build(),
         ByteBuffer.allocate(0),
         trailers,
@@ -228,8 +217,7 @@ class EnvoyClientTest {
             method = RequestMethod.POST,
             scheme = "https",
             authority = "api.foo.com",
-            path = "foo",
-            upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+            path = "foo")
             .build(),
         ByteBuffer.allocate(0),
         trailers,

--- a/library/kotlin/test/io/envoyproxy/envoymobile/GRPCRequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/GRPCRequestBuilderTest.kt
@@ -51,4 +51,13 @@ class GRPCRequestBuilderTest {
 
     assertThat(request.headers.containsKey("grpc-timeout")).isFalse()
   }
+
+  @Test
+  fun `h2 header is present`() {
+    val headers = GRPCRequestBuilder("/pb.api.v1.Foo/GetBar", "foo.bar.com", false)
+        .build()
+        .outboundHeaders()
+
+    assertThat(headers["x-envoy-mobile-upstream-protocol"]).containsExactly("http2")
+  }
 }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
@@ -9,7 +9,7 @@ class RequestBuilderTest {
   fun `adding retry policy should have policy present in request`() {
 
     val retryPolicy = RetryPolicy(maxRetryCount = 23, retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), perRetryTimeoutMS = 1234)
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addRetryPolicy(retryPolicy)
         .build()
 
@@ -18,7 +18,7 @@ class RequestBuilderTest {
 
   @Test
   fun `not adding retry policy should have null body in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
 
     assertThat(request.retryPolicy).isNull()
@@ -26,7 +26,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding new headers should append to the list of header keys`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")
         .build()
 
@@ -35,7 +35,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing headers should clear headers in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")
         .removeHeaders("header_a")
         .build()
@@ -45,7 +45,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific header value should not be in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -56,7 +56,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific header value should keep the other header values in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -67,7 +67,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding a specific header value should keep the other header values in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .build()
@@ -77,7 +77,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing all header values should remove header list in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")
         .removeHeader("header_a", "value_a1")
         .build()

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
@@ -36,7 +36,7 @@ class RequestBuilderTest {
   }
 
   @Test
-  fun `not adding upstream http protocol should have null body in request`() {
+  fun `not adding upstream http protocol should have null upstream protocol in request`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .build()
 

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
@@ -9,7 +9,7 @@ class RequestBuilderTest {
   fun `adding retry policy should have policy present in request`() {
 
     val retryPolicy = RetryPolicy(maxRetryCount = 23, retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), perRetryTimeoutMS = 1234)
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addRetryPolicy(retryPolicy)
         .build()
 
@@ -18,15 +18,34 @@ class RequestBuilderTest {
 
   @Test
   fun `not adding retry policy should have null body in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .build()
 
     assertThat(request.retryPolicy).isNull()
   }
 
   @Test
+  fun `adding upstream http protocol should have hint present in request`() {
+
+    val retryPolicy = RetryPolicy(maxRetryCount = 23, retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), perRetryTimeoutMS = 1234)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+        .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
+        .build()
+
+    assertThat(request.upstreamHttpProtocol).isEqualTo(UpstreamHttpProtocol.HTTP2)
+  }
+
+  @Test
+  fun `not adding upstream http protocol should have null body in request`() {
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+        .build()
+
+    assertThat(request.upstreamHttpProtocol).isNull()
+  }
+
+  @Test
   fun `adding new headers should append to the list of header keys`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .build()
 
@@ -35,7 +54,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing headers should clear headers in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .removeHeaders("header_a")
         .build()
@@ -45,7 +64,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific header value should not be in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -56,7 +75,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing a specific header value should keep the other header values in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -67,7 +86,7 @@ class RequestBuilderTest {
 
   @Test
   fun `adding a specific header value should keep the other header values in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .build()
@@ -77,7 +96,7 @@ class RequestBuilderTest {
 
   @Test
   fun `removing all header values should remove header list in request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .removeHeader("header_a", "value_a1")
         .build()

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestMapperTest.kt
@@ -74,7 +74,7 @@ class RequestMapperTest {
   }
 
   @Test
-  fun `invalid semicolon prefixed header keys are filtered out of outbound request headers`() {
+  fun `restricted header keys are filtered out of outbound request headers`() {
     val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .addHeader(":restricted", "value")
         .addHeader("x-envoy-mobile-test", "value")

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestMapperTest.kt
@@ -7,7 +7,7 @@ class RequestMapperTest {
 
   @Test
   fun `method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -16,7 +16,7 @@ class RequestMapperTest {
 
   @Test
   fun `scheme is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -26,7 +26,7 @@ class RequestMapperTest {
 
   @Test
   fun `authority is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -35,7 +35,7 @@ class RequestMapperTest {
 
   @Test
   fun `path is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -43,8 +43,26 @@ class RequestMapperTest {
   }
 
   @Test
+  fun `h1 is added to outbound request headers`() {
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP1)
+        .build()
+        .outboundHeaders()
+
+    assertThat(requestHeaders["x-envoy-mobile-upstream-protocol"]).containsExactly("http1")
+  }
+
+  @Test
+  fun `h2 is added to outbound request headers`() {
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+        .build()
+        .outboundHeaders()
+
+    assertThat(requestHeaders["x-envoy-mobile-upstream-protocol"]).containsExactly("http2")
+  }
+
+  @Test
   fun `same key headers are joined to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_1", "value_a")
         .addHeader("header_1", "value_b")
         .build()
@@ -55,31 +73,35 @@ class RequestMapperTest {
 
   @Test
   fun `invalid semicolon prefixed header keys are filtered out of outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader(":restricted", "value")
+        .addHeader("x-envoy-mobile-test", "value")
         .build()
         .outboundHeaders()
 
     assertThat(requestHeaders).doesNotContainKey(":restricted")
+    assertThat(requestHeaders).doesNotContainKey("x-envoy-mobile-test")
   }
 
   @Test
   fun `restricted headers are not overwritten in outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader(":scheme", "override")
         .addHeader(":authority", "override")
         .addHeader(":path", "override")
+        .addHeader("x-envoy-mobile-upstream-protocol", "override")
         .build()
         .outboundHeaders()
 
     assertThat(requestHeaders[":scheme"]).containsExactly("https")
     assertThat(requestHeaders[":authority"]).containsExactly("api.foo.com")
     assertThat(requestHeaders[":path"]).containsExactly("/foo")
+    assertThat(requestHeaders["x-envoy-mobile-upstream-protocol"]).containsExactly("http2")
   }
 
   @Test
   fun `request headers are forwarded to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_1", "value_a")
         .addHeader("header_2", "value_b")
         .build()
@@ -102,7 +124,7 @@ class RequestMapperTest {
         perRetryTimeoutMS = 9001)
     val retryPolicyHeaders = retryPolicy.outboundHeaders()
 
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addRetryPolicy(retryPolicy)
         .build()
         .outboundHeaders()
@@ -123,7 +145,7 @@ class RequestMapperTest {
         perRetryTimeoutMS = 9001)
     val retryPolicyHeaders = retryPolicy.outboundHeaders()
 
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("x-envoy-max-retries", "override")
         .addRetryPolicy(retryPolicy)
         .build()
@@ -134,7 +156,7 @@ class RequestMapperTest {
 
   @Test
   fun `delete method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.DELETE, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.DELETE, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -143,7 +165,7 @@ class RequestMapperTest {
 
   @Test
   fun `get method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.GET, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.GET, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -152,7 +174,7 @@ class RequestMapperTest {
 
   @Test
   fun `head method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.HEAD, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.HEAD, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -161,7 +183,7 @@ class RequestMapperTest {
 
   @Test
   fun `options method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.OPTIONS, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.OPTIONS, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -170,7 +192,7 @@ class RequestMapperTest {
 
   @Test
   fun `patch method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.PATCH, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.PATCH, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -179,7 +201,7 @@ class RequestMapperTest {
 
   @Test
   fun `post method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -188,7 +210,7 @@ class RequestMapperTest {
 
   @Test
   fun `put method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.PUT, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.PUT, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -197,7 +219,7 @@ class RequestMapperTest {
 
   @Test
   fun `trace method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.TRACE, scheme = "https", authority = "api.foo.com", path = "/foo")
+    val requestHeaders = RequestBuilder(method = RequestMethod.TRACE, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestMapperTest.kt
@@ -7,7 +7,7 @@ class RequestMapperTest {
 
   @Test
   fun `method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -16,7 +16,7 @@ class RequestMapperTest {
 
   @Test
   fun `scheme is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -26,7 +26,7 @@ class RequestMapperTest {
 
   @Test
   fun `authority is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -35,7 +35,7 @@ class RequestMapperTest {
 
   @Test
   fun `path is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -44,7 +44,8 @@ class RequestMapperTest {
 
   @Test
   fun `h1 is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP1)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+        .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP1)
         .build()
         .outboundHeaders()
 
@@ -53,7 +54,8 @@ class RequestMapperTest {
 
   @Test
   fun `h2 is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+        .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
         .build()
         .outboundHeaders()
 
@@ -62,7 +64,7 @@ class RequestMapperTest {
 
   @Test
   fun `same key headers are joined to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .addHeader("header_1", "value_a")
         .addHeader("header_1", "value_b")
         .build()
@@ -73,7 +75,7 @@ class RequestMapperTest {
 
   @Test
   fun `invalid semicolon prefixed header keys are filtered out of outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .addHeader(":restricted", "value")
         .addHeader("x-envoy-mobile-test", "value")
         .build()
@@ -85,7 +87,8 @@ class RequestMapperTest {
 
   @Test
   fun `restricted headers are not overwritten in outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
+        .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
         .addHeader(":scheme", "override")
         .addHeader(":authority", "override")
         .addHeader(":path", "override")
@@ -101,7 +104,7 @@ class RequestMapperTest {
 
   @Test
   fun `request headers are forwarded to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .addHeader("header_1", "value_a")
         .addHeader("header_2", "value_b")
         .build()
@@ -124,7 +127,7 @@ class RequestMapperTest {
         perRetryTimeoutMS = 9001)
     val retryPolicyHeaders = retryPolicy.outboundHeaders()
 
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .addRetryPolicy(retryPolicy)
         .build()
         .outboundHeaders()
@@ -145,7 +148,7 @@ class RequestMapperTest {
         perRetryTimeoutMS = 9001)
     val retryPolicyHeaders = retryPolicy.outboundHeaders()
 
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .addHeader("x-envoy-max-retries", "override")
         .addRetryPolicy(retryPolicy)
         .build()
@@ -156,7 +159,7 @@ class RequestMapperTest {
 
   @Test
   fun `delete method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.DELETE, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.DELETE, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -165,7 +168,7 @@ class RequestMapperTest {
 
   @Test
   fun `get method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.GET, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.GET, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -174,7 +177,7 @@ class RequestMapperTest {
 
   @Test
   fun `head method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.HEAD, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.HEAD, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -183,7 +186,7 @@ class RequestMapperTest {
 
   @Test
   fun `options method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.OPTIONS, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.OPTIONS, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -192,7 +195,7 @@ class RequestMapperTest {
 
   @Test
   fun `patch method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.PATCH, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.PATCH, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -201,7 +204,7 @@ class RequestMapperTest {
 
   @Test
   fun `post method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -210,7 +213,7 @@ class RequestMapperTest {
 
   @Test
   fun `put method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.PUT, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.PUT, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 
@@ -219,7 +222,7 @@ class RequestMapperTest {
 
   @Test
   fun `trace method is added to outbound request headers`() {
-    val requestHeaders = RequestBuilder(method = RequestMethod.TRACE, scheme = "https", authority = "api.foo.com", path = "/foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val requestHeaders = RequestBuilder(method = RequestMethod.TRACE, scheme = "https", authority = "api.foo.com", path = "/foo")
         .build()
         .outboundHeaders()
 

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
@@ -8,13 +8,13 @@ class RequestTest {
 
   @Test
   fun `requests with the same properties should be equal`() {
-    val request1 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request1 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .addHeader("header_b", "value_b1")
         .build()
 
-    val request2 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request2 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .addHeader("header_b", "value_b1")
@@ -25,7 +25,7 @@ class RequestTest {
 
   @Test
   fun `requests converted to a builder should build to the same request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
         .addRetryPolicy(RetryPolicy(23, listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), 1234))
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
@@ -8,13 +8,13 @@ class RequestTest {
 
   @Test
   fun `requests with the same properties should be equal`() {
-    val request1 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request1 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .addHeader("header_b", "value_b1")
         .build()
 
-    val request2 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request2 = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .addHeader("header_b", "value_b1")
@@ -25,8 +25,9 @@ class RequestTest {
 
   @Test
   fun `requests converted to a builder should build to the same request`() {
-    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo", upstreamHttpProtocol = UpstreamHttpProtocol.HTTP2)
+    val request = RequestBuilder(method = RequestMethod.POST, scheme = "https", authority = "api.foo.com", path = "foo")
         .addRetryPolicy(RetryPolicy(23, listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), 1234))
+        .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .addHeader("header_b", "value_b1")

--- a/library/swift/src/BUILD
+++ b/library/swift/src/BUILD
@@ -24,6 +24,7 @@ swift_static_framework(
         "RetryPolicy.swift",
         "RetryPolicyMapper.swift",
         "StreamEmitter.swift",
+        "UpstreamHttpProtocol.swift",
     ],
     module_name = "Envoy",
     objc_includes = [

--- a/library/swift/src/GRPCRequestBuilder.swift
+++ b/library/swift/src/GRPCRequestBuilder.swift
@@ -14,7 +14,8 @@ public final class GRPCRequestBuilder: NSObject {
     self.underlyingBuilder = RequestBuilder(method: .post,
                                             scheme: useHTTPS ? "https" : "http",
                                             authority: authority,
-                                            path: path)
+                                            path: path,
+                                            upstreamHttpProtocol: .http2)
     self.underlyingBuilder.addHeader(name: "content-type", value: "application/grpc")
   }
 

--- a/library/swift/src/GRPCRequestBuilder.swift
+++ b/library/swift/src/GRPCRequestBuilder.swift
@@ -14,9 +14,9 @@ public final class GRPCRequestBuilder: NSObject {
     self.underlyingBuilder = RequestBuilder(method: .post,
                                             scheme: useHTTPS ? "https" : "http",
                                             authority: authority,
-                                            path: path,
-                                            upstreamHttpProtocol: .http2)
+                                            path: path)
     self.underlyingBuilder.addHeader(name: "content-type", value: "application/grpc")
+    self.underlyingBuilder.addUpstreamHttpProtocol(.http2)
   }
 
   /// Append a value to the header key.

--- a/library/swift/src/Request.swift
+++ b/library/swift/src/Request.swift
@@ -11,6 +11,8 @@ public final class Request: NSObject {
   public let authority: String
   /// The URL path for the request (i.e., "/foo").
   public let path: String
+  /// The protcol version to use for upstream requests.
+  public let upstreamHttpProtocol: UpstreamHttpProtocol
   /// Headers to send with the request.
   /// Multiple values for a given name are valid, and will be sent as comma-separated values.
   public let headers: [String: [String]]
@@ -29,6 +31,7 @@ public final class Request: NSObject {
        scheme: String,
        authority: String,
        path: String,
+       upstreamHttpProtocol: UpstreamHttpProtocol,
        headers: [String: [String]] = [:],
        retryPolicy: RetryPolicy?)
   {
@@ -36,6 +39,7 @@ public final class Request: NSObject {
     self.scheme = scheme
     self.authority = authority
     self.path = path
+    self.upstreamHttpProtocol = upstreamHttpProtocol
     self.headers = headers
     self.retryPolicy = retryPolicy
   }
@@ -53,6 +57,7 @@ extension Request {
       && self.scheme == other.scheme
       && self.authority == other.authority
       && self.path == other.path
+      && self.upstreamHttpProtocol == other.upstreamHttpProtocol
       && self.headers == other.headers
       && self.retryPolicy == other.retryPolicy
   }

--- a/library/swift/src/Request.swift
+++ b/library/swift/src/Request.swift
@@ -11,13 +11,13 @@ public final class Request: NSObject {
   public let authority: String
   /// The URL path for the request (i.e., "/foo").
   public let path: String
-  /// The protcol version to use for upstream requests.
-  public let upstreamHttpProtocol: UpstreamHttpProtocol
   /// Headers to send with the request.
   /// Multiple values for a given name are valid, and will be sent as comma-separated values.
   public let headers: [String: [String]]
-  // Retry policy to use for this request.
+  /// Retry policy to use for this request.
   public let retryPolicy: RetryPolicy?
+  /// The protocol version to use for upstream requests.
+  public let upstreamHttpProtocol: UpstreamHttpProtocol?
 
   /// Converts the request back to a builder so that it can be modified (i.e., by a filter).
   ///
@@ -31,17 +31,17 @@ public final class Request: NSObject {
        scheme: String,
        authority: String,
        path: String,
-       upstreamHttpProtocol: UpstreamHttpProtocol,
        headers: [String: [String]] = [:],
-       retryPolicy: RetryPolicy?)
+       retryPolicy: RetryPolicy?,
+       upstreamHttpProtocol: UpstreamHttpProtocol?)
   {
     self.method = method
     self.scheme = scheme
     self.authority = authority
     self.path = path
-    self.upstreamHttpProtocol = upstreamHttpProtocol
     self.headers = headers
     self.retryPolicy = retryPolicy
+    self.upstreamHttpProtocol = upstreamHttpProtocol
   }
 }
 
@@ -57,8 +57,8 @@ extension Request {
       && self.scheme == other.scheme
       && self.authority == other.authority
       && self.path == other.path
-      && self.upstreamHttpProtocol == other.upstreamHttpProtocol
       && self.headers == other.headers
       && self.retryPolicy == other.retryPolicy
+      && self.upstreamHttpProtocol == other.upstreamHttpProtocol
   }
 }

--- a/library/swift/src/RequestBuilder.swift
+++ b/library/swift/src/RequestBuilder.swift
@@ -74,7 +74,9 @@ public final class RequestBuilder: NSObject {
   }
 
   @discardableResult
-  public func addUpstreamHttpProtocol(_ upstreamHttpProtocol: UpstreamHttpProtocol) -> RequestBuilder {
+  public func addUpstreamHttpProtocol(_ upstreamHttpProtocol: UpstreamHttpProtocol)
+    -> RequestBuilder
+  {
     self.upstreamHttpProtocol = upstreamHttpProtocol
     return self
   }

--- a/library/swift/src/RequestBuilder.swift
+++ b/library/swift/src/RequestBuilder.swift
@@ -11,13 +11,13 @@ public final class RequestBuilder: NSObject {
   public let authority: String
   /// The URL path for the request (i.e., "/foo").
   public let path: String
-  /// The protcol version to use for upstream requests.
-  public let upstreamHttpProtocol: UpstreamHttpProtocol
   /// Headers to send with the request.
   /// Multiple values for a given name are valid, and will be sent as comma-separated values.
   public private(set) var headers: [String: [String]] = [:]
-  // Retry policy to use for this request.
+  /// Retry policy to use for this request.
   public private(set) var retryPolicy: RetryPolicy?
+  /// The protocol version to use for upstream requests.
+  public private(set) var upstreamHttpProtocol: UpstreamHttpProtocol?
 
   // MARK: - Initializers
 
@@ -36,14 +36,12 @@ public final class RequestBuilder: NSObject {
   public init(method: RequestMethod,
               scheme: String = "https",
               authority: String,
-              path: String,
-              upstreamHttpProtocol: UpstreamHttpProtocol)
+              path: String)
   {
     self.method = method
     self.scheme = scheme
     self.authority = authority
     self.path = path
-    self.upstreamHttpProtocol = upstreamHttpProtocol
   }
 
   // MARK: - Builder functions
@@ -66,13 +64,18 @@ public final class RequestBuilder: NSObject {
     if self.headers[name]?.isEmpty == true {
       self.headers.removeValue(forKey: name)
     }
-
     return self
   }
 
   @discardableResult
   public func addRetryPolicy(_ retryPolicy: RetryPolicy) -> RequestBuilder {
     self.retryPolicy = retryPolicy
+    return self
+  }
+
+  @discardableResult
+  public func addUpstreamHttpProtocol(_ upstreamHttpProtocol: UpstreamHttpProtocol) -> RequestBuilder {
+    self.upstreamHttpProtocol = upstreamHttpProtocol
     return self
   }
 
@@ -102,12 +105,11 @@ extension Request {
                           scheme: String,
                           authority: String,
                           path: String,
-                          upstreamHttpProtocol: UpstreamHttpProtocol,
                           build: (RequestBuilder) -> Void)
     -> Request
   {
     let builder = RequestBuilder(method: method, scheme: scheme,
-                                 authority: authority, path: path, upstreamHttpProtocol: upstreamHttpProtocol)
+                                 authority: authority, path: path)
     build(builder)
     return builder.build()
   }

--- a/library/swift/src/RequestBuilder.swift
+++ b/library/swift/src/RequestBuilder.swift
@@ -11,6 +11,8 @@ public final class RequestBuilder: NSObject {
   public let authority: String
   /// The URL path for the request (i.e., "/foo").
   public let path: String
+  /// The protcol version to use for upstream requests.
+  public let upstreamHttpProtocol: UpstreamHttpProtocol
   /// Headers to send with the request.
   /// Multiple values for a given name are valid, and will be sent as comma-separated values.
   public private(set) var headers: [String: [String]] = [:]
@@ -25,6 +27,7 @@ public final class RequestBuilder: NSObject {
     self.scheme = request.scheme
     self.authority = request.authority
     self.path = request.path
+    self.upstreamHttpProtocol = request.upstreamHttpProtocol
     self.headers = request.headers
     self.retryPolicy = request.retryPolicy
   }
@@ -33,12 +36,14 @@ public final class RequestBuilder: NSObject {
   public init(method: RequestMethod,
               scheme: String = "https",
               authority: String,
-              path: String)
+              path: String,
+              upstreamHttpProtocol: UpstreamHttpProtocol)
   {
     self.method = method
     self.scheme = scheme
     self.authority = authority
     self.path = path
+    self.upstreamHttpProtocol = upstreamHttpProtocol
   }
 
   // MARK: - Builder functions
@@ -76,6 +81,7 @@ public final class RequestBuilder: NSObject {
                    scheme: self.scheme,
                    authority: self.authority,
                    path: self.path,
+                   upstreamHttpProtocol: self.upstreamHttpProtocol,
                    headers: self.headers,
                    retryPolicy: self.retryPolicy)
   }
@@ -96,11 +102,12 @@ extension Request {
                           scheme: String,
                           authority: String,
                           path: String,
+                          upstreamHttpProtocol: UpstreamHttpProtocol,
                           build: (RequestBuilder) -> Void)
     -> Request
   {
     let builder = RequestBuilder(method: method, scheme: scheme,
-                                 authority: authority, path: path)
+                                 authority: authority, path: path, upstreamHttpProtocol: upstreamHttpProtocol)
     build(builder)
     return builder.build()
   }

--- a/library/swift/src/RequestBuilder.swift
+++ b/library/swift/src/RequestBuilder.swift
@@ -86,9 +86,9 @@ public final class RequestBuilder: NSObject {
                    scheme: self.scheme,
                    authority: self.authority,
                    path: self.path,
-                   upstreamHttpProtocol: self.upstreamHttpProtocol,
                    headers: self.headers,
-                   retryPolicy: self.retryPolicy)
+                   retryPolicy: self.retryPolicy,
+                   upstreamHttpProtocol: self.upstreamHttpProtocol)
   }
 }
 

--- a/library/swift/src/RequestMapper.swift
+++ b/library/swift/src/RequestMapper.swift
@@ -1,4 +1,4 @@
-private let kRestrictedHeaderPrefix = ":"
+private let kRestrictedHeaderPrefix = [":", "x-envoy-mobile"]
 
 extension Request {
   /// Returns a set of outbound headers that include HTTP
@@ -7,12 +7,13 @@ extension Request {
   /// - returns: Outbound headers to send with an HTTP request.
   func outboundHeaders() -> [String: [String]] {
     var headers = self.headers
-      .filter { !$0.key.hasPrefix(kRestrictedHeaderPrefix) }
+      .filter { !kRestrictedHeaderPrefix.contains(where: $0.key.hasPrefix) }
       .reduce(into: [
         ":method": [self.method.stringValue],
         ":scheme": [self.scheme],
         ":authority": [self.authority],
         ":path": [self.path],
+        "x-envoy-mobile-upstream-protocol": [self.upstreamHttpProtocol.stringValue],
       ]) { $0[$1.key] = $1.value }
 
     if let retryPolicy = self.retryPolicy {

--- a/library/swift/src/RequestMapper.swift
+++ b/library/swift/src/RequestMapper.swift
@@ -1,4 +1,4 @@
-private let kRestrictedHeaderPrefix = [":", "x-envoy-mobile"]
+private let kRestrictedHeaderPrefixes = [":", "x-envoy-mobile"]
 
 extension Request {
   /// Returns a set of outbound headers that include HTTP
@@ -7,7 +7,7 @@ extension Request {
   /// - returns: Outbound headers to send with an HTTP request.
   func outboundHeaders() -> [String: [String]] {
     var headers = self.headers
-      .filter { !kRestrictedHeaderPrefix.contains(where: $0.key.hasPrefix) }
+      .filter { !kRestrictedHeaderPrefixes.contains(where: $0.key.hasPrefix) }
       .reduce(into: [
         ":method": [self.method.stringValue],
         ":scheme": [self.scheme],

--- a/library/swift/src/RequestMapper.swift
+++ b/library/swift/src/RequestMapper.swift
@@ -13,11 +13,14 @@ extension Request {
         ":scheme": [self.scheme],
         ":authority": [self.authority],
         ":path": [self.path],
-        "x-envoy-mobile-upstream-protocol": [self.upstreamHttpProtocol.stringValue],
       ]) { $0[$1.key] = $1.value }
 
     if let retryPolicy = self.retryPolicy {
       headers = headers.merging(retryPolicy.outboundHeaders()) { _, retryHeader in retryHeader }
+    }
+
+    if let upstreamHttpProtocol = self.upstreamHttpProtocol {
+      headers["x-envoy-mobile-upstream-protocol"] = [upstreamHttpProtocol.stringValue]
     }
 
     return headers

--- a/library/swift/src/UpstreamHttpProtocol.swift
+++ b/library/swift/src/UpstreamHttpProtocol.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-/// Available upstream http protocols.
+/// Available upstream HTTP protocols.
 @objc
 public enum UpstreamHttpProtocol: Int {
   case http1
   case http2
 
-  /// String representation of the log level.
+  /// String representation of the protocol.
   var stringValue: String {
     switch self {
     case .http1:

--- a/library/swift/src/UpstreamHttpProtocol.swift
+++ b/library/swift/src/UpstreamHttpProtocol.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Available upstream http protocols.
+@objc
+public enum UpstreamHttpProtocol: Int {
+  case http1
+  case http2
+
+  /// String representation of the log level.
+  var stringValue: String {
+    switch self {
+    case .http1:
+      return "http1"
+    case .http2:
+      return "http2"
+    }
+  }
+}

--- a/library/swift/test/EnvoyClientTests.swift
+++ b/library/swift/test/EnvoyClientTests.swift
@@ -28,7 +28,7 @@ final class EnvoyClientTests: XCTestCase {
     let closeExpectation = self.expectation(description: "Calls close")
 
     let expectedRequest = RequestBuilder(
-      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs", upstreamHttpProtocol: .http2)
+      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
       .build()
     let expectedData = Data([1, 2, 3])
     let expectedTrailers = ["foo": ["bar", "baz"]]

--- a/library/swift/test/EnvoyClientTests.swift
+++ b/library/swift/test/EnvoyClientTests.swift
@@ -28,7 +28,7 @@ final class EnvoyClientTests: XCTestCase {
     let closeExpectation = self.expectation(description: "Calls close")
 
     let expectedRequest = RequestBuilder(
-      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
+      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs", upstreamHttpProtocol: .http2)
       .build()
     let expectedData = Data([1, 2, 3])
     let expectedTrailers = ["foo": ["bar", "baz"]]

--- a/library/swift/test/GRPCRequestBuilderTests.swift
+++ b/library/swift/test/GRPCRequestBuilderTests.swift
@@ -26,6 +26,14 @@ final class GRPCRequestBuilderTests: XCTestCase {
     XCTAssertEqual(["application/grpc"], request.headers["content-type"])
   }
 
+  func testAddsH2UpstreamHeader() {
+    let headers = GRPCRequestBuilder(path: "/pb.api.v1.Foo/GetBar",
+                                     authority: "foo.bar.com")
+      .build()
+      .outboundHeaders()
+    XCTAssertEqual(["http2"], headers["x-envoy-mobile-upstream-protocol"])
+  }
+
   func testUsesHTTPPOST() {
     let request = GRPCRequestBuilder(path: "/pb.api.v1.Foo/GetBar",
                                      authority: "foo.bar.com")

--- a/library/swift/test/RequestBuilderTests.swift
+++ b/library/swift/test/RequestBuilderTests.swift
@@ -11,7 +11,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testHasMatchingMethodPresentInRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+                                 authority: "api.foo.com", path: "/foo")
       .build()
     XCTAssertEqual(.post, request.method)
   }
@@ -20,7 +20,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testHasMatchingURLPresentInRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+                                 authority: "api.foo.com", path: "/foo")
       .build()
     XCTAssertEqual("https", request.scheme)
     XCTAssertEqual("api.foo.com", request.authority)
@@ -31,7 +31,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testAddingRetryPolicyHasRetryPolicyInRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+                                 authority: "api.foo.com", path: "/foo")
       .addRetryPolicy(kRetryPolicy)
       .build()
     XCTAssertEqual(kRetryPolicy, request.retryPolicy)
@@ -39,7 +39,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testNotAddingRetryPolicyHasNilRetryPolicyInRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+                                 authority: "api.foo.com", path: "/foo")
       .build()
     XCTAssertNil(request.retryPolicy)
   }
@@ -48,7 +48,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testAddingNewHeaderAddsToListOfHeaderKeys() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "bar")
       .build()
     XCTAssertEqual(["bar"], request.headers["foo"])
@@ -56,7 +56,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testRemovingSpecificHeaderKeyRemovesAllOfItsValuesFromRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .removeHeaders(name: "foo")
@@ -66,7 +66,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testRemovingSpecificHeaderKeyDoesNotRemoveOtherKeysFromRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "bar", value: "2")
       .removeHeaders(name: "foo")
@@ -76,7 +76,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testRemovingSpecificHeaderValueRemovesItFromRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .addHeader(name: "foo", value: "3")
@@ -87,13 +87,30 @@ final class RequestBuilderTests: XCTestCase {
 
   func testRemovingAllHeaderValuesRemovesKeyFromRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+                                 authority: "api.foo.com", path: "/foo")
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .removeHeader(name: "foo", value: "1")
       .removeHeader(name: "foo", value: "2")
       .build()
     XCTAssertNil(request.headers["foo"])
+  }
+
+  // MARK: - Upstream Http Protocol
+
+  func testAddingUpstreamHttpProtocolHasUpstreamHttpProtocolInRequest() {
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
+      .addUpstreamHttpProtocol(.http1)
+      .build()
+    XCTAssertEqual(.http1, request.upstreamHttpProtocol)
+  }
+
+  func testNotAddingUpstreamHttpProtocolHasNilUpstreamHttpProtocolInRequest() {
+    let request = RequestBuilder(method: .post, scheme: "https",
+                                 authority: "api.foo.com", path: "/foo")
+      .build()
+    XCTAssertNil(request.upstreamHttpProtocol)
   }
 
   // MARK: - Request conversion
@@ -119,7 +136,7 @@ final class RequestBuilderTests: XCTestCase {
   // MARK: - Private
 
   private func newRequestBuilder() -> RequestBuilder {
-    return RequestBuilder(method: .post, scheme: "https", authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
+    return RequestBuilder(method: .post, scheme: "https", authority: "api.foo.com", path: "/foo")
       .addRetryPolicy(kRetryPolicy)
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")

--- a/library/swift/test/RequestBuilderTests.swift
+++ b/library/swift/test/RequestBuilderTests.swift
@@ -96,7 +96,7 @@ final class RequestBuilderTests: XCTestCase {
     XCTAssertNil(request.headers["foo"])
   }
 
-  // MARK: - Upstream Http Protocol
+  // MARK: - Upstream HTTP Protocol
 
   func testAddingUpstreamHttpProtocolHasUpstreamHttpProtocolInRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",

--- a/library/swift/test/RequestBuilderTests.swift
+++ b/library/swift/test/RequestBuilderTests.swift
@@ -11,7 +11,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testHasMatchingMethodPresentInRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo")
+                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .build()
     XCTAssertEqual(.post, request.method)
   }
@@ -20,7 +20,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testHasMatchingURLPresentInRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo")
+                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .build()
     XCTAssertEqual("https", request.scheme)
     XCTAssertEqual("api.foo.com", request.authority)
@@ -31,7 +31,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testAddingRetryPolicyHasRetryPolicyInRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo")
+                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .addRetryPolicy(kRetryPolicy)
       .build()
     XCTAssertEqual(kRetryPolicy, request.retryPolicy)
@@ -39,7 +39,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testNotAddingRetryPolicyHasNilRetryPolicyInRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo")
+                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .build()
     XCTAssertNil(request.retryPolicy)
   }
@@ -48,7 +48,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testAddingNewHeaderAddsToListOfHeaderKeys() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo")
+                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: "foo", value: "bar")
       .build()
     XCTAssertEqual(["bar"], request.headers["foo"])
@@ -56,7 +56,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testRemovingSpecificHeaderKeyRemovesAllOfItsValuesFromRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo")
+                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .removeHeaders(name: "foo")
@@ -66,7 +66,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testRemovingSpecificHeaderKeyDoesNotRemoveOtherKeysFromRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo")
+                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "bar", value: "2")
       .removeHeaders(name: "foo")
@@ -76,7 +76,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testRemovingSpecificHeaderValueRemovesItFromRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo")
+                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .addHeader(name: "foo", value: "3")
@@ -87,7 +87,7 @@ final class RequestBuilderTests: XCTestCase {
 
   func testRemovingAllHeaderValuesRemovesKeyFromRequest() {
     let request = RequestBuilder(method: .post, scheme: "https",
-                                 authority: "api.foo.com", path: "/foo")
+                                 authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .removeHeader(name: "foo", value: "1")
@@ -119,7 +119,7 @@ final class RequestBuilderTests: XCTestCase {
   // MARK: - Private
 
   private func newRequestBuilder() -> RequestBuilder {
-    return RequestBuilder(method: .post, scheme: "https", authority: "api.foo.com", path: "/foo")
+    return RequestBuilder(method: .post, scheme: "https", authority: "api.foo.com", path: "/foo", upstreamHttpProtocol: .http2)
       .addRetryPolicy(kRetryPolicy)
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")

--- a/library/swift/test/RequestMapperTests.swift
+++ b/library/swift/test/RequestMapperTests.swift
@@ -3,49 +3,51 @@ import XCTest
 
 final class RequestMapperTests: XCTestCase {
   func testAddsMethodToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .build()
       .outboundHeaders()
     XCTAssertEqual(["POST"], headers[":method"])
   }
 
   func testAddsSchemeToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .build()
       .outboundHeaders()
     XCTAssertEqual(["https"], headers[":scheme"])
   }
 
   func testAddsAuthorityToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .build()
       .outboundHeaders()
     XCTAssertEqual(["x.y.z"], headers[":authority"])
   }
 
   func testAddsPathToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .build()
       .outboundHeaders()
     XCTAssertEqual(["/foo"], headers[":path"])
   }
 
-  func testAddsH2ToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
-      .build()
-      .outboundHeaders()
-    XCTAssertEqual(["http2"], headers["x-envoy-mobile-upstream-protocol"])
-  }
-
   func testAddsH1ToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http1)
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .addUpstreamHttpProtocol(.http1)
       .build()
       .outboundHeaders()
     XCTAssertEqual(["http1"], headers["x-envoy-mobile-upstream-protocol"])
   }
 
+  func testAddsH2ToHeaders() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .addUpstreamHttpProtocol(.http2)
+      .build()
+      .outboundHeaders()
+    XCTAssertEqual(["http2"], headers["x-envoy-mobile-upstream-protocol"])
+  }
+
   func testJoinsHeaderValuesWithTheSameKey() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .build()
@@ -54,7 +56,7 @@ final class RequestMapperTests: XCTestCase {
   }
 
   func testStripsHeadersWithSemicolonPrefix() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .addHeader(name: ":restricted", value: "someValue")
       .build()
       .outboundHeaders()
@@ -62,7 +64,7 @@ final class RequestMapperTests: XCTestCase {
   }
 
   func testStripsHeadersWithXEnvoyMobilePrefix() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
       .addHeader(name: "x-envoy-mobile-test", value: "someValue")
       .build()
       .outboundHeaders()
@@ -70,7 +72,8 @@ final class RequestMapperTests: XCTestCase {
   }
 
   func testCannotOverrideStandardRestrictedHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+      .addUpstreamHttpProtocol(.http2)
       .addHeader(name: ":scheme", value: "override")
       .addHeader(name: ":authority", value: "override")
       .addHeader(name: ":path", value: "override")
@@ -89,7 +92,7 @@ final class RequestMapperTests: XCTestCase {
                                   perRetryTimeoutMS: 9001)
     let retryHeaders = retryPolicy.outboundHeaders()
     let requestHeaders = RequestBuilder(method: .post, scheme: "https",
-                                        authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+                                        authority: "x.y.z", path: "/foo")
       .addHeader(name: "foo", value: "bar")
       .addRetryPolicy(retryPolicy)
       .build()
@@ -106,7 +109,7 @@ final class RequestMapperTests: XCTestCase {
     let retryPolicy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases,
                                   perRetryTimeoutMS: 9001)
     let requestHeaders = RequestBuilder(method: .post, scheme: "https",
-                                        authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+                                        authority: "x.y.z", path: "/foo")
       .addHeader(name: "x-envoy-max-retries", value: "override")
       .addRetryPolicy(retryPolicy)
       .build()

--- a/library/swift/test/RequestMapperTests.swift
+++ b/library/swift/test/RequestMapperTests.swift
@@ -3,35 +3,49 @@ import XCTest
 
 final class RequestMapperTests: XCTestCase {
   func testAddsMethodToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
       .build()
       .outboundHeaders()
     XCTAssertEqual(["POST"], headers[":method"])
   }
 
   func testAddsSchemeToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
       .build()
       .outboundHeaders()
     XCTAssertEqual(["https"], headers[":scheme"])
   }
 
   func testAddsAuthorityToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
       .build()
       .outboundHeaders()
     XCTAssertEqual(["x.y.z"], headers[":authority"])
   }
 
   func testAddsPathToHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
       .build()
       .outboundHeaders()
     XCTAssertEqual(["/foo"], headers[":path"])
   }
 
+  func testAddsH2ToHeaders() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+      .build()
+      .outboundHeaders()
+    XCTAssertEqual(["http2"], headers["x-envoy-mobile-upstream-protocol"])
+  }
+
+  func testAddsH1ToHeaders() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http1)
+      .build()
+      .outboundHeaders()
+    XCTAssertEqual(["http1"], headers["x-envoy-mobile-upstream-protocol"])
+  }
+
   func testJoinsHeaderValuesWithTheSameKey() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: "foo", value: "1")
       .addHeader(name: "foo", value: "2")
       .build()
@@ -40,24 +54,34 @@ final class RequestMapperTests: XCTestCase {
   }
 
   func testStripsHeadersWithSemicolonPrefix() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: ":restricted", value: "someValue")
       .build()
       .outboundHeaders()
     XCTAssertNil(headers[":restricted"])
   }
 
+  func testStripsHeadersWithXEnvoyMobilePrefix() {
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
+      .addHeader(name: "x-envoy-mobile-test", value: "someValue")
+      .build()
+      .outboundHeaders()
+    XCTAssertNil(headers["x-envoy-mobile-test"])
+  }
+
   func testCannotOverrideStandardRestrictedHeaders() {
-    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo")
+    let headers = RequestBuilder(method: .post, scheme: "https", authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: ":scheme", value: "override")
       .addHeader(name: ":authority", value: "override")
       .addHeader(name: ":path", value: "override")
+      .addHeader(name: "x-envoy-mobile-upstream-protocol", value: "override")
       .build()
       .outboundHeaders()
 
     XCTAssertEqual(["https"], headers[":scheme"])
     XCTAssertEqual(["x.y.z"], headers[":authority"])
     XCTAssertEqual(["/foo"], headers[":path"])
+    XCTAssertEqual(["http2"], headers["x-envoy-mobile-upstream-protocol"])
   }
 
   func testIncludesRetryPolicyHeaders() {
@@ -65,7 +89,7 @@ final class RequestMapperTests: XCTestCase {
                                   perRetryTimeoutMS: 9001)
     let retryHeaders = retryPolicy.outboundHeaders()
     let requestHeaders = RequestBuilder(method: .post, scheme: "https",
-                                        authority: "x.y.z", path: "/foo")
+                                        authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: "foo", value: "bar")
       .addRetryPolicy(retryPolicy)
       .build()
@@ -82,7 +106,7 @@ final class RequestMapperTests: XCTestCase {
     let retryPolicy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases,
                                   perRetryTimeoutMS: 9001)
     let requestHeaders = RequestBuilder(method: .post, scheme: "https",
-                                        authority: "x.y.z", path: "/foo")
+                                        authority: "x.y.z", path: "/foo", upstreamHttpProtocol: .http2)
       .addHeader(name: "x-envoy-max-retries", value: "override")
       .addRetryPolicy(retryPolicy)
       .build()

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -61,7 +61,7 @@ public:
   Dispatcher http_dispatcher_{preferred_network_};
 };
 
-TEST_F(DispatcherTest, PreferredNetwork) {
+TEST_F(DispatcherTest, SetDestinationCluster) {
   envoy_stream_t stream = 1;
   // Setup bridge_callbacks to handle the response headers.
   envoy_http_callbacks bridge_callbacks;
@@ -103,7 +103,7 @@ TEST_F(DispatcherTest, PreferredNetwork) {
   HttpTestUtility::addDefaultHeaders(headers);
   envoy_headers c_headers = Utility::toBridgeHeaders(headers);
 
-  preferred_network_.store(ENVOY_NET_WLAN);
+  preferred_network_.store(ENVOY_NET_GENERIC);
   Event::PostCb send_headers_post_cb;
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&send_headers_post_cb));
   http_dispatcher_.sendHeaders(stream, c_headers, false);
@@ -113,7 +113,7 @@ TEST_F(DispatcherTest, PreferredNetwork) {
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
-      {"x-envoy-mobile-cluster", "base_wlan"},
+      {"x-envoy-mobile-cluster", "base"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
   send_headers_post_cb();
@@ -155,6 +155,134 @@ TEST_F(DispatcherTest, PreferredNetwork) {
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers3), true));
   send_headers_post_cb3();
+
+  // Encode response headers.
+  Event::PostCb stream_deletion_post_cb;
+  EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
+  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&stream_deletion_post_cb));
+  TestHeaderMapImpl response_headers{{":status", "200"}};
+  response_encoder_->encodeHeaders(response_headers, true);
+  ASSERT_EQ(cc.on_headers_calls, 1);
+  stream_deletion_post_cb();
+
+  // Ensure that the callbacks on the bridge_callbacks were called.
+  ASSERT_EQ(cc.on_complete_calls, 1);
+}
+
+TEST_F(DispatcherTest, SetDestinationClusterUpstreamProtocol) {
+  envoy_stream_t stream = 1;
+  // Setup bridge_callbacks to handle the response headers.
+  envoy_http_callbacks bridge_callbacks;
+  callbacks_called cc = {0, 0, 0, 0, 0};
+  bridge_callbacks.context = &cc;
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void {
+    ASSERT_TRUE(end_stream);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
+    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_headers_calls++;
+  };
+  bridge_callbacks.on_complete = [](void* context) -> void {
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_complete_calls++;
+  };
+
+  // Create a stream.
+  Event::PostCb start_stream_post_cb;
+  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+
+  // Grab the response encoder in order to dispatch responses on the stream.
+  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
+  // API.
+  EXPECT_CALL(api_listener_, newStream(_, _))
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+        response_encoder_ = &encoder;
+        return request_decoder_;
+      }));
+  start_stream_post_cb();
+
+  // Send request headers. Sending multiple headers is illegal and the upstream codec would not
+  // accept it. However, given we are just trying to test preferred network headers and using mocks
+  // this is fine.
+
+  TestRequestHeaderMapImpl headers{{"x-envoy-mobile-upstream-protocol", "http2"}};
+  HttpTestUtility::addDefaultHeaders(headers);
+  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
+
+  preferred_network_.store(ENVOY_NET_GENERIC);
+  Event::PostCb send_headers_post_cb;
+  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&send_headers_post_cb));
+  http_dispatcher_.sendHeaders(stream, c_headers, false);
+
+  TestResponseHeaderMapImpl expected_headers{
+      {":scheme", "http"},
+      {":method", "GET"},
+      {":authority", "host"},
+      {":path", "/"},
+      {"x-envoy-mobile-cluster", "base_h2"},
+  };
+  EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
+  send_headers_post_cb();
+
+  TestRequestHeaderMapImpl headers2{{"x-envoy-mobile-upstream-protocol", "http2"}};
+  HttpTestUtility::addDefaultHeaders(headers2);
+  envoy_headers c_headers2 = Utility::toBridgeHeaders(headers2);
+
+  preferred_network_.store(ENVOY_NET_WLAN);
+  Event::PostCb send_headers_post_cb2;
+  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&send_headers_post_cb2));
+  http_dispatcher_.sendHeaders(stream, c_headers2, false);
+
+  TestResponseHeaderMapImpl expected_headers2{
+      {":scheme", "http"},
+      {":method", "GET"},
+      {":authority", "host"},
+      {":path", "/"},
+      {"x-envoy-mobile-cluster", "base_wlan_h2"},
+  };
+  EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers2), false));
+  send_headers_post_cb2();
+
+  TestRequestHeaderMapImpl headers3{{"x-envoy-mobile-upstream-protocol", "http2"}};
+  HttpTestUtility::addDefaultHeaders(headers3);
+  envoy_headers c_headers3 = Utility::toBridgeHeaders(headers3);
+
+  preferred_network_.store(ENVOY_NET_WWAN);
+  Event::PostCb send_headers_post_cb3;
+  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&send_headers_post_cb3));
+  http_dispatcher_.sendHeaders(stream, c_headers3, true);
+
+  TestResponseHeaderMapImpl expected_headers3{
+      {":scheme", "http"},
+      {":method", "GET"},
+      {":authority", "host"},
+      {":path", "/"},
+      {"x-envoy-mobile-cluster", "base_wwan_h2"},
+  };
+  EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers3), true));
+  send_headers_post_cb3();
+
+  // Anything other than http2 sends to the base http1 cluster.
+  // TestRequestHeaderMapImpl headers4{{"x-envoy-mobile-upstream-protocol", "garbage"}};
+  // HttpTestUtility::addDefaultHeaders(headers4);
+  // envoy_headers c_headers4 = Utility::toBridgeHeaders(headers4);
+
+  // preferred_network_.store(ENVOY_NET_WWAN);
+  // Event::PostCb send_headers_post_cb4;
+  // EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&send_headers_post_cb4));
+  // http_dispatcher_.sendHeaders(stream, c_headers4, true);
+
+  // TestResponseHeaderMapImpl expected_headers4{
+  //     {":scheme", "http"},
+  //     {":method", "GET"},
+  //     {":authority", "host"},
+  //     {":path", "/"},
+  //     {"x-envoy-mobile-cluster", "base_wwan"},
+  // };
+  // EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers4), true));
+  // send_headers_post_cb4();
 
   // Encode response headers.
   Event::PostCb stream_deletion_post_cb;

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -288,7 +288,7 @@ TEST_F(DispatcherTest, SetDestinationClusterUpstreamProtocol) {
   Event::PostCb stream_deletion_post_cb;
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&stream_deletion_post_cb));
-  TestHeaderMapImpl response_headers{{":status", "200"}};
+  TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, true);
   ASSERT_EQ(cc.on_headers_calls, 1);
   stream_deletion_post_cb();

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -265,24 +265,24 @@ TEST_F(DispatcherTest, SetDestinationClusterUpstreamProtocol) {
   send_headers_post_cb3();
 
   // Anything other than http2 sends to the base http1 cluster.
-  // TestRequestHeaderMapImpl headers4{{"x-envoy-mobile-upstream-protocol", "garbage"}};
-  // HttpTestUtility::addDefaultHeaders(headers4);
-  // envoy_headers c_headers4 = Utility::toBridgeHeaders(headers4);
+  TestRequestHeaderMapImpl headers4{{"x-envoy-mobile-upstream-protocol", "garbage"}};
+  HttpTestUtility::addDefaultHeaders(headers4);
+  envoy_headers c_headers4 = Utility::toBridgeHeaders(headers4);
 
-  // preferred_network_.store(ENVOY_NET_WWAN);
-  // Event::PostCb send_headers_post_cb4;
-  // EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&send_headers_post_cb4));
-  // http_dispatcher_.sendHeaders(stream, c_headers4, true);
+  preferred_network_.store(ENVOY_NET_WWAN);
+  Event::PostCb send_headers_post_cb4;
+  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&send_headers_post_cb4));
+  http_dispatcher_.sendHeaders(stream, c_headers4, true);
 
-  // TestResponseHeaderMapImpl expected_headers4{
-  //     {":scheme", "http"},
-  //     {":method", "GET"},
-  //     {":authority", "host"},
-  //     {":path", "/"},
-  //     {"x-envoy-mobile-cluster", "base_wwan"},
-  // };
-  // EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers4), true));
-  // send_headers_post_cb4();
+  TestResponseHeaderMapImpl expected_headers4{
+      {":scheme", "http"},
+      {":method", "GET"},
+      {":authority", "host"},
+      {":path", "/"},
+      {"x-envoy-mobile-cluster", "base_wwan"},
+  };
+  EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers4), true));
+  send_headers_post_cb4();
 
   // Encode response headers.
   Event::PostCb stream_deletion_post_cb;

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -264,8 +264,8 @@ TEST_F(DispatcherTest, SetDestinationClusterUpstreamProtocol) {
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers3), true));
   send_headers_post_cb3();
 
-  // Anything other than http2 sends to the base http1 cluster.
-  TestRequestHeaderMapImpl headers4{{"x-envoy-mobile-upstream-protocol", "garbage"}};
+  // Setting http1.
+  TestRequestHeaderMapImpl headers4{{"x-envoy-mobile-upstream-protocol", "http1"}};
   HttpTestUtility::addDefaultHeaders(headers4);
   envoy_headers c_headers4 = Utility::toBridgeHeaders(headers4);
 


### PR DESCRIPTION
Description: this PR adds the ability to decide what protocol to use for upstream requests. Note that this will be unnecessary once ALPN works for upstream requests (https://github.com/lyft/envoy-mobile/issues/502)
Risk Level: low
Testing: updated unit tests
Docs Changes: updated docs

Fixes #679 

Signed-off-by: Jose Nino <jnino@lyft.com>