### PR TITLE
core: make `run()` private

### DIFF
--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -29,6 +29,8 @@ public:
   Http::Dispatcher& httpDispatcher();
 
 private:
+  envoy_status_t run(std::string config, std::string log_level);
+
   envoy_engine_callbacks callbacks_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;
@@ -37,8 +39,6 @@ private:
   std::unique_ptr<Envoy::MainCommon> main_common_ GUARDED_BY(mutex_);
   Envoy::Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
   Event::Dispatcher* event_dispatcher_;
-
-  envoy_status_t run(std::string config, std::string log_level);
 };
 
 } // namespace Envoy

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -26,8 +26,6 @@ public:
 
   ~Engine();
 
-  envoy_status_t run(std::string config, std::string log_level);
-
   Http::Dispatcher& httpDispatcher();
 
 private:
@@ -39,6 +37,8 @@ private:
   std::unique_ptr<Envoy::MainCommon> main_common_ GUARDED_BY(mutex_);
   Envoy::Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
   Event::Dispatcher* event_dispatcher_;
+
+  envoy_status_t run(std::string config, std::string log_level);
 };
 
 } // namespace Envoy


### PR DESCRIPTION
This is only called by the implementation of the `Engine`, and can be `private`.

Signed-off-by: Michael Rebello <me@michaelrebello.com>