### PR TITLE
android: fix app lifecycle monitoring with typed config

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -29,6 +29,8 @@ public class AndroidEngineImpl implements EnvoyEngine {
 
   @Override
   public int runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
-    return this.runWithConfig(envoyConfiguration, logLevel);
+    AndroidAppLifecycleMonitor monitor = new AndroidAppLifecycleMonitor();
+    application.registerActivityLifecycleCallbacks(monitor);
+    return envoyEngine.runWithConfig(envoyConfiguration, logLevel);
   }
 }


### PR DESCRIPTION
We should be registering the application for lifecycle callbacks in both the typed config and YAML config cases.

Related to https://github.com/lyft/envoy-mobile/pull/717/files.

Signed-off-by: Michael Rebello <me@michaelrebello.com>