### PR TITLE
ci: bump max binary size limit to 5.5MB

### DIFF
--- a/ci/test_size_regression.sh
+++ b/ci/test_size_regression.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Checks the absolute size, and the relative increase of a file.
-MAX_SIZE=5000000
+# Checks the absolute size and the relative size increase of a file.
+
+MAX_SIZE=5500000 # 5.5MB
 MAX_PERC=1
 
 if [ `uname` == "Darwin" ]


### PR DESCRIPTION
We have slightly exceeded the `5MB` size limit here: https://github.com/lyft/envoy-mobile/pull/704/checks?check_run_id=473012084

Rather than disable this job, we're bumping by 500KB and will continue to monitor the size.

Signed-off-by: Michael Rebello <me@michaelrebello.com>