### PR TITLE
ios: fix trailers never being called

### DIFF
--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -199,8 +199,8 @@ static void ios_on_error(envoy_error error, void *context) {
   atomic_store(context->closed, NO);
 
   // Create native callbacks
-  envoy_http_callbacks native_callbacks = {ios_on_headers,  ios_on_data,  ios_on_trailers,
-                                           ios_on_metadata, ios_on_error, ios_on_complete,
+  envoy_http_callbacks native_callbacks = {ios_on_headers,  ios_on_data,  ios_on_metadata,
+                                           ios_on_trailers, ios_on_error, ios_on_complete,
                                            ios_on_cancel,   context};
   _nativeCallbacks = native_callbacks;
 


### PR DESCRIPTION
The instantiation of the native `envoy_http_callbacks` has a mis-ordered set of C parameters which resulted in `ios_on_metadata` being called instead of `ios_on_trailers`.

This "works" (doesn't crash) because these are the same type, so it compiles fine.

I identified this problem by looking at trace logs after noticing that iOS trailers were not being passed through to the platform layer. I saw logs for `dispatching to platform response trailers for stream`, but noticed that the callbacks never propagated through to the platform.

At the moment we don't have a test suite that covers this bridging between the C/Obj-C or C/Java layers, but we should cover this in https://github.com/lyft/envoy-mobile/issues/414 / https://github.com/lyft/envoy-mobile/issues/197.

Signed-off-by: Michael Rebello <me@michaelrebello.com>