### PR TITLE
ci: cat iOS log to check when CI flakes

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -51,6 +51,8 @@ jobs:
       # Wait for the app to start and get some requests/responses.
       - name: 'Sleep'
         run: sleep 120
+      - name: 'Cat log'
+        run: 'cat /tmp/envoy.log'
       # Check for the sentinel value that shows the app is alive and well.
       - name: 'Check liveliness'
         run: 'cat /tmp/envoy.log | grep "Response status (1): 200"'
@@ -79,6 +81,8 @@ jobs:
       # Wait for the app to start and get some requests/responses.
       - name: 'Sleep'
         run: sleep 120
+      - name: 'Cat log'
+        run: 'cat /tmp/envoy.log'
       # Check for the sentinel value that shows the app is alive and well.
       - name: 'Check liveliness'
         run: 'cat /tmp/envoy.log | grep "Response status (1): 200"'

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -51,6 +51,8 @@ jobs:
       # Wait for the app to start and get some requests/responses.
       - name: 'Sleep'
         run: sleep 120
+      # Print out the log in case the liveliness check fails.
+      # This allows the author to decide if the failure is a flake or a real problem.
       - name: 'Cat log'
         run: 'cat /tmp/envoy.log'
       # Check for the sentinel value that shows the app is alive and well.
@@ -81,6 +83,8 @@ jobs:
       # Wait for the app to start and get some requests/responses.
       - name: 'Sleep'
         run: sleep 120
+      # Print out the log in case the liveliness check fails.
+      # This allows the author to decide if the failure is a flake or a real problem.
       - name: 'Cat log'
         run: 'cat /tmp/envoy.log'
       # Check for the sentinel value that shows the app is alive and well.


### PR DESCRIPTION
Description: iOS CI greps for indicators of liveliness. Sometimes they fail in CI when local runs are ok. This additional step should show us if CI failures are flakes or real.
Risk Level: low
Testing: CI

Signed-off-by: Jose Nino <jnino@lyft.com>