### PR TITLE
core: fix crash with potential race

### DIFF
--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -58,7 +58,7 @@ private:
   std::thread main_thread_;
   std::unique_ptr<Http::Dispatcher> http_dispatcher_;
   std::unique_ptr<MainCommon> main_common_ GUARDED_BY(mutex_);
-  Server::Instance* server_;
+  Server::Instance* server_{};
   Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
   Event::Dispatcher* event_dispatcher_;
 };


### PR DESCRIPTION
Fixes an [issue](https://github.com/lyft/envoy-mobile/issues/729) where the library could potentially race and crash when calling `flushStats` when `server_` has not yet been assigned. @junr03 astutely pointed out that this could be caused by the fact that `server_` is not assigned to anything, so the `if (server_)` check does not perform as expected. To fix this, we should assign it to `nullptr` immediately.

I was able to simulate the race by calling `flushStats()` at the top of `Engine::run()` (before `server_` is assigned). With this patch, the crash disappears.

Resolves https://github.com/lyft/envoy-mobile/issues/729.

Signed-off-by: Michael Rebello <me@michaelrebello.com>