### PR TITLE
platform: close streams explicitly with data or trailers

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyStreamEmitter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyStreamEmitter.kt
@@ -29,22 +29,14 @@ class EnvoyStreamEmitter(
     return this
   }
 
-  /**
-   * For ending an associated stream and sending trailers.
-   *
-   * @param trailers to send with ending a stream. If null, stream will be closed with an empty data frame.
-   */
-  override fun close(trailers: Map<String, List<String>>?) {
-    trailers?.let {
-      stream.sendTrailers(it)
-      return
-    }
-    stream.sendData(ByteBuffer.allocate(0), true)
+  override fun close(trailers: Map<String, List<String>>) {
+    stream.sendTrailers(trailers)
   }
 
-  /**
-   * For cancelling and ending an associated stream.
-   */
+  override fun close(byteBuffer: ByteBuffer) {
+    stream.sendData(byteBuffer, true)
+  }
+
   override fun cancel() {
     stream.cancel()
   }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/GRPCStreamEmitter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/GRPCStreamEmitter.kt
@@ -37,6 +37,6 @@ class GRPCStreamEmitter(
    * Close this connection.
    */
   fun close() {
-    emitter.close(null)
+    emitter.close(ByteBuffer.allocate(0))
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/StreamEmitter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/StreamEmitter.kt
@@ -33,9 +33,16 @@ interface StreamEmitter : CancelableStream {
   fun sendMetadata(metadata: Map<String, List<String>>): StreamEmitter
 
   /**
-   * For ending an associated stream and sending trailers.
+   * Close the stream with trailers.
    *
-   * @param trailers to send with ending a stream. If null, stream will be closed with an empty data frame.
+   * @param trailers trailers with which to close the stream.
    */
-  fun close(trailers: Map<String, List<String>>?)
+  fun close(trailers: Map<String, List<String>>)
+
+  /**
+   * Close the stream with a data frame.
+   *
+   * @param byteBuffer data with which to close the stream.
+   */
+  fun close(byteBuffer: ByteBuffer)
 }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -97,7 +97,7 @@ class EnvoyClientTest {
             .build(),
         ResponseHandler(Executor {}))
 
-    emitter.close(null)
+    emitter.close(ByteBuffer.allocate(0))
 
     verify(stream).sendData(ByteBuffer.allocate(0), true)
   }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/GRPCStreamEmitterTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/GRPCStreamEmitterTest.kt
@@ -15,12 +15,11 @@ class GRPCStreamEmitterTest {
   private lateinit var emitter: StreamEmitter
 
   private val dataOutputStream = ByteArrayOutputStream()
-  private var isCloseCalledWithNull = false
+  private var isClosedCallWithEmptyData = false
 
   @Before
   fun setup() {
     emitter = object : StreamEmitter {
-
       override fun cancel() {
         throw UnsupportedOperationException("unexpected usage of mock emitter")
       }
@@ -34,8 +33,12 @@ class GRPCStreamEmitterTest {
         throw UnsupportedOperationException("unexpected usage of mock emitter")
       }
 
-      override fun close(trailers: Map<String, List<String>>?) {
-        isCloseCalledWithNull = trailers == null
+      override fun close(trailers: Map<String, List<String>>) {
+        throw UnsupportedOperationException("unexpected usage of mock emitter")
+      }
+
+      override fun close(byteBuffer: ByteBuffer) {
+        isClosedCallWithEmptyData = byteBuffer.array().size == 0
       }
     }
   }
@@ -43,7 +46,7 @@ class GRPCStreamEmitterTest {
   @After
   fun teardown() {
     dataOutputStream.reset()
-    isCloseCalledWithNull = false
+    isClosedCallWithEmptyData = false
   }
 
   @Test
@@ -92,6 +95,6 @@ class GRPCStreamEmitterTest {
     GRPCStreamEmitter(emitter)
       .close()
 
-    assertThat(isCloseCalledWithNull).isTrue()
+    assertThat(isClosedCallWithEmptyData).isTrue()
   }
 }

--- a/library/swift/src/EnvoyStreamEmitter.swift
+++ b/library/swift/src/EnvoyStreamEmitter.swift
@@ -21,12 +21,12 @@ extension EnvoyStreamEmitter: StreamEmitter {
     return self
   }
 
-  func close(trailers: [String: [String]]?) {
-    if let trailers = trailers {
-      self.stream.sendTrailers(trailers)
-    } else {
-      self.stream.send(Data(), close: true)
-    }
+  func close(trailers: [String: [String]]) {
+    self.stream.sendTrailers(trailers)
+  }
+
+  func close(data: Data) {
+    self.stream.send(data, close: true)
   }
 
   func cancel() {

--- a/library/swift/src/GRPCStreamEmitter.swift
+++ b/library/swift/src/GRPCStreamEmitter.swift
@@ -51,6 +51,6 @@ public final class GRPCStreamEmitter: NSObject {
     // The gRPC protocol requires the client stream to close with a DATA frame.
     // More information here:
     // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
-    self.underlyingEmitter.close(trailers: nil)
+    self.underlyingEmitter.close(data: Data())
   }
 }

--- a/library/swift/src/StreamEmitter.swift
+++ b/library/swift/src/StreamEmitter.swift
@@ -26,9 +26,13 @@ public protocol StreamEmitter: CancelableStream {
   @discardableResult
   func sendMetadata(_ metadata: [String: [String]]) -> StreamEmitter
 
-  /// End the stream.
+  /// Close the stream with trailers.
   ///
   /// - parameter trailers: Trailers with which to close the stream.
-  //                        If nil, stream will be closed with an empty data frame.
-  func close(trailers: [String: [String]]?)
+  func close(trailers: [String: [String]])
+
+  /// Close the stream with a data frame.
+  ///
+  /// - parameter data: Data with which to close the stream.
+  func close(data: Data)
 }


### PR DESCRIPTION
Replaces the `close(trailers: Map<String, List<String>>?)` function with two new functions (one for closing with data, and one for closing with trailers).

This removes the ambiguity of how a stream will be closed by making the consumer specify explicitly whether they'd like to close a stream using trailers or data.

The change is being done as a precursor for integrating L7 Swift/Kotlin filters, which will have interfaces in which trailers are not nullable.

Signed-off-by: Michael Rebello <me@michaelrebello.com>