### PR TITLE
docs: update with new cpu/memory analysis

### DIFF
--- a/docs/root/development/performance/cpu_battery_impact.rst
+++ b/docs/root/development/performance/cpu_battery_impact.rst
@@ -3,22 +3,11 @@
 Analysis of CPU/battery impact
 ==============================
 
-.. warning::
-
-  These analyses have not been updated since Envoy Mobile added interfaces for performing
-  network requests directly using the library. They will be re-run as part of :issue:`#536 <536>`.
-
-Modified versions of the "hello world" example apps were used to run these experiments:
-
-- :tree:`Android control app <8636711/examples/kotlin/control>`
-- :tree:`Android Envoy app <8636711/examples/kotlin/hello_world>`
-- :tree:`iOS control app <2f27581/examples/objective-c/control/control>`
-- :tree:`iOS Envoy app <2f27581/examples/objective-c/xcode_variant/EnvoyObjc/EnvoyObjc>`
-
-The 2 apps on each platform:
+We utilized 2 apps (1 control, 1 variant) on each platform to validate
+performance using the native networking stacks versus Envoy Mobile:
 
 - **Control:** Made a request every ``200ms`` to an endpoint without Envoy compiled in the app.
-- **Envoy:** Made the same request at the same interval, but routed through an instance of Envoy.
+- **Envoy:** Made the same request at the same interval, but using Envoy Mobile.
 
 All request/response caching was disabled.
 
@@ -28,21 +17,21 @@ Results
 iOS
 ---
 
-Valid through SHA :tree:`2f27581 <2f27581>`.
+Valid through SHA :tree:`v0.2.3.03062020 <v0.2.3.03062020>`.
 
 Envoy:
 
 - Avg CPU: ~4%
-- Avg memory: 12MB
-- Battery: 1/20 Xcode Instruments score
+- Avg memory: 46MB
+- Battery: Negligible
 
 Control:
 
-- Avg CPU: ~2%
-- Avg memory: 6MB
-- Battery: 1/20 Xcode Instruments score
+- Avg CPU: ~4%
+- Avg memory: 29MB
+- Battery: Negligible
 
-**Based on these results, control and Envoy are relatively similar with a slight increase using Envoy.**
+**Based on these results, control and Envoy are relatively similar with a slight increase in memory using Envoy.**
 
 Android
 -------
@@ -69,25 +58,31 @@ Experimentation method
 iOS
 ---
 
-The original investigation was completed as part of :issue:`#113 <113>`,
-and a critical performance issue was fixed in :issue:`#215 <215>`.
+The sample apps checked into
+`this analysis repository release <https://github.com/rebello95/EnvoyMobileAnalysis/releases/tag/v0.2.3.03062020>`_
+were used to run the analysis outlined in this document.
 
-For analysis, the `Energy Diagnostics tool from Xcode Instruments <https://developer.apple.com/library/archive/documentation/Performance/Conceptual/EnergyGuide-iOS/MonitorEnergyWithInstruments.html>`_
-was used.
+For the analysis, we utilized Xcode Instruments to monitor the 2 sample apps
+while they ran in the foreground for a few minutes.
 
-Requests were made using ``URLSession``, with the session's cache set to ``nil`` (disabling caching).
-Envoy listened to the data sent over ``URLSession``, proxying it through.
+Control requests were made using ``URLSession``, with the session
+configuration's cache set to ``nil`` (disabling caching).
 
-Both apps were run (one at a time) on a physical device (iPhone 6s iOS 12.2.x) while running Instruments.
+Variant requests were made using the ``EnvoyClient``.
 
-Reproducing the Envoy example app:
+Both apps were run (one at a time) on a physical device (iPhone XS, iOS 13.3.1)
+while running Instruments.
 
-1. Build the library using ``bazel build ios_dist --config=ios --ios_multi_cpus=armv7,arm64``
-2. Copy ``./dist/Envoy.framework`` to the example's :tree:`source directory <2f27581/examples/objective-c/xcode_variant/EnvoyObjc/EnvoyObjc>`
-3. Build/run the example app
+Additional screenshots from the analysis are available on the
+`release <https://github.com/rebello95/EnvoyMobileAnalysis/releases/tag/v0.2.3.03062020>`_.
 
 Android
 -------
+
+Modified versions of the "hello world" example apps were used to run these experiments:
+
+- :tree:`Android control app <8636711/examples/kotlin/control>`
+- :tree:`Android Envoy app <8636711/examples/kotlin/hello_world>`
 
 We're currently using ``HttpURLConnection`` to communicate and send requests to Envoy. Envoy in it's current state is run as
 a process listening to traffic sent over this connection.
@@ -120,36 +115,8 @@ CPU usage experiment steps:
 2. Wait 10minutes to gather a sample set of data to analyze
 3. Take the average CPU% and MEM%
 
-Analysis
-~~~~~~~~
-
-iOS
----
-
-Envoy had a small increase in memory and CPU usage compared to control.
-
-During the :issue:`initial investigation <113#issuecomment-505676324>`, we identified and fixed
-:issue:`issue <215>` with ``libevent`` that was severely degrading CPU (and subsequently battery) performance.
-
-:issue:`We used Wireshark <113#issuecomment-505673869>` to validate that
-network traffic was flowing through Envoy on the phone every ``200ms``, giving us confidence that there was
-no additional caching happening within ``URLSession``.
-
-Android
--------
-
-There are minimal differences between Envoy and control. By enabling trace logging within Envoy,
-we are able to observe the following:
-
-1. Requests to S3 are being logged in Envoy
-2. DNS resolution does happen every 5 seconds
-3. Stats are flushed every 5 seconds
-
-The DNS resolution and stats flush happening every 5 seconds was originally a concern,
-but updating the frequency to 1 minute did not result in a significant change.
-
-Open issues regarding battery usage
------------------------------------
+Open issues
+~~~~~~~~~~~
 
 For current issues with CPU/battery, please see issues with the
 `perf/cpu label <https://github.com/lyft/envoy-mobile/labels/perf%2Fcpu>`_.

--- a/docs/root/development/performance/cpu_battery_impact.rst
+++ b/docs/root/development/performance/cpu_battery_impact.rst
@@ -59,7 +59,7 @@ iOS
 ---
 
 The sample apps checked into
-`this analysis repository release <https://github.com/rebello95/EnvoyMobileAnalysis/releases/tag/v0.2.3.03062020>`_
+`this analysis repository <https://github.com/rebello95/EnvoyMobileAnalysis/tree/v0.2.3.03062020>`_
 were used to run the analysis outlined in this document.
 
 For the analysis, we utilized Xcode Instruments to monitor the 2 sample apps


### PR DESCRIPTION
Re-ran the analysis on CPU/battery with the current version of Envoy Mobile, and am updating the documentation accordingly. The code used to run the analysis is linked in the documentation and available at https://github.com/rebello95/EnvoyMobileAnalysis/tree/v0.2.3.03062020.

Resolves https://github.com/lyft/envoy-mobile/issues/536, and created https://github.com/lyft/envoy-mobile/issues/741 to track re-running the Android analysis.

Signed-off-by: Michael Rebello <me@michaelrebello.com>