### PR TITLE
cocoapods: checkout submodules

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -61,6 +61,8 @@ jobs:
     needs: [master_ios_dist]
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: true
       - name: 'Install dependencies'
         run: ./envoy/ci/mac_ci_setup.sh
       - uses: actions/download-artifact@v1


### PR DESCRIPTION
Description: After #750 I moved the deps install to use the script in Envoy. This means that the CI checkout needs to be recursive. The only path not updated was the cocoapods artifact. This PR fixes it.

Signed-off-by: Jose Nino <jnino@lyft.com>
