### PR TITLE
binary size: Android binary size investigation -- Apply Keith's patch

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,7 @@
 licenses(["notice"])  # Apache 2
 
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
-
+exports_files(["Info.plist"])
 alias(
     name = "ios_framework",
     actual = "//library/swift/src:ios_framework",

--- a/Info.plist
+++ b/Info.plist
@@ -5,14 +5,14 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.lyft.$(PRODUCT_NAME)</string>
+	<string>io.envoyproxy.envoymobile.helloworld</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>0.1</string>
 </dict>
 </plist>

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.lyft.$(PRODUCT_NAME)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/Info.plist
+++ b/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleIdentifier</key>
-	<string>io.envoyproxy.envoymobile.helloworld</string>
+	<string>foo</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/bazel/swift_static_framework.bzl
+++ b/bazel/swift_static_framework.bzl
@@ -2,7 +2,7 @@
 This rules creates a fat static framework that can be included later with
 static_framework_import
 """
-
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_framework", "ios_static_framework")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_library")
 
@@ -195,6 +195,15 @@ def swift_static_framework(
         visibility = ["//visibility:public"],
         deps = deps,
     )
+    ios_framework(
+         name = "dynamic",
+         deps = [archive_name],
+         minimum_os_version = "10.0",
+         bundle_id = "foo",
+         infoplists = ["//:Info.plist"],
+         families = ["iphone"],
+         visibility = ["//visibility:public"],
+     )
 
     _swift_static_framework(
         name = name,

--- a/bazel/swift_static_framework.bzl
+++ b/bazel/swift_static_framework.bzl
@@ -197,6 +197,7 @@ def swift_static_framework(
     )
     ios_framework(
          name = "dynamic",
+         linkopts = ["-lresolv.9", "-lc++"],
          deps = [archive_name],
          minimum_os_version = "10.0",
          bundle_id = "foo",

--- a/examples/swift/hello_world/BUILD
+++ b/examples/swift/hello_world/BUILD
@@ -6,7 +6,8 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 swift_library(
     name = "appmain",
     srcs = glob(["*.swift"]),
-    deps = ["//dist:envoy_mobile_ios"],
+#    deps = ["//dist:envoy_mobile_ios"],
+    deps = ["//library/swift/src:dynamic"],
 )
 
 ios_application(

--- a/examples/swift/hello_world/BUILD
+++ b/examples/swift/hello_world/BUILD
@@ -14,6 +14,7 @@ ios_application(
     name = "app",
     bundle_id = "io.envoyproxy.envoymobile.helloworld",
     families = ["iphone"],
+    frameworks = ["//library/swift/src:dynamic"],
     infoplists = ["Info.plist"],
     minimum_os_version = "10.0",
     deps = ["appmain"],

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -335,6 +335,9 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__JLjava_nio_ByteBuffer
 // https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/design.html
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BZ(
     JNIEnv* env, jclass, jlong stream_handle, jbyteArray data, jboolean end_stream) {
+  if (end_stream) {
+    __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_send_data_end_stream");
+  }
 
   // TODO: check for null pointer in envoy_data.bytes - we could copy or raise an exception
   return send_data(static_cast<envoy_stream_t>(stream_handle), array_to_native_data(env, data),
@@ -350,7 +353,7 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(
     JNIEnv* env, jclass, jlong stream_handle, jobjectArray trailers) {
-
+  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_send_trailers");
   return send_trailers(static_cast<envoy_stream_t>(stream_handle),
                        to_native_headers(env, trailers));
 }


### PR DESCRIPTION
Draft PR for investigation purposes.

We've noticed ~5MB per architecture increase for iOS with the inclusion of Envoy Mobile. On Android, we are observing ~10MB increase per architecture. @keith had the suggestion that since we are doing a static framework and using stripping, we are able to get a smaller artifact size for Envoy Mobile. Android uses a dynamic library here so we may not be able to get the stripping benefits.

The diff here is to attempt to capture an iOS application increase if we were to not use stripping to see if we are able to observe a similar 10MB increase. If we do, then we have a high confident signal that stripping is the reasoning for the discrepancies between iOS and Android artifacts.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
