### PR TITLE
ci: remove heroku :/

### DIFF
--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -5,8 +5,14 @@ set -e
 # Set up basic requirements and install them.
 # workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
 sudo rm -rf /var/lib/apt/lists/*
+
+# We have seen problems with heroku's keys.
+# We do not use heroku, but it is pre-installed in the github actions machines.
+sudo apt remove heroku
+
 sudo apt-get clean
 sudo apt-get update
+
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y wget software-properties-common make cmake git \
   unzip bc libtool ninja-build automake zip time \


### PR DESCRIPTION
Description: remove pre-installed heroku package from the github actions machine. It looks like they have trouble updating their keys every so often https://github.com/heroku/cli/issues/497

Signed-off-by: Jose Nino <jnino@lyft.com>
