### PR TITLE
stats: emit downstream_rq http metrics

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -198,8 +198,9 @@ stats_config:
             regex: 'cluster\.[\w]+?\.upstream_rq_unknown'
         - safe_regex:
             google_re2: {}
-            regex: 'http.api_router.downstream_rq_[1|2|3|4|5]xx'
-        - exact: http.api_router.downstream_rq_completed
+            regex: 'http.hcm.downstream_rq_[1|2|3|4|5]xx'
+        - exact: 'http.hcm.downstream_rq_total'
+        - exact: 'http.hcm.downstream_rq_completed'
         - safe_regex:
             google_re2: {}
             regex: 'vhost.api.vcluster\.[\w]+?\.upstream_rq_[1|2|3|4|5]xx'

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -198,6 +198,10 @@ stats_config:
             regex: 'cluster\.[\w]+?\.upstream_rq_unknown'
         - safe_regex:
             google_re2: {}
+            regex: 'http.api_router.downstream_rq_[1|2|3|4|5]xx'
+        - exact: http.api_router.downstream_rq_completed
+        - safe_regex:
+            google_re2: {}
             regex: 'vhost.api.vcluster\.[\w]+?\.upstream_rq_[1|2|3|4|5]xx'
         - safe_regex:
             google_re2: {}


### PR DESCRIPTION
Description: this PR adds emission of some downstream_rq metrics to compliment the upstream_rq metrics already emitted. This will allow users to have a view of both network success (upstream_rq) and client perceived success (downstream_rq)
Risk Level: low
Testing: local

Signed-off-by: Jose Nino <jnino@lyft.com>