### PR TITLE
stats: emit stats for retries

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -149,13 +149,22 @@ stats_config:
       patterns:
         - safe_regex:
             google_re2: {}
-            regex: 'cluster\.[\w]+?\.upstream_rq_total'
-        - safe_regex:
-            google_re2: {}
             regex: 'cluster\.[\w]+?\.upstream_cx_active'
         - safe_regex:
             google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_retry'
+        - safe_regex:
+            google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_retry_overflow'
+        - safe_regex:
+            google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_retry_success'
+        - safe_regex:
+            google_re2: {}
             regex: 'cluster\.[\w]+?\.upstream_rq_time'
+        - safe_regex:
+            google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_total'
 watchdog:
   megamiss_timeout: 60s
   miss_timeout: 60s


### PR DESCRIPTION
Adding the following stats to the allow-list based on [these Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats):

- `upstream_rq_retry`
- `upstream_rq_retry_overflow`
- `upstream_rq_retry_success`

Also re-alphabetized the stats list.

Signed-off-by: Michael Rebello <me@michaelrebello.com>