### PR TITLE
core: expose functionality for flushing stats manually

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -108,6 +108,11 @@ Engine::~Engine() {
 }
 
 void Engine::flushStats() {
+  // Stats must be flushed from the main thread. If we aren't on the main thread, join it.
+  if (main_thread_.joinable()) {
+    main_thread_.join();
+  }
+
   // Server instance will be null if the post-init callback has not been completed within run().
   // In this case, we can simply ignore the flush.
   if (server_instance_ != nullptr) {

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -112,6 +112,7 @@ void Engine::flushStats() {
   // In this case, we can simply ignore the flush.
   if (server_) {
     // Stats must be flushed from the main thread.
+    // Dispatching should be moved after https://github.com/lyft/envoy-mobile/issues/720
     server_->dispatcher().post([this]() -> void { server_->flushStats(); });
   }
 }

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -28,6 +28,13 @@ public:
 
   Http::Dispatcher& httpDispatcher();
 
+  /**
+   * Flush the stats sinks outside of a flushing interval.
+   * Note: stats flushing may not be synchronous.
+   * Therefore, this function may return prior to flushing taking place.
+   */
+  void flushStats();
+
 private:
   envoy_status_t run(std::string config, std::string log_level);
 
@@ -35,9 +42,10 @@ private:
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;
   std::thread main_thread_;
-  std::unique_ptr<Envoy::Http::Dispatcher> http_dispatcher_;
-  std::unique_ptr<Envoy::MainCommon> main_common_ GUARDED_BY(mutex_);
-  Envoy::Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
+  std::unique_ptr<Http::Dispatcher> http_dispatcher_;
+  std::unique_ptr<MainCommon> main_common_ GUARDED_BY(mutex_);
+  Server::Instance* server_instance_;
+  Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
   Event::Dispatcher* event_dispatcher_;
 };
 

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -44,7 +44,7 @@ private:
   std::thread main_thread_;
   std::unique_ptr<Http::Dispatcher> http_dispatcher_;
   std::unique_ptr<MainCommon> main_common_ GUARDED_BY(mutex_);
-  Server::Instance* server_instance_;
+  Server::Instance* server_;
   Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
   Event::Dispatcher* event_dispatcher_;
 };

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -62,6 +62,12 @@ envoy_status_t set_preferred_network(envoy_network_t network) {
   return ENVOY_SUCCESS;
 }
 
+void flush_stats() {
+  if (auto e = engine_.lock()) {
+    e->flushStats();
+  }
+}
+
 /**
  * External entrypoint for library.
  */

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -93,6 +93,7 @@ envoy_status_t set_preferred_network(envoy_network_t network);
 
 /**
  * Flush the stats sinks outside of a flushing interval.
+ * Note: flushing before the engine has started will result in a no-op.
  * Note: stats flushing may not be synchronous.
  * Therefore, this function may return prior to flushing taking place.
  */

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -92,6 +92,13 @@ envoy_engine_t init_engine();
 envoy_status_t set_preferred_network(envoy_network_t network);
 
 /**
+ * Flush the stats sinks outside of a flushing interval.
+ * Note: stats flushing may not be synchronous.
+ * Therefore, this function may return prior to flushing taking place.
+ */
+void flush_stats();
+
+/**
  * External entry point for library.
  * @param engine, handle to the engine to run.
  * @param callbacks, the callbacks that will run the engine callbacks.


### PR DESCRIPTION
Adds functionality built on top of the upstream Envoy changes in https://github.com/envoyproxy/envoy/pull/10097 which will allow the bridging layers to manually flush stats based on lifecycle changes in the mobile application.

Note: Stats must be flushed from the main Envoy thread, as validated by the following assertion failure that occurs when attempting to flush from another thread:

```
[2020-02-27 14:38:43.181][4716580][critical][assert] [external/envoy/source/common/thread_local/thread_local_impl.cc:190] assert failure: std::this_thread::get_id() == main_thread_id_.
```

Follow-up PRs will call these functions from Java/Objective-C.

Part of https://github.com/lyft/envoy-mobile/issues/573.

Signed-off-by: Michael Rebello <me@michaelrebello.com>