### PR TITLE
retries: enable retry budget for concurrent retries

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -74,7 +74,7 @@ static_resources:
       thresholds:
         - priority: DEFAULT
           # n.b: with mobile clients there are scenarios where all concurrent requests might be
-          # retries, e.g when the phone goes offline. Therefore, Envoy Mobile allows all concurrent
+          # retries (e.g., when the phone goes offline). Therefore, Envoy Mobile allows all concurrent
           # requests to be retries by setting the concurrent retry budget to 100%.
           # This configuration uses the default for max concurrent requests (1024) because there is
           # no reasonable scenario where a mobile client should have even close to that many concurrent

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -76,7 +76,7 @@ static_resources:
           # n.b: with mobile clients there are scenarios where all concurrent requests might be
           # retries, e.g when the phone goes offline. Therefore, Envoy Mobile allows all concurrent
           # requests to be retries by setting the concurrent retry budget to 100%.
-          # This configuration uses the default for max concurrent retries (1024) because there is
+          # This configuration uses the default for max concurrent requests (1024) because there is
           # no reasonable scenario where a mobile client should have even close to that many concurrent
           # requests.
           retry_budget:

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -73,9 +73,15 @@ static_resources:
     circuit_breakers: &circuit_breakers_settings
       thresholds:
         - priority: DEFAULT
+          # n.b: with mobile clients there are scenarios where all concurrent requests might be
+          # retries, e.g when the phone goes offline. Therefore, Envoy Mobile allows all concurrent
+          # requests to be retries by setting the concurrent retry budget to 100%.
+          # This configuration uses the default for max concurrent retries (1024) because there is
+          # no reasonable scenario where a mobile client should have even close to that many concurrent
+          # requests.
           retry_budget:
             budget_percent:
-              value: 50
+              value: 100
   - name: base_wlan
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -70,6 +70,12 @@ static_resources:
         keepalive_interval: 10
         keepalive_probes: 1
         keepalive_time: 5
+    circuit_breakers: &circuit_breakers_settings
+      thresholds:
+        - priority: DEFAULT
+          retry_budget:
+            budget_percent:
+              value: 50
   - name: base_wlan
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED
@@ -80,6 +86,7 @@ static_resources:
         dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_wwan
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED
@@ -90,6 +97,7 @@ static_resources:
         dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_h2
     http2_protocol_options: {}
     connect_timeout: {{ connect_timeout_seconds }}s
@@ -101,6 +109,7 @@ static_resources:
         dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_wlan_h2
     http2_protocol_options: {}
     connect_timeout: {{ connect_timeout_seconds }}s
@@ -112,6 +121,7 @@ static_resources:
         dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_wwan_h2
     http2_protocol_options: {}
     connect_timeout: {{ connect_timeout_seconds }}s
@@ -123,6 +133,7 @@ static_resources:
         dns_cache_config: *dns_cache_config
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: stats
     connect_timeout: {{ connect_timeout_seconds }}s
     dns_refresh_rate: {{ dns_refresh_rate_seconds }}s


### PR DESCRIPTION
Description: previously the cluster configuration for circuit breakers was not specified. This meant that Envoy Mobile was using the default of 3 concurrent retries. This is not appropriate, specially because all* active traffic goes through the same cluster. This PR changes the configuration and explicitly sets the `retry_budget` configuration.
Risk Level: low (more retries will actually be allowed)
Testing: local

Signed-off-by: Jose Nino <jnino@lyft.com>