### PR TITLE
stats: add emission rule for upstream_rq_active

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -157,6 +157,9 @@ stats_config:
             regex: 'cluster\.[\w]+?\.upstream_rq_[1|2|3|4|5]xx'
         - safe_regex:
             google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_active'
+        - safe_regex:
+            google_re2: {}
             regex: 'cluster\.[\w]+?\.upstream_rq_retry'
         - safe_regex:
             google_re2: {}


### PR DESCRIPTION
Description: since traffic was moved to be able to select h2, upstream_rq_active is useful to determine concurrency.
Risk Level: low
Testing: CI

Signed-off-by: Jose Nino <jnino@lyft.com>