### PR TITLE
core: add missing header docstrings

### DIFF
--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -21,11 +21,25 @@ namespace Envoy {
 
 class Engine {
 public:
+  /**
+   * Constructor for a new engine instance.
+   * @param callbacks, the callbacks to be used for streams started through the engine.
+   * @param config, the Envoy configuration to use when starting the instance.
+   * @param log_level, the log level with which to configure the engine.
+   * @param preferred_network, the preferred network that should be used for new streams.
+   */
   Engine(envoy_engine_callbacks callbacks, const char* config, const char* log_level,
          std::atomic<envoy_network_t>& preferred_network);
 
+  /**
+   * Engine destructor.
+   */
   ~Engine();
 
+  /**
+   * Accessor for the http dispatcher.
+   * @return Http::Dispatcher&, the dispatcher being used by the engine.
+   */
   Http::Dispatcher& httpDispatcher();
 
 private:

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -26,7 +26,7 @@ public:
    * @param callbacks, the callbacks to use for engine lifecycle monitoring.
    * @param config, the Envoy configuration to use when starting the instance.
    * @param log_level, the log level with which to configure the engine.
-   * @param preferred_network, the preferred network that should be used for new streams.
+   * @param preferred_network, hook to obtain the preferred network for new streams.
    */
   Engine(envoy_engine_callbacks callbacks, const char* config, const char* log_level,
          std::atomic<envoy_network_t>& preferred_network);

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -23,7 +23,7 @@ class Engine {
 public:
   /**
    * Constructor for a new engine instance.
-   * @param callbacks, the callbacks to be used for streams started through the engine.
+   * @param callbacks, the callbacks to use for engine lifecycle monitoring.
    * @param config, the Envoy configuration to use when starting the instance.
    * @param log_level, the log level with which to configure the engine.
    * @param preferred_network, the preferred network that should be used for new streams.


### PR DESCRIPTION
Signed-off-by: Michael Rebello <me@michaelrebello.com>