### PR TITLE
dns: add ability to set dns failure refresh rate

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -33,10 +33,13 @@ static_resources:
           - name: envoy.filters.http.dynamic_forward_proxy
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
-              dns_cache_config:
+              dns_cache_config: &dns_cache_config
                 name: dynamic_forward_proxy_cache_config
                 dns_lookup_family: AUTO
                 dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+                dns_failure_refresh_rate:
+                  base_interval: {{ dns_failure_refresh_rate_seconds_base }}s
+                  max_interval: {{ dns_failure_refresh_rate_seconds_max }}s
           - name: envoy.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -48,10 +51,7 @@ static_resources:
       name: envoy.clusters.dynamic_forward_proxy
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
-        dns_cache_config:
-          name: dynamic_forward_proxy_cache_config
-          dns_lookup_family: AUTO
-          dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+        dns_cache_config: *dns_cache_config
     transport_socket: &base_transport_socket
       name: envoy.transport_sockets.tls
       typed_config:
@@ -75,10 +75,7 @@ static_resources:
       name: envoy.clusters.dynamic_forward_proxy
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
-        dns_cache_config:
-          name: dynamic_forward_proxy_cache_config
-          dns_lookup_family: AUTO
-          dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+        dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
   - name: base_wwan
@@ -88,10 +85,7 @@ static_resources:
       name: envoy.clusters.dynamic_forward_proxy
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
-        dns_cache_config:
-          name: dynamic_forward_proxy_cache_config
-          dns_lookup_family: AUTO
-          dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+        dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
   - name: base_h2
@@ -102,10 +96,7 @@ static_resources:
       name: envoy.clusters.dynamic_forward_proxy
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
-        dns_cache_config:
-          name: dynamic_forward_proxy_cache_config
-          dns_lookup_family: AUTO
-          dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+        dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
   - name: base_wlan_h2
@@ -116,10 +107,7 @@ static_resources:
       name: envoy.clusters.dynamic_forward_proxy
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
-        dns_cache_config:
-          name: dynamic_forward_proxy_cache_config
-          dns_lookup_family: AUTO
-          dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+        dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
   - name: base_wwan_h2
@@ -130,10 +118,7 @@ static_resources:
       name: envoy.clusters.dynamic_forward_proxy
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
-        dns_cache_config:
-          name: dynamic_forward_proxy_cache_config
-          dns_lookup_family: AUTO
-          dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+        dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
   - name: stats

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -12,7 +12,7 @@ public class EnvoyConfiguration {
   /**
    * Create an EnvoyConfiguration with a user provided configuration values.
    *
-   * @param statsDomain                  The domain to flush stats to.
+   * @param statsDomain                  the domain to flush stats to.
    * @param connectTimeoutSeconds        timeout for new network connections to hosts in
    *                                     the cluster.
    * @param dnsRefreshSeconds            rate in seconds to refresh DNS.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -5,8 +5,8 @@ public class EnvoyConfiguration {
   public final String statsDomain;
   public final Integer connectTimeoutSeconds;
   public final Integer dnsRefreshSeconds;
-  public final Integer dnsRefreshSecondsBase;
-  public final Integer dnsRefreshSecondsMax;
+  public final Integer dnsFailureRefreshSecondsBase;
+  public final Integer dnsFailureRefreshSecondsMax;
   public final Integer statsFlushSeconds;
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -5,22 +5,29 @@ public class EnvoyConfiguration {
   public final String statsDomain;
   public final Integer connectTimeoutSeconds;
   public final Integer dnsRefreshSeconds;
+  public final Integer dnsRefreshSecondsBase;
+  public final Integer dnsRefreshSecondsMax;
   public final Integer statsFlushSeconds;
 
   /**
    * Create an EnvoyConfiguration with a user provided configuration values.
    *
-   * @param statsDomain           The domain to flush stats to.
-   * @param connectTimeoutSeconds timeout for new network connections to hosts in
-   *                              the cluster.
-   * @param dnsRefreshSeconds     rate in seconds to refresh DNS.
-   * @param statsFlushSeconds     interval at which to flush Envoy stats.
+   * @param statsDomain                  The domain to flush stats to.
+   * @param connectTimeoutSeconds        timeout for new network connections to hosts in
+   *                                     the cluster.
+   * @param dnsRefreshSeconds            rate in seconds to refresh DNS.
+   * @param dnsFailureRefreshSecondsBase base rate in seconds to refresh DNS on failure.
+   * @param dnsFailureRefreshSecondsMax  max rate in seconds to refresh DNS on failure.
+   * @param statsFlushSeconds            interval at which to flush Envoy stats.
    */
   public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds, int dnsRefreshSeconds,
+                            int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax,
                             int statsFlushSeconds) {
     this.statsDomain = statsDomain;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.dnsRefreshSeconds = dnsRefreshSeconds;
+    this.dnsFailureRefreshSecondsBase = dnsFailureRefreshSecondsBase;
+    this.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
     this.statsFlushSeconds = statsFlushSeconds;
   }
 
@@ -38,6 +45,10 @@ public class EnvoyConfiguration {
         templateYAML.replace("{{ stats_domain }}", String.format("%s", statsDomain))
             .replace("{{ connect_timeout_seconds }}", String.format("%s", connectTimeoutSeconds))
             .replace("{{ dns_refresh_rate_seconds }}", String.format("%s", dnsRefreshSeconds))
+            .replace("{{ dns_failure_refresh_rate_seconds_base }}",
+                     String.format("%s", dnsFailureRefreshSecondsBase))
+            .replace("{{ dns_failure_refresh_rate_seconds_max }}",
+                     String.format("%s", dnsFailureRefreshSecondsMax))
             .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
             .replace("{{ device_os }}", "Android");
 

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -9,6 +9,9 @@ mock_template:
   stats_domain: {{ stats_domain }}
   connect_timeout: {{ connect_timeout_seconds }}s
   dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
+  dns_failure_refresh_rate:
+    base_interval: {{ dns_failure_refresh_rate_seconds_base }}s
+    max_interval: {{ dns_failure_refresh_rate_seconds_max }}s
   stats_flush_interval: {{ stats_flush_interval_seconds }}s
   os: {{ device_os }}
 """
@@ -18,13 +21,15 @@ class EnvoyConfigurationTest {
 
   @Test
   fun `resolving with default configuration resolves with values`() {
-    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345)
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567)
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG)
     assertThat(resolvedTemplate).contains("stats_domain: stats.foo.com")
     assertThat(resolvedTemplate).contains("connect_timeout: 123s")
     assertThat(resolvedTemplate).contains("dns_refresh_rate: 234s")
-    assertThat(resolvedTemplate).contains("stats_flush_interval: 345s")
+    assertThat(resolvedTemplate).contains("base_interval: 345")
+    assertThat(resolvedTemplate).contains("max_interval: 456")
+    assertThat(resolvedTemplate).contains("stats_flush_interval: 567s")
     assertThat(resolvedTemplate).contains("os: Android")
   }
 

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -27,8 +27,8 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("stats_domain: stats.foo.com")
     assertThat(resolvedTemplate).contains("connect_timeout: 123s")
     assertThat(resolvedTemplate).contains("dns_refresh_rate: 234s")
-    assertThat(resolvedTemplate).contains("base_interval: 345")
-    assertThat(resolvedTemplate).contains("max_interval: 456")
+    assertThat(resolvedTemplate).contains("base_interval: 345s")
+    assertThat(resolvedTemplate).contains("max_interval: 456s")
     assertThat(resolvedTemplate).contains("stats_flush_interval: 567s")
     assertThat(resolvedTemplate).contains("os: Android")
   }

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -36,7 +36,7 @@ class EnvoyConfigurationTest {
 
   @Test(expected = EnvoyConfiguration.ConfigurationException::class)
   fun `resolve templates with invalid templates will throw on build`() {
-    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345)
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567)
 
     envoyConfiguration.resolveTemplate("{{ }}")
   }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
@@ -18,6 +18,8 @@ open class EnvoyClientBuilder(
   private var statsDomain = "0.0.0.0"
   private var connectTimeoutSeconds = 30
   private var dnsRefreshSeconds = 60
+  private var dnsFailureRefreshSecondsBase: UInt = 2
+  private var dnsFailureRefreshSecondsMax: UInt = 10
   private var statsFlushSeconds = 60
 
   /**
@@ -55,6 +57,18 @@ open class EnvoyClientBuilder(
    */
   fun addDNSRefreshSeconds(dnsRefreshSeconds: Int): EnvoyClientBuilder {
     this.dnsRefreshSeconds = dnsRefreshSeconds
+    return this
+  }
+
+  /**
+   * Add a rate at which to refresh DNS in case of DNS failure.
+   *
+   * @param base rate in seconds.
+   * @param max rate in seconds.
+   */
+  fun addDNSFailureRefreshSeconds(base: UInt, max: UInt): EnvoyClientBuilder {
+    this.dnsFailureRefreshSecondsBase = base
+    this.dnsFailureRefreshSecondsMax = max
     return this
   }
 

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
@@ -18,8 +18,8 @@ open class EnvoyClientBuilder(
   private var statsDomain = "0.0.0.0"
   private var connectTimeoutSeconds = 30
   private var dnsRefreshSeconds = 60
-  private var dnsFailureRefreshSecondsBase: UInt = 2
-  private var dnsFailureRefreshSecondsMax: UInt = 10
+  private var dnsFailureRefreshSecondsBase = 2
+  private var dnsFailureRefreshSecondsMax = 10
   private var statsFlushSeconds = 60
 
   /**
@@ -66,7 +66,7 @@ open class EnvoyClientBuilder(
    * @param base rate in seconds.
    * @param max rate in seconds.
    */
-  fun addDNSFailureRefreshSeconds(base: UInt, max: UInt): EnvoyClientBuilder {
+  fun addDNSFailureRefreshSeconds(base: Int, max: Int): EnvoyClientBuilder {
     this.dnsFailureRefreshSecondsBase = base
     this.dnsFailureRefreshSecondsMax = max
     return this
@@ -93,7 +93,7 @@ open class EnvoyClientBuilder(
         return Envoy(engineType(), configuration.yaml, logLevel)
       }
       is Standard -> {
-        Envoy(engineType(), EnvoyConfiguration(statsDomain, connectTimeoutSeconds, dnsRefreshSeconds, statsFlushSeconds), logLevel)
+        Envoy(engineType(), EnvoyConfiguration(statsDomain, connectTimeoutSeconds, dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax, statsFlushSeconds), logLevel)
       }
     }
   }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
@@ -56,7 +56,7 @@ class EnvoyBuilderTest {
     clientBuilder = EnvoyClientBuilder(Standard())
     clientBuilder.addEngineType { engine }
 
-    clientBuilder.addDNSRefreshSeconds(1234, 5678)
+    clientBuilder.addDNSFailureRefreshSeconds(1234, 5678)
     val envoy = clientBuilder.build()
     assertThat(envoy.envoyConfiguration!!.dnsFailureRefreshSecondsBase).isEqualTo(1234)
     assertThat(envoy.envoyConfiguration!!.dnsFailureRefreshSecondsMax).isEqualTo(5678)

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
@@ -5,16 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.Mockito.mock
 
-private const val TEST_CONFIG = """
-mock_template:
-- name: mock
-  connect_timeout: {{ connect_timeout_seconds }}
-  dns_refresh_rate: {{ dns_refresh_rate_seconds }}
-  stats_flush_interval: {{ stats_flush_interval_seconds }}
-  stats_domain: {{ stats_domain }}
-  os: {{ device_os }}
-"""
-
 class EnvoyBuilderTest {
 
   private lateinit var clientBuilder: EnvoyClientBuilder
@@ -23,7 +13,7 @@ class EnvoyBuilderTest {
 
   @Test
   fun `adding log level builder uses log level for running Envoy`() {
-    clientBuilder = EnvoyClientBuilder(Custom(TEST_CONFIG))
+    clientBuilder = EnvoyClientBuilder(Standard())
     clientBuilder.addEngineType { engine }
 
     clientBuilder.addLogLevel(LogLevel.DEBUG)
@@ -59,6 +49,17 @@ class EnvoyBuilderTest {
     clientBuilder.addDNSRefreshSeconds(1234)
     val envoy = clientBuilder.build()
     assertThat(envoy.envoyConfiguration!!.dnsRefreshSeconds).isEqualTo(1234)
+  }
+
+  @Test
+  fun `specifying DNS failure refresh overrides default`() {
+    clientBuilder = EnvoyClientBuilder(Standard())
+    clientBuilder.addEngineType { engine }
+
+    clientBuilder.addDNSRefreshSeconds(1234, 5678)
+    val envoy = clientBuilder.build()
+    assertThat(envoy.envoyConfiguration!!.dnsFailureRefreshSecondsBase).isEqualTo(1234)
+    assertThat(envoy.envoyConfiguration!!.dnsFailureRefreshSecondsMax).isEqualTo(5678)
   }
 
   @Test

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -15,7 +15,7 @@ class EnvoyClientTest {
 
   private val engine = mock(EnvoyEngine::class.java)
   private val stream = mock(EnvoyHTTPStream::class.java)
-  private val config = EnvoyConfiguration("stats.foo.com", 0, 0, 0)
+  private val config = EnvoyConfiguration("stats.foo.com", 0, 0, 0, 0, 0)
 
   @Test
   fun `starting a stream on envoy sends headers`() {

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -7,6 +7,8 @@
 - (instancetype)initWithStatsDomain:(NSString *)statsDomain
               connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
                   dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
+       dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
+        dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
                   statsFlushSeconds:(UInt32)statsFlushSeconds {
   self = [super init];
   if (!self) {
@@ -16,6 +18,8 @@
   self.statsDomain = statsDomain;
   self.connectTimeoutSeconds = connectTimeoutSeconds;
   self.dnsRefreshSeconds = dnsRefreshSeconds;
+  self.dnsFailureRefreshSecondsBase = dnsFailureRefreshSecondsBase;
+  self.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
   self.statsFlushSeconds = statsFlushSeconds;
   return self;
 }
@@ -27,6 +31,10 @@
         [NSString stringWithFormat:@"%lu", (unsigned long)self.connectTimeoutSeconds],
     @"dns_refresh_rate_seconds" :
         [NSString stringWithFormat:@"%lu", (unsigned long)self.dnsRefreshSeconds],
+    @"dns_failure_refresh_rate_seconds_base" :
+        [NSString stringWithFormat:@"%lu", (unsigned long)self.dnsFailureRefreshSecondsBase],
+    @"dns_failure_refresh_rate_seconds_max" :
+        [NSString stringWithFormat:@"%lu", (unsigned long)self.dnsFailureRefreshSecondsMax],
     @"stats_flush_interval_seconds" :
         [NSString stringWithFormat:@"%lu", (unsigned long)self.statsFlushSeconds],
     @"device_os" : @"iOS"

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -133,6 +133,8 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 @property (nonatomic, strong) NSString *statsDomain;
 @property (nonatomic, assign) UInt32 connectTimeoutSeconds;
 @property (nonatomic, assign) UInt32 dnsRefreshSeconds;
+@property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsBase;
+@property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsMax;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
 
 /**
@@ -141,6 +143,8 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 - (instancetype)initWithStatsDomain:(NSString *)statsDomain
               connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
                   dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
+       dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
+        dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
                   statsFlushSeconds:(UInt32)statsFlushSeconds;
 
 /**

--- a/library/swift/src/EnvoyClientBuilder.swift
+++ b/library/swift/src/EnvoyClientBuilder.swift
@@ -15,6 +15,8 @@ public final class EnvoyClientBuilder: NSObject {
   private var statsDomain: String = "0.0.0.0"
   private var connectTimeoutSeconds: UInt32 = 30
   private var dnsRefreshSeconds: UInt32 = 60
+  private var dnsFailureRefreshSecondsBase: UInt32 = 2
+  private var dnsFailureRefreshSecondsMax: UInt32 = 10
   private var statsFlushSeconds: UInt32 = 60
 
   // MARK: - Public
@@ -77,6 +79,19 @@ public final class EnvoyClientBuilder: NSObject {
     return self
   }
 
+  /// Add a rate at which to refresh DNS in case of DNS failure.
+  ///
+  /// - parameter base: base rate in seconds.
+  /// - parameter max: max rate in seconds.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addDNSFailureRefreshSeconds(base: UInt32, max: UInt32) -> EnvoyClientBuilder {
+    self.dnsFailureRefreshSecondsBase = base
+    self.dnsFailureRefreshSecondsMax = max
+    return self
+  }
+
   /// Add an interval at which to flush Envoy stats.
   ///
   /// - parameter statsFlushSeconds: Interval at which to flush Envoy stats.
@@ -100,6 +115,8 @@ public final class EnvoyClientBuilder: NSObject {
       let config = EnvoyConfiguration(statsDomain: self.statsDomain,
                                       connectTimeoutSeconds: self.connectTimeoutSeconds,
                                       dnsRefreshSeconds: self.dnsRefreshSeconds,
+                                      dnsFailureRefreshSecondsBase: self.dnsFailureRefreshSecondsBase,
+                                      dnsFailureRefreshSecondsMax: self.dnsFailureRefreshSecondsMax,
                                       statsFlushSeconds: self.statsFlushSeconds)
       return EnvoyClient(config: config, logLevel: self.logLevel, engine: engine)
     }

--- a/library/swift/src/EnvoyClientBuilder.swift
+++ b/library/swift/src/EnvoyClientBuilder.swift
@@ -115,7 +115,8 @@ public final class EnvoyClientBuilder: NSObject {
       let config = EnvoyConfiguration(statsDomain: self.statsDomain,
                                       connectTimeoutSeconds: self.connectTimeoutSeconds,
                                       dnsRefreshSeconds: self.dnsRefreshSeconds,
-                                      dnsFailureRefreshSecondsBase: self.dnsFailureRefreshSecondsBase,
+                                      dnsFailureRefreshSecondsBase:
+                                        self.dnsFailureRefreshSecondsBase,
                                       dnsFailureRefreshSecondsMax: self.dnsFailureRefreshSecondsMax,
                                       statsFlushSeconds: self.statsFlushSeconds)
       return EnvoyClient(config: config, logLevel: self.logLevel, engine: engine)

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -143,7 +143,9 @@ final class EnvoyClientBuilderTests: XCTestCase {
     let config = EnvoyConfiguration(statsDomain: "stats.foo.com",
                                     connectTimeoutSeconds: 200,
                                     dnsRefreshSeconds: 300,
-                                    statsFlushSeconds: 400)
+                                    dnsFailureRefreshSecondsBase: 400,
+                                    dnsFailureRefreshSecondsMax: 500,
+                                    statsFlushSeconds: 600)
     guard let resolvedYAML = config.resolveTemplate(kMockTemplate) else {
       XCTFail("Resolved template YAML is nil")
       return
@@ -152,7 +154,9 @@ final class EnvoyClientBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("stats_domain: stats.foo.com"))
     XCTAssertTrue(resolvedYAML.contains("connect_timeout: 200s"))
     XCTAssertTrue(resolvedYAML.contains("dns_refresh_rate: 300s"))
-    XCTAssertTrue(resolvedYAML.contains("stats_flush_interval: 400s"))
+    XCTAssertTrue(resolvedYAML.contains("base_interval: 400s"))
+    XCTAssertTrue(resolvedYAML.contains("max_interval: 500s"))
+    XCTAssertTrue(resolvedYAML.contains("stats_flush_interval: 600s"))
     XCTAssertTrue(resolvedYAML.contains("device_os: iOS"))
   }
 
@@ -160,7 +164,9 @@ final class EnvoyClientBuilderTests: XCTestCase {
     let config = EnvoyConfiguration(statsDomain: "stats.foo.com",
                                     connectTimeoutSeconds: 200,
                                     dnsRefreshSeconds: 300,
-                                    statsFlushSeconds: 400)
+                                    dnsFailureRefreshSecondsBase: 400,
+                                    dnsFailureRefreshSecondsMax: 500,
+                                    statsFlushSeconds: 600)
     XCTAssertNil(config.resolveTemplate("{{ missing }}"))
   }
 }


### PR DESCRIPTION
Description: updates envoy ref to include https://github.com/envoyproxy/envoy/pull/10137. Exposes client builder function to add dns failure refresh rate.
Risk Level: low, new configuration option
Testing: local apps, CI
Docs Changes: created #715 to create a section in the docs for all the builder options.

Fixes #673 
