### PR TITLE
ios: flush stats on background / termination

### DIFF
--- a/EnvoyMobile.podspec
+++ b/EnvoyMobile.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     s.platform = :ios, '10.0'
     s.swift_version = '5.1'
     s.libraries = 'resolv.9', 'c++'
-    s.frameworks = 'SystemConfiguration'
+    s.frameworks = 'SystemConfiguration', 'UIKit'
     s.source = { http: "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_cocoapods.zip" }
     s.vendored_frameworks = 'Envoy.framework'
     s.source_files = 'Envoy.framework/Headers/*.h', 'Envoy.framework/Swift/*.swift'

--- a/dist/BUILD
+++ b/dist/BUILD
@@ -22,6 +22,7 @@ apple_static_framework_import(
     ],
     sdk_frameworks = [
         "SystemConfiguration",
+        "UIKit",
     ],
     visibility = ["//visibility:public"],
 )

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -8,6 +8,7 @@ objc_library(
     name = "envoy_engine_objc_lib",
     srcs = [
         "EnvoyConfiguration.m",
+        "EnvoyDeviceLifecycleMonitor.m",
         "EnvoyEngineImpl.m",
         "EnvoyHTTPCallbacks.m",
         "EnvoyHTTPStreamImpl.m",
@@ -18,6 +19,7 @@ objc_library(
     ],
     sdk_frameworks = [
         "SystemConfiguration",
+        "UIKit",
     ],
     visibility = ["//visibility:public"],
     deps = ["//library/common:envoy_main_interface_lib"],

--- a/library/objective-c/EnvoyDeviceLifecycleMonitor.m
+++ b/library/objective-c/EnvoyDeviceLifecycleMonitor.m
@@ -1,0 +1,35 @@
+#import "library/objective-c/EnvoyEngine.h"
+
+#import "library/common/main_interface.h"
+
+#import <UIKit/UIKit.h>
+
+@implementation EnvoyDeviceLifecycleMonitor
+
++ (void)startFlushingStatsOnLifecycleChanges {
+  static dispatch_once_t lifecycleMonitoringStarted;
+  dispatch_once(&lifecycleMonitoringStarted, ^{
+    [self startObservingLifecycleNotifications];
+  });
+}
+
+#pragma mark - Private
+
++ (void)startObservingLifecycleNotifications {
+  NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+  [notificationCenter addObserver:self
+                         selector:@selector(lifecycleDidChangeWithNotification:)
+                             name:UIApplicationWillResignActiveNotification
+                           object:nil];
+  [notificationCenter addObserver:self
+                         selector:@selector(lifecycleDidChangeWithNotification:)
+                             name:UIApplicationWillTerminateNotification
+                           object:nil];
+}
+
++ (void)lifecycleDidChangeWithNotification:(NSNotification *)notification {
+  NSLog(@"[Envoy] triggering stats flush (%@)", notification.name);
+  flush_stats();
+}
+
+@end

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -208,4 +208,14 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 
 @end
 
+#pragma mark - EnvoyDeviceLifecycleMonitor
+
+@interface EnvoyDeviceLifecycleMonitor : NSObject
+
+// Start monitoring device lifecycle changes.
+// Flushes stats when the app resigns active or is about to be terminated.
++ (void)startFlushingStatsOnLifecycleChanges;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -20,6 +20,7 @@ static void ios_on_exit() {
 
   _engineHandle = init_engine();
   [EnvoyNetworkMonitor startReachabilityIfNeeded];
+  [EnvoyDeviceLifecycleMonitor startFlushingStatsOnLifecycleChanges];
   return self;
 }
 


### PR DESCRIPTION
Builds on https://github.com/lyft/envoy-mobile/pull/707 by consuming this interface to flush stats when the app is backgrounded or terminated. This will help ensure that stats are sent to the server when possible before the app potentially loses its in-memory stats cache.

Part of #573.

Signed-off-by: Michael Rebello <me@michaelrebello.com>