### PR TITLE
ci: add missing key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
   rev: v1.16.0
   hooks:
     - id: codespell
-      args: [-L uint]
+      args: [-L keyserver]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
   rev: v1.16.0
   hooks:
     - id: codespell
-      args: [-L keyserver]
+      args: [-L=uint, -L=keyserver]

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -8,7 +8,7 @@ sudo rm -rf /var/lib/apt/lists/*
 
 # We have seen problems with heroku's keys.
 # We do not use heroku, but it is pre-installed in the github actions machines.
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 30739094656B3CC5
+curl https://cli-assets.heroku.com/apt/release.key | apt-key add -
 
 sudo apt-get clean
 sudo apt-get update

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -5,8 +5,14 @@ set -e
 # Set up basic requirements and install them.
 # workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
 sudo rm -rf /var/lib/apt/lists/*
+
+# We have seen problems with heroku's keys.
+# We do not use heroku, but it is pre-installed in the github actions machines.
+sudo apt remove heroku
+
 sudo apt-get clean
 sudo apt-get update
+
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y wget software-properties-common make cmake git \
   unzip bc libtool ninja-build automake zip time \

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -8,7 +8,7 @@ sudo rm -rf /var/lib/apt/lists/*
 
 # We have seen problems with heroku's keys.
 # We do not use heroku, but it is pre-installed in the github actions machines.
-sudo apt remove heroku
+sudo apt-key adv --keyserver  keyserver.ubuntu.com --recv-keys 30739094656B3CC5
 
 sudo apt-get clean
 sudo apt-get update

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -8,7 +8,7 @@ sudo rm -rf /var/lib/apt/lists/*
 
 # We have seen problems with heroku's keys.
 # We do not use heroku, but it is pre-installed in the github actions machines.
-curl https://cli-assets.heroku.com/apt/release.key | apt-key add -
+curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
 
 sudo apt-get clean
 sudo apt-get update

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -8,7 +8,7 @@ sudo rm -rf /var/lib/apt/lists/*
 
 # We have seen problems with heroku's keys.
 # We do not use heroku, but it is pre-installed in the github actions machines.
-sudo apt-key adv --keyserver  keyserver.ubuntu.com --recv-keys 30739094656B3CC5
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 30739094656B3CC5
 
 sudo apt-get clean
 sudo apt-get update

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -8,7 +8,7 @@ sudo rm -rf /var/lib/apt/lists/*
 
 # We have seen problems with heroku's keys.
 # We do not use heroku, but it is pre-installed in the github actions machines.
-sudo apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 30739094656B3CC5
 
 sudo apt-get clean
 sudo apt-get update

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -8,7 +8,7 @@ sudo rm -rf /var/lib/apt/lists/*
 
 # We have seen problems with heroku's keys.
 # We do not use heroku, but it is pre-installed in the github actions machines.
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 30739094656B3CC5
+sudo apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
 
 sudo apt-get clean
 sudo apt-get update


### PR DESCRIPTION
Description: messed up gpg keys for heroku on github actions hosted machines. I opened https://github.com/heroku/cli/issues/1464 with heroku to start a discussion. For now I found in https://cli-assets.heroku.com/install-ubuntu.sh where they host their key.

Signed-off-by: Jose Nino <jnino@lyft.com>