### PR TITLE
build: disable known issue assertions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,7 @@ build --workspace_status_command=envoy/bazel/get_workspace_status
 build --xcode_version=11.3
 build --incompatible_bzl_disallow_load_after_statement=false
 build --javabase=@bazel_tools//tools/jdk:jdk
+build --define disable_known_issue_asserts=true
 
 # Default flags for builds targeting iOS
 # Manual Stamping is necessary in order to get versioning information in the ios


### PR DESCRIPTION
Description: With this change https://github.com/envoyproxy/envoy/pull/10015 Envoy now supports conditionally disabling assertions that cover known issues via build options. This allows us to resolve the crash on shutdown on iOS while the upstream issue is investigated.
Risk Level: Low
Testing: Local, upstream

Signed-off-by: Mike Schore <mike.schore@gmail.com>
