### PR TITLE
config: add app metadata to node config

### DIFF
--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -133,35 +133,35 @@ Specify the rate at which Envoy Mobile should flush its queued stats.
   // Swift
   builder.addStatsFlushSeconds(5)
 
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 ``addAppVersion``
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
-Specify the version of the app using Envoy Mobile. This information is sent as identifying
-information when flushing metrics.
-
-**Example**::
-
-  // Kotlin
-  builder.addAppVersion("version")
-
-  // Swift
-  builder.addAppVersion("version")
-
-~~~~~~~~~~~~~~~~~~~~~~~~
-``addId``
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Specify the ID of the app using Envoy Mobile. This information is sent as identifying
-information when flushing metrics.
+Specify the version of the app using Envoy Mobile.
+This information is sent as metadata when flushing stats.
 
 **Example**::
 
   // Kotlin
-  builder.addId("id")
+  builder.addAppVersion("v1.2.3")
 
   // Swift
-  builder.addId("id")
+  builder.addAppVersion("v1.2.3")
+
+~~~~~~~~~~~~
+``addAppId``
+~~~~~~~~~~~~
+
+Specify the version of the app using Envoy Mobile.
+This information is sent as metadata when flushing stats.
+
+**Example**::
+
+  // Kotlin
+  builder.addAppId("com.mydomain.myapp")
+
+  // Swift
+  builder.addAppId("com.mydomain.myapp)
 
 ----------------------
 Advanced configuration

--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -125,8 +125,6 @@ will be emitted.
 
 Specify the rate at which Envoy Mobile should flush its queued stats.
 
-Note that the library automatically flushes stats on application backgrounding/termination as well.
-
 **Example**::
 
   // Kotlin
@@ -134,6 +132,36 @@ Note that the library automatically flushes stats on application backgrounding/t
 
   // Swift
   builder.addStatsFlushSeconds(5)
+
+~~~~~~~~~~~~~~~~~~~~~~~~
+``addAppVersion``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specify the version of the app using Envoy Mobile. This information is sent as identifying
+information when flushing metrics.
+
+**Example**::
+
+  // Kotlin
+  builder.addAppVersion("version")
+
+  // Swift
+  builder.addAppVersion("version")
+
+~~~~~~~~~~~~~~~~~~~~~~~~
+``addId``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specify the ID of the app using Envoy Mobile. This information is sent as identifying
+information when flushing metrics.
+
+**Example**::
+
+  // Kotlin
+  builder.addId("id")
+
+  // Swift
+  builder.addId("id")
 
 ----------------------
 Advanced configuration

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -172,4 +172,6 @@ watchdog:
 node:
   metadata:
     os: {{ device_os }}
+    app_version : {{ app_version }}
+    app_id : {{ app_id }}
 )";

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -171,7 +171,7 @@ watchdog:
   miss_timeout: 60s
 node:
   metadata:
-    os: {{ device_os }}
-    app_version : {{ app_version }}
     app_id : {{ app_id }}
+    app_version : {{ app_version }}
+    os: {{ device_os }}
 )";

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -8,6 +8,8 @@ public class EnvoyConfiguration {
   public final Integer dnsFailureRefreshSecondsBase;
   public final Integer dnsFailureRefreshSecondsMax;
   public final Integer statsFlushSeconds;
+  public final String appVersion;
+  public final String appId;
 
   /**
    * Create a new instance of the configuration.
@@ -19,16 +21,20 @@ public class EnvoyConfiguration {
    * @param dnsFailureRefreshSecondsBase base rate in seconds to refresh DNS on failure.
    * @param dnsFailureRefreshSecondsMax  max rate in seconds to refresh DNS on failure.
    * @param statsFlushSeconds            interval at which to flush Envoy stats.
+   * @param appVersion                   the App Version of the App using this Envoy Client.
+   * @param appId                        the App ID of the App using this Envoy Client.
    */
   public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds, int dnsRefreshSeconds,
                             int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax,
-                            int statsFlushSeconds) {
+                            int statsFlushSeconds, String appVersion, String appId) {
     this.statsDomain = statsDomain;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.dnsRefreshSeconds = dnsRefreshSeconds;
     this.dnsFailureRefreshSecondsBase = dnsFailureRefreshSecondsBase;
     this.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
     this.statsFlushSeconds = statsFlushSeconds;
+    this.appVersion = appVersion;
+    this.appId = appId;
   }
 
   /**
@@ -50,7 +56,9 @@ public class EnvoyConfiguration {
             .replace("{{ dns_failure_refresh_rate_seconds_max }}",
                      String.format("%s", dnsFailureRefreshSecondsMax))
             .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
-            .replace("{{ device_os }}", "Android");
+            .replace("{{ device_os }}", "Android")
+            .replace("{{ app_version }}", String.format("%s", appVersion))
+            .replace("{{ app_id }}", String.format("%s", appId));
 
     if (resolvedConfiguration.contains("{{")) {
       throw new ConfigurationException();

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -48,7 +48,7 @@ public class EnvoyConfiguration {
    */
   String resolveTemplate(String templateYAML) {
     String resolvedConfiguration =
-        templateYAML.replace("{{ stats_domain }}", String.format("%s", statsDomain))
+        templateYAML.replace("{{ stats_domain }}", statsDomain)
             .replace("{{ connect_timeout_seconds }}", String.format("%s", connectTimeoutSeconds))
             .replace("{{ dns_refresh_rate_seconds }}", String.format("%s", dnsRefreshSeconds))
             .replace("{{ dns_failure_refresh_rate_seconds_base }}",
@@ -57,8 +57,8 @@ public class EnvoyConfiguration {
                      String.format("%s", dnsFailureRefreshSecondsMax))
             .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
             .replace("{{ device_os }}", "Android")
-            .replace("{{ app_version }}", String.format("%s", appVersion))
-            .replace("{{ app_id }}", String.format("%s", appId));
+            .replace("{{ app_version }}", appVersion)
+            .replace("{{ app_id }}", appId);
 
     if (resolvedConfiguration.contains("{{")) {
       throw new ConfigurationException();

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -23,7 +23,7 @@ class EnvoyConfigurationTest {
 
   @Test
   fun `resolving with default configuration resolves with values`() {
-    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567, "version", "id")
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567, "v1.2.3", "com.mydomain.myapp")
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG)
     assertThat(resolvedTemplate).contains("stats_domain: stats.foo.com")
@@ -33,14 +33,14 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("max_interval: 456s")
     assertThat(resolvedTemplate).contains("stats_flush_interval: 567s")
     assertThat(resolvedTemplate).contains("os: Android")
-    assertThat(resolvedTemplate).contains("app_version: version")
-    assertThat(resolvedTemplate).contains("app_id: id")
+    assertThat(resolvedTemplate).contains("app_version: v1.2.3")
+    assertThat(resolvedTemplate).contains("app_id: com.mydomain.myapp")
   }
 
 
   @Test(expected = EnvoyConfiguration.ConfigurationException::class)
   fun `resolve templates with invalid templates will throw on build`() {
-    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567, "version", "id")
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567, "v1.2.3", "com.mydomain.myapp")
 
     envoyConfiguration.resolveTemplate("{{ }}")
   }

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -14,6 +14,8 @@ mock_template:
     max_interval: {{ dns_failure_refresh_rate_seconds_max }}s
   stats_flush_interval: {{ stats_flush_interval_seconds }}s
   os: {{ device_os }}
+  app_version: {{ app_version }}
+  app_id: {{ app_id }}
 """
 
 
@@ -21,7 +23,7 @@ class EnvoyConfigurationTest {
 
   @Test
   fun `resolving with default configuration resolves with values`() {
-    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567)
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567, "version", "id")
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG)
     assertThat(resolvedTemplate).contains("stats_domain: stats.foo.com")
@@ -31,12 +33,14 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("max_interval: 456s")
     assertThat(resolvedTemplate).contains("stats_flush_interval: 567s")
     assertThat(resolvedTemplate).contains("os: Android")
+    assertThat(resolvedTemplate).contains("app_version: version")
+    assertThat(resolvedTemplate).contains("app_id: id")
   }
 
 
   @Test(expected = EnvoyConfiguration.ConfigurationException::class)
   fun `resolve templates with invalid templates will throw on build`() {
-    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567)
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567, "version", "id")
 
     envoyConfiguration.resolveTemplate("{{ }}")
   }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClientBuilder.kt
@@ -21,6 +21,8 @@ open class EnvoyClientBuilder(
   private var dnsFailureRefreshSecondsBase = 2
   private var dnsFailureRefreshSecondsMax = 10
   private var statsFlushSeconds = 60
+  private var appVersion = "unspecified"
+  private var appId = "unspecified"
 
   /**
    * Add a log level to use with Envoy.
@@ -97,6 +99,30 @@ open class EnvoyClientBuilder(
   }
 
   /**
+   * Add the App Version of the App using this Envoy Client.
+   *
+   * @param appVersion the version.
+   *
+   * @return this builder.
+   */
+  fun addAppVersion(appVersion: String): EnvoyClientBuilder {
+    this.appVersion = appVersion
+    return this
+  }
+
+  /**
+   * Add the App ID of the App using this Envoy Client.
+   *
+   * @param appId the ID.
+   *
+   * @return this builder.
+   */
+  fun addAppId(appId: String): EnvoyClientBuilder {
+    this.appId = appId
+    return this
+  }
+
+  /**
    * Builds a new instance of Envoy using the provided configurations.
    *
    * @return A new instance of Envoy.
@@ -107,7 +133,7 @@ open class EnvoyClientBuilder(
         return Envoy(engineType(), configuration.yaml, logLevel)
       }
       is Standard -> {
-        Envoy(engineType(), EnvoyConfiguration(statsDomain, connectTimeoutSeconds, dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax, statsFlushSeconds), logLevel)
+        Envoy(engineType(), EnvoyConfiguration(statsDomain, connectTimeoutSeconds, dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax, statsFlushSeconds, appVersion, appId), logLevel)
       }
     }
   }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
@@ -72,4 +72,26 @@ class EnvoyBuilderTest {
     val envoy = clientBuilder.build()
     assertThat(envoy.envoyConfiguration!!.statsFlushSeconds).isEqualTo(1234)
   }
+
+  @Test
+  fun `specifying app version overrides default`() {
+    clientBuilder = EnvoyClientBuilder(Standard())
+    clientBuilder.addEngineType { engine }
+
+    clientBuilder.addAppVersion("version")
+    clientBuilder.build()
+    val envoy = clientBuilder.build()
+    assertThat(envoy.envoyConfiguration!!.appVersion).isEqualTo("version")
+  }
+
+  @Test
+  fun `specifying app id overrides default`() {
+    clientBuilder = EnvoyClientBuilder(Standard())
+    clientBuilder.addEngineType { engine }
+
+    clientBuilder.addAppId("id")
+    clientBuilder.build()
+    val envoy = clientBuilder.build()
+    assertThat(envoy.envoyConfiguration!!.appId).isEqualTo("id")
+  }
 }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientBuilderTest.kt
@@ -78,10 +78,10 @@ class EnvoyBuilderTest {
     clientBuilder = EnvoyClientBuilder(Standard())
     clientBuilder.addEngineType { engine }
 
-    clientBuilder.addAppVersion("version")
+    clientBuilder.addAppVersion("v1.2.3")
     clientBuilder.build()
     val envoy = clientBuilder.build()
-    assertThat(envoy.envoyConfiguration!!.appVersion).isEqualTo("version")
+    assertThat(envoy.envoyConfiguration!!.appVersion).isEqualTo("v1.2.3")
   }
 
   @Test
@@ -89,9 +89,9 @@ class EnvoyBuilderTest {
     clientBuilder = EnvoyClientBuilder(Standard())
     clientBuilder.addEngineType { engine }
 
-    clientBuilder.addAppId("id")
+    clientBuilder.addAppId("com.mydomain.myapp")
     clientBuilder.build()
     val envoy = clientBuilder.build()
-    assertThat(envoy.envoyConfiguration!!.appId).isEqualTo("id")
+    assertThat(envoy.envoyConfiguration!!.appId).isEqualTo("com.mydomain.myapp")
   }
 }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -15,7 +15,7 @@ class EnvoyClientTest {
 
   private val engine = mock(EnvoyEngine::class.java)
   private val stream = mock(EnvoyHTTPStream::class.java)
-  private val config = EnvoyConfiguration("stats.foo.com", 0, 0, 0, 0, 0, "version", "id")
+  private val config = EnvoyConfiguration("stats.foo.com", 0, 0, 0, 0, 0, "v1.2.3", "com.mydomain.myapp")
 
   @Test
   fun `starting a stream on envoy sends headers`() {

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -15,7 +15,7 @@ class EnvoyClientTest {
 
   private val engine = mock(EnvoyEngine::class.java)
   private val stream = mock(EnvoyHTTPStream::class.java)
-  private val config = EnvoyConfiguration("stats.foo.com", 0, 0, 0, 0, 0)
+  private val config = EnvoyConfiguration("stats.foo.com", 0, 0, 0, 0, 0, "version", "id")
 
   @Test
   fun `starting a stream on envoy sends headers`() {

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -9,7 +9,9 @@
                   dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
        dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
         dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
-                  statsFlushSeconds:(UInt32)statsFlushSeconds {
+                  statsFlushSeconds:(UInt32)statsFlushSeconds
+                         appVersion:(NSString *)appVersion
+                              appId:(NSString *)appId {
   self = [super init];
   if (!self) {
     return nil;
@@ -21,6 +23,8 @@
   self.dnsFailureRefreshSecondsBase = dnsFailureRefreshSecondsBase;
   self.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
   self.statsFlushSeconds = statsFlushSeconds;
+  self.appVersion = appVersion;
+  self.appId = appId;
   return self;
 }
 
@@ -37,7 +41,9 @@
         [NSString stringWithFormat:@"%lu", (unsigned long)self.dnsFailureRefreshSecondsMax],
     @"stats_flush_interval_seconds" :
         [NSString stringWithFormat:@"%lu", (unsigned long)self.statsFlushSeconds],
-    @"device_os" : @"iOS"
+    @"device_os" : @"iOS",
+    @"app_version" : self.appVersion,
+    @"app_id" : self.appId
   };
 
   for (NSString *templateKey in templateKeysToValues) {

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -136,6 +136,8 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 @property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsBase;
 @property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsMax;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
+@property (nonatomic, strong) NSString *appVersion;
+@property (nonatomic, strong) NSString *appId;
 
 /**
  Create a new instance of the configuration.
@@ -145,7 +147,9 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
                   dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
        dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
         dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
-                  statsFlushSeconds:(UInt32)statsFlushSeconds;
+                  statsFlushSeconds:(UInt32)statsFlushSeconds
+                         appVersion:(NSString *)appVersion
+                              appId:(NSString *)appId;
 
 /**
  Resolves the provided configuration template using properties on this configuration.

--- a/library/swift/src/EnvoyClientBuilder.swift
+++ b/library/swift/src/EnvoyClientBuilder.swift
@@ -18,6 +18,8 @@ public final class EnvoyClientBuilder: NSObject {
   private var dnsFailureRefreshSecondsBase: UInt32 = 2
   private var dnsFailureRefreshSecondsMax: UInt32 = 10
   private var statsFlushSeconds: UInt32 = 60
+  private var appVersion: String = "unspecified"
+  private var appId: String = "unspecified"
 
   // MARK: - Public
 
@@ -81,8 +83,8 @@ public final class EnvoyClientBuilder: NSObject {
 
   /// Add a rate at which to refresh DNS in case of DNS failure.
   ///
-  /// - parameter base: base rate in seconds.
-  /// - parameter max: max rate in seconds.
+  /// - parameter base: Base rate in seconds.
+  /// - parameter max: Max rate in seconds.
   ///
   /// - returns: This builder.
   @discardableResult
@@ -103,6 +105,28 @@ public final class EnvoyClientBuilder: NSObject {
     return self
   }
 
+  /// Add the App Version of the App using this Envoy Client.
+  ///
+  /// - parameter appVersion: The version.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addAppVersion(_ appVersion: String) -> EnvoyClientBuilder {
+    self.appVersion = appVersion
+    return self
+  }
+
+  /// Add the App ID of the App using this Envoy Client.
+  ///
+  /// - parameter appId: The ID.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addAppId(_ appId: String) -> EnvoyClientBuilder {
+    self.appId = appId
+    return self
+  }
+
   /// Builds a new instance of EnvoyClient using the provided configurations.
   ///
   /// - returns: A new instance of EnvoyClient.
@@ -118,7 +142,9 @@ public final class EnvoyClientBuilder: NSObject {
         dnsRefreshSeconds: self.dnsRefreshSeconds,
         dnsFailureRefreshSecondsBase: self.dnsFailureRefreshSecondsBase,
         dnsFailureRefreshSecondsMax: self.dnsFailureRefreshSecondsMax,
-        statsFlushSeconds: self.statsFlushSeconds)
+        statsFlushSeconds: self.statsFlushSeconds,
+        appVersion: self.appVersion,
+        appId: self.appId)
       return EnvoyClient(config: config, logLevel: self.logLevel, engine: engine)
     }
   }

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -13,6 +13,8 @@ mock_template:
     base_interval: {{ dns_failure_refresh_rate_seconds_base }}s
     max_interval: {{ dns_failure_refresh_rate_seconds_max }}s
   stats_flush_interval: {{ stats_flush_interval_seconds }}s
+  app_version: {{ app_version }}
+  app_id: {{ app_id }}
 """
 
 private final class MockEnvoyEngine: NSObject, EnvoyEngine {
@@ -139,13 +141,43 @@ final class EnvoyClientBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
+  func testAddingAppVersionAddsToConfigurationWhenRunningEnvoy() throws {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual("version", config.appVersion)
+      expectation.fulfill()
+    }
+
+    _ = try EnvoyClientBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addAppVersion("version")
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
+  func testAddingAppIdAddsToConfigurationWhenRunningEnvoy() throws {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual("id", config.appId)
+      expectation.fulfill()
+    }
+
+    _ = try EnvoyClientBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addAppId("id")
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
   func testResolvesYAMLWithIndividuallySetValues() throws {
     let config = EnvoyConfiguration(statsDomain: "stats.foo.com",
                                     connectTimeoutSeconds: 200,
                                     dnsRefreshSeconds: 300,
                                     dnsFailureRefreshSecondsBase: 400,
                                     dnsFailureRefreshSecondsMax: 500,
-                                    statsFlushSeconds: 600)
+                                    statsFlushSeconds: 600,
+                                    appVersion: "version",
+                                    appId: "id")
     guard let resolvedYAML = config.resolveTemplate(kMockTemplate) else {
       XCTFail("Resolved template YAML is nil")
       return
@@ -158,6 +190,8 @@ final class EnvoyClientBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("max_interval: 500s"))
     XCTAssertTrue(resolvedYAML.contains("stats_flush_interval: 600s"))
     XCTAssertTrue(resolvedYAML.contains("device_os: iOS"))
+    XCTAssertTrue(resolvedYAML.contains("app_version: version"))
+    XCTAssertTrue(resolvedYAML.contains("app_id: id"))
   }
 
   func testReturnsNilWhenUnresolvedValueInTemplate() {
@@ -166,7 +200,9 @@ final class EnvoyClientBuilderTests: XCTestCase {
                                     dnsRefreshSeconds: 300,
                                     dnsFailureRefreshSecondsBase: 400,
                                     dnsFailureRefreshSecondsMax: 500,
-                                    statsFlushSeconds: 600)
+                                    statsFlushSeconds: 600,
+                                    appVersion: "version",
+                                    appId: "id")
     XCTAssertNil(config.resolveTemplate("{{ missing }}"))
   }
 }

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -144,13 +144,13 @@ final class EnvoyClientBuilderTests: XCTestCase {
   func testAddingAppVersionAddsToConfigurationWhenRunningEnvoy() throws {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
-      XCTAssertEqual("version", config.appVersion)
+      XCTAssertEqual("v1.2.3", config.appVersion)
       expectation.fulfill()
     }
 
     _ = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addAppVersion("version")
+      .addAppVersion("v1.2.3")
       .build()
     self.waitForExpectations(timeout: 0.01)
   }
@@ -158,13 +158,13 @@ final class EnvoyClientBuilderTests: XCTestCase {
   func testAddingAppIdAddsToConfigurationWhenRunningEnvoy() throws {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
-      XCTAssertEqual("id", config.appId)
+      XCTAssertEqual("com.mydomain.myapp", config.appId)
       expectation.fulfill()
     }
 
     _ = try EnvoyClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addAppId("id")
+      .addAppId("com.mydomain.myapp")
       .build()
     self.waitForExpectations(timeout: 0.01)
   }
@@ -176,8 +176,8 @@ final class EnvoyClientBuilderTests: XCTestCase {
                                     dnsFailureRefreshSecondsBase: 400,
                                     dnsFailureRefreshSecondsMax: 500,
                                     statsFlushSeconds: 600,
-                                    appVersion: "version",
-                                    appId: "id")
+                                    appVersion: "v1.2.3",
+                                    appId: "com.mydomain.myapp")
     guard let resolvedYAML = config.resolveTemplate(kMockTemplate) else {
       XCTFail("Resolved template YAML is nil")
       return
@@ -190,8 +190,8 @@ final class EnvoyClientBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("max_interval: 500s"))
     XCTAssertTrue(resolvedYAML.contains("stats_flush_interval: 600s"))
     XCTAssertTrue(resolvedYAML.contains("device_os: iOS"))
-    XCTAssertTrue(resolvedYAML.contains("app_version: version"))
-    XCTAssertTrue(resolvedYAML.contains("app_id: id"))
+    XCTAssertTrue(resolvedYAML.contains("app_version: v1.2.3"))
+    XCTAssertTrue(resolvedYAML.contains("app_id: com.mydomain.myapp"))
   }
 
   func testReturnsNilWhenUnresolvedValueInTemplate() {
@@ -201,8 +201,8 @@ final class EnvoyClientBuilderTests: XCTestCase {
                                     dnsFailureRefreshSecondsBase: 400,
                                     dnsFailureRefreshSecondsMax: 500,
                                     statsFlushSeconds: 600,
-                                    appVersion: "version",
-                                    appId: "id")
+                                    appVersion: "v1.2.3",
+                                    appId: "com.mydomain.myapp")
     XCTAssertNil(config.resolveTemplate("{{ missing }}"))
   }
 }


### PR DESCRIPTION
Description: this PR adds `app_version` and `app_id` to the available fields in the node metadata for Envoy Mobile's config. It also adds Client Builder functions to allow the user to override these values. These values can be used to identify the clients making use of Envoy Mobile.

Note that we have discussed making the information in the node metadata fully dynamic. However, that type of change bears some more thinking implementation wise. I am tracking this in #755.
Risk Level: low, adds new information to the node metadata.
Testing: added unit tests.
Docs Changes: updated the client builder docs.

Signed-off-by: Jose Nino <jnino@lyft.com>
