### PR TITLE
core: make streams with`is_internally_created`

### DIFF
--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -295,9 +295,11 @@ envoy_status_t Dispatcher::startStream(envoy_stream_t new_stream_handle,
 
     // Only the initial setting of the api_listener_ is guarded.
     //
-    // Note: streams created by Envoy Mobile are tagged as is_internally_created. This means that the Http::ConnectionManager _will not_ sanitize headers when creating a stream.
+    // Note: streams created by Envoy Mobile are tagged as is_internally_created. This means that
+    // the Http::ConnectionManager _will not_ sanitize headers when creating a stream.
     direct_stream->request_decoder_ =
-        &TS_UNCHECKED_READ(api_listener_)->newStream(*direct_stream->callbacks_, true /* is_internally_created */);
+        &TS_UNCHECKED_READ(api_listener_)
+             ->newStream(*direct_stream->callbacks_, true /* is_internally_created */);
 
     Thread::ReleasableLockGuard lock(streams_lock_);
     streams_.emplace(new_stream_handle, std::move(direct_stream));
@@ -322,14 +324,18 @@ envoy_status_t Dispatcher::sendHeaders(envoy_stream_t stream, envoy_headers head
     if (direct_stream) {
       RequestHeaderMapPtr internal_headers = Utility::toRequestHeaders(headers);
       setDestinationCluster(*internal_headers);
-      // Set the x-forwarded-proto header to https because Envoy Mobile only has clusters with TLS enabled.
-      // This is done here because the ApiListener's synthetic connection would make the Http::ConnectionManager set the scheme to http otherwise.
-      // In the future we might want to configure the connection instead of setting the header here.
+      // Set the x-forwarded-proto header to https because Envoy Mobile only has clusters with TLS
+      // enabled. This is done here because the ApiListener's synthetic connection would make the
+      // Http::ConnectionManager set the scheme to http otherwise. In the future we might want to
+      // configure the connection instead of setting the header here.
       // https://github.com/envoyproxy/envoy/issues/10291
       //
-      // Setting this header is also currently important because Envoy Mobile starts stream with the ApiListener setting the is_internally_created bool to true.
-      // This means the Http::ConnectionManager *will not* mutate Envoy Mobile's request headers. One of the mutations done is adding the x-forwarded-proto header if not present.
-      // Unfortunately, the router relies on the present of this header to determine if it should provided a route for a request here:
+      // Setting this header is also currently important because Envoy Mobile starts stream with the
+      // ApiListener setting the is_internally_created bool to true. This means the
+      // Http::ConnectionManager *will not* mutate Envoy Mobile's request headers. One of the
+      // mutations done is adding the x-forwarded-proto header if not present. Unfortunately, the
+      // router relies on the present of this header to determine if it should provided a route for
+      // a request here:
       // https://github.com/envoyproxy/envoy/blob/c9e3b9d2c453c7fe56a0e3615f0c742ac0d5e768/source/common/router/config_impl.cc#L1091-L1096
       internal_headers->setReferenceForwardedProto(Headers::get().SchemeValues.Https);
       ENVOY_LOG(debug, "[S{}] request headers for stream (end_stream={}):\n{}", stream, end_stream,

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -294,8 +294,11 @@ envoy_status_t Dispatcher::startStream(envoy_stream_t new_stream_handle,
         std::make_unique<DirectStreamCallbacks>(*direct_stream, bridge_callbacks, *this);
 
     // Only the initial setting of the api_listener_ is guarded.
+    //
+    // Note: streams created by Envoy Mobile are tagged as is_internally_created. This means that the Http::ConnectionManager _will not_ sanitize headers when creating a stream.
+    // This seems like the correct thing to do, as we want the headers created by the client to be preserved.
     direct_stream->request_decoder_ =
-        &TS_UNCHECKED_READ(api_listener_)->newStream(*direct_stream->callbacks_);
+        &TS_UNCHECKED_READ(api_listener_)->newStream(*direct_stream->callbacks_, true /* is_internally_created */);
 
     Thread::ReleasableLockGuard lock(streams_lock_);
     streams_.emplace(new_stream_handle, std::move(direct_stream));
@@ -322,6 +325,16 @@ envoy_status_t Dispatcher::sendHeaders(envoy_stream_t stream, envoy_headers head
       ENVOY_LOG(debug, "[S{}] request headers for stream (end_stream={}):\n{}", stream, end_stream,
                 *internal_headers);
       setDestinationCluster(*internal_headers);
+      // Set the x-forwarded-proto header to https because Envoy Mobile only has clusters with TLS enabled.
+      // This is done here because the ApiListener's synthetic connection would make the Http::ConnectionManager set the scheme to http otherwise.
+      // In the future we might want to configure the connection instead of setting the header here.
+      // https://github.com/envoyproxy/envoy/issues/10291
+      //
+      // Setting this header is also currently important because Envoy Mobile starts stream with the ApiListener setting the is_internally_created bool to true.
+      // This means the Http::ConnectionManager *will not* mutate Envoy Mobile's request headers. One of the mutations done is adding the x-forwarded-proto header if not present.
+      // Unfortunately, the router relies on the present of this header to determine if it should provided a route for a request here:
+      // https://github.com/envoyproxy/envoy/blob/c9e3b9d2c453c7fe56a0e3615f0c742ac0d5e768/source/common/router/config_impl.cc#L1091-L1096
+      internal_headers->setReferenceForwardedProto(Headers::get().SchemeValues.Https);
       direct_stream->request_decoder_->decodeHeaders(std::move(internal_headers), end_stream);
       direct_stream->closeLocal(end_stream);
     }

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -296,7 +296,6 @@ envoy_status_t Dispatcher::startStream(envoy_stream_t new_stream_handle,
     // Only the initial setting of the api_listener_ is guarded.
     //
     // Note: streams created by Envoy Mobile are tagged as is_internally_created. This means that the Http::ConnectionManager _will not_ sanitize headers when creating a stream.
-    // This seems like the correct thing to do, as we want the headers created by the client to be preserved.
     direct_stream->request_decoder_ =
         &TS_UNCHECKED_READ(api_listener_)->newStream(*direct_stream->callbacks_, true /* is_internally_created */);
 

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -114,6 +114,7 @@ TEST_F(DispatcherTest, SetDestinationCluster) {
       {":authority", "host"},
       {":path", "/"},
       {"x-envoy-mobile-cluster", "base"},
+      {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
   send_headers_post_cb();
@@ -133,6 +134,7 @@ TEST_F(DispatcherTest, SetDestinationCluster) {
       {":authority", "host"},
       {":path", "/"},
       {"x-envoy-mobile-cluster", "base_wlan"},
+      {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers2), false));
   send_headers_post_cb2();
@@ -152,6 +154,7 @@ TEST_F(DispatcherTest, SetDestinationCluster) {
       {":authority", "host"},
       {":path", "/"},
       {"x-envoy-mobile-cluster", "base_wwan"},
+      {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers3), true));
   send_headers_post_cb3();
@@ -222,6 +225,7 @@ TEST_F(DispatcherTest, SetDestinationClusterUpstreamProtocol) {
       {":authority", "host"},
       {":path", "/"},
       {"x-envoy-mobile-cluster", "base_h2"},
+      {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
   send_headers_post_cb();
@@ -241,6 +245,7 @@ TEST_F(DispatcherTest, SetDestinationClusterUpstreamProtocol) {
       {":authority", "host"},
       {":path", "/"},
       {"x-envoy-mobile-cluster", "base_wlan_h2"},
+      {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers2), false));
   send_headers_post_cb2();
@@ -260,6 +265,7 @@ TEST_F(DispatcherTest, SetDestinationClusterUpstreamProtocol) {
       {":authority", "host"},
       {":path", "/"},
       {"x-envoy-mobile-cluster", "base_wwan_h2"},
+      {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers3), true));
   send_headers_post_cb3();
@@ -280,6 +286,7 @@ TEST_F(DispatcherTest, SetDestinationClusterUpstreamProtocol) {
       {":authority", "host"},
       {":path", "/"},
       {"x-envoy-mobile-cluster", "base_wwan"},
+      {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers4), true));
   send_headers_post_cb4();


### PR DESCRIPTION
Description: in order to prevent the Http::ConnectionManager from sanitizing retry headers attached by the platform, streams are now marked by `is_internally_created` true.
Risk Level: medium, but output shown below shows that the requests still have expected headers.
Testing: log and behavior confirmation. Integration tests are needed and will be focus of imminent work.

Fixes #733 
