### PR TITLE
platform: remove sendMetadata/onMetadata

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -51,16 +51,6 @@ public class EnvoyHTTPStream {
   }
 
   /**
-   * Send metadata over an HTTP streamHandle. This method can be invoked multiple
-   * times.
-   *
-   * @param metadata, the metadata to send.
-   */
-  public void sendMetadata(Map<String, List<String>> metadata) {
-    JniLibrary.sendMetadata(streamHandle, toJniLibraryHeaders(metadata));
-  }
-
-  /**
    * Send trailers over an open HTTP streamHandle. This method can only be invoked
    * once per streamHandle. Note that this method implicitly ends the
    * streamHandle.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -92,15 +92,6 @@ class JniLibrary {
   protected static native int sendData(long stream, ByteBuffer data, boolean endStream);
 
   /**
-   * Send metadata over an HTTP stream. This method can be invoked multiple times.
-   *
-   * @param stream,   the stream to send metadata over.
-   * @param metadata, the metadata to send.
-   * @return int, the resulting status of the operation.
-   */
-  protected static native int sendMetadata(long stream, byte[][] metadata);
-
-  /**
    * Send trailers over an open HTTP stream. This method can only be invoked once
    * per stream. Note that this method implicitly ends the stream.
    *

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -11,7 +11,10 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 
 class JvmCallbackContext {
   private enum FrameType {
-    NONE, HEADERS, METADATA, TRAILERS,
+    NONE,
+    HEADERS,
+    METADATA,
+    TRAILERS,
   }
 
   private final EnvoyHTTPCallbacks callbacks;
@@ -23,9 +26,7 @@ class JvmCallbackContext {
   private long expectedHeaderLength = 0;
   private long accumulatedHeaderLength = 0;
 
-  public JvmCallbackContext(EnvoyHTTPCallbacks callbacks) {
-    this.callbacks = callbacks;
-  }
+  public JvmCallbackContext(EnvoyHTTPCallbacks callbacks) { this.callbacks = callbacks; }
 
   /**
    * Initializes state for accumulating header pairs via passHeaders, ultimately
@@ -44,9 +45,7 @@ class JvmCallbackContext {
    *
    * @param length, the total number of trailers included in this header block.
    */
-  public void onTrailers(long length) {
-    startAccumulation(FrameType.TRAILERS, length, true);
-  }
+  public void onTrailers(long length) { startAccumulation(FrameType.TRAILERS, length, true); }
 
   /**
    * Allows pairs of strings to be passed across the JVM, reducing overall calls
@@ -90,17 +89,17 @@ class JvmCallbackContext {
     Runnable runnable = new Runnable() {
       public void run() {
         switch (frameType) {
-          case HEADERS:
-            callbacks.onHeaders(headers, endStream);
-            break;
-          case METADATA:
-            break;
-          case TRAILERS:
-            callbacks.onTrailers(headers);
-            break;
-          case NONE:
-          default:
-            assert false : "missing header frame type";
+        case HEADERS:
+          callbacks.onHeaders(headers, endStream);
+          break;
+        case METADATA:
+          break;
+        case TRAILERS:
+          callbacks.onTrailers(headers);
+          break;
+        case NONE:
+        default:
+          assert false : "missing header frame type";
         }
       }
     };
@@ -159,7 +158,7 @@ class JvmCallbackContext {
     assert expectedHeaderLength == 0;
     assert accumulatedHeaderLength == 0;
 
-    headerAccumulator = new HashMap((int) length);
+    headerAccumulator = new HashMap((int)length);
     pendingFrameType = type;
     expectedHeaderLength = length;
     pendingEndStream = endStream;

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -11,10 +11,7 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 
 class JvmCallbackContext {
   private enum FrameType {
-    NONE,
-    HEADERS,
-    METADATA,
-    TRAILERS,
+    NONE, HEADERS, METADATA, TRAILERS,
   }
 
   private final EnvoyHTTPCallbacks callbacks;
@@ -26,7 +23,9 @@ class JvmCallbackContext {
   private long expectedHeaderLength = 0;
   private long accumulatedHeaderLength = 0;
 
-  public JvmCallbackContext(EnvoyHTTPCallbacks callbacks) { this.callbacks = callbacks; }
+  public JvmCallbackContext(EnvoyHTTPCallbacks callbacks) {
+    this.callbacks = callbacks;
+  }
 
   /**
    * Initializes state for accumulating header pairs via passHeaders, ultimately
@@ -45,7 +44,9 @@ class JvmCallbackContext {
    *
    * @param length, the total number of trailers included in this header block.
    */
-  public void onTrailers(long length) { startAccumulation(FrameType.TRAILERS, length, true); }
+  public void onTrailers(long length) {
+    startAccumulation(FrameType.TRAILERS, length, true);
+  }
 
   /**
    * Allows pairs of strings to be passed across the JVM, reducing overall calls
@@ -89,18 +90,17 @@ class JvmCallbackContext {
     Runnable runnable = new Runnable() {
       public void run() {
         switch (frameType) {
-        case HEADERS:
-          callbacks.onHeaders(headers, endStream);
-          break;
-        case METADATA:
-          callbacks.onMetadata(headers);
-          break;
-        case TRAILERS:
-          callbacks.onTrailers(headers);
-          break;
-        case NONE:
-        default:
-          assert false : "missing header frame type";
+          case HEADERS:
+            callbacks.onHeaders(headers, endStream);
+            break;
+          case METADATA:
+            break;
+          case TRAILERS:
+            callbacks.onTrailers(headers);
+            break;
+          case NONE:
+          default:
+            assert false : "missing header frame type";
         }
       }
     };
@@ -159,7 +159,7 @@ class JvmCallbackContext {
     assert expectedHeaderLength == 0;
     assert accumulatedHeaderLength == 0;
 
-    headerAccumulator = new HashMap((int)length);
+    headerAccumulator = new HashMap((int) length);
     pendingFrameType = type;
     expectedHeaderLength = length;
     pendingEndStream = endStream;

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
@@ -27,14 +27,6 @@ public interface EnvoyHTTPCallbacks {
   void onData(ByteBuffer data, boolean endStream);
 
   /**
-   * Called when all metadata get received on the async HTTP stream. Note that end
-   * stream is implied when on_metadata is called.
-   *
-   * @param metadata, the metadata received.
-   */
-  void onMetadata(Map<String, List<String>> metadata);
-
-  /**
    * Called when all trailers get received on the async HTTP stream. Note that end
    * stream is implied when on_trailers is called.
    *

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyStreamEmitter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyStreamEmitter.kt
@@ -7,25 +7,8 @@ class EnvoyStreamEmitter(
   private val stream: EnvoyHTTPStream
 ) : StreamEmitter {
 
-  /**
-   * For sending data to an associated stream.
-   *
-   * @param byteBuffer the byte buffer data to send to the stream.
-   * @return StreamEmitter, this stream emitter.
-   */
   override fun sendData(byteBuffer: ByteBuffer): StreamEmitter {
     stream.sendData(byteBuffer, false)
-    return this
-  }
-
-  /**
-   * For sending a map of metadata to an associated stream.
-   *
-   * @param metadata the metadata to send over the stream.
-   * @return StreamEmitter, this stream emitter.
-   */
-  override fun sendMetadata(metadata: Map<String, List<String>>): StreamEmitter {
-    stream.sendMetadata(metadata)
     return this
   }
 

--- a/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
@@ -15,7 +15,6 @@ class ResponseHandler(val executor: Executor) {
 
     internal var onHeadersClosure: (headers: Map<String, List<String>>, statusCode: Int, endStream: Boolean) -> Unit = { _, _, _ -> Unit }
     internal var onDataClosure: (byteBuffer: ByteBuffer, endStream: Boolean) -> Unit = { _, _ -> Unit }
-    internal var onMetadataClosure: (metadata: Map<String, List<String>>) -> Unit = { Unit }
     internal var onTrailersClosure: (trailers: Map<String, List<String>>) -> Unit = { Unit }
     internal var onErrorClosure: (errorCode: Int, message: String) -> Unit = { _, _ -> Unit }
     internal var onCancelClosure: () -> Unit = { Unit }
@@ -31,10 +30,6 @@ class ResponseHandler(val executor: Executor) {
 
     override fun onData(byteBuffer: ByteBuffer, endStream: Boolean) {
       onDataClosure(byteBuffer, endStream)
-    }
-
-    override fun onMetadata(metadata: Map<String, List<String>>) {
-      onMetadataClosure(metadata)
     }
 
     override fun onTrailers(trailers: Map<String, List<String>>) {
@@ -76,18 +71,6 @@ class ResponseHandler(val executor: Executor) {
    */
   fun onData(closure: (byteBuffer: ByteBuffer, endStream: Boolean) -> Unit): ResponseHandler {
     underlyingCallbacks.onDataClosure = closure
-    return this
-  }
-
-  /**
-   * Called when response metadata is received by the stream.
-   *
-   * @param metadata the metadata of a response.
-   * @param endStream true if the stream is complete.
-   * @return ResponseHandler, this ResponseHandler.
-   */
-  fun onMetadata(closure: (metadata: Map<String, List<String>>) -> Unit): ResponseHandler {
-    underlyingCallbacks.onMetadataClosure = closure
     return this
   }
 

--- a/library/kotlin/src/io/envoyproxy/envoymobile/StreamEmitter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/StreamEmitter.kt
@@ -25,14 +25,6 @@ interface StreamEmitter : CancelableStream {
   fun sendData(byteBuffer: ByteBuffer): StreamEmitter
 
   /**
-   * For sending a map of metadata to an associated stream.
-   *
-   * @param metadata the metadata to send over the stream.
-   * @return this stream emitter.
-   */
-  fun sendMetadata(metadata: Map<String, List<String>>): StreamEmitter
-
-  /**
    * Close the stream with trailers.
    *
    * @param trailers trailers with which to close the stream.

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -64,26 +64,6 @@ class EnvoyClientTest {
   }
 
   @Test
-  fun `sending metadata on stream forwards metadata to the underlying stream`() {
-    `when`(engine.startStream(any())).thenReturn(stream)
-    val envoy = Envoy(engine, config)
-
-    val metadata = mapOf("key_1" to listOf("value_a"))
-    val emitter = envoy.send(
-        RequestBuilder(
-            method = RequestMethod.POST,
-            scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
-            .build(),
-        ResponseHandler(Executor {}))
-
-    emitter.sendMetadata(metadata)
-
-    verify(stream).sendMetadata(metadata)
-  }
-
-  @Test
   fun `closing stream sends empty data to the underlying stream`() {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)

--- a/library/kotlin/test/io/envoyproxy/envoymobile/GRPCStreamEmitterTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/GRPCStreamEmitterTest.kt
@@ -29,10 +29,6 @@ class GRPCStreamEmitterTest {
         return this
       }
 
-      override fun sendMetadata(metadata: Map<String, List<String>>): StreamEmitter {
-        throw UnsupportedOperationException("unexpected usage of mock emitter")
-      }
-
       override fun close(trailers: Map<String, List<String>>) {
         throw UnsupportedOperationException("unexpected usage of mock emitter")
       }

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -33,13 +33,6 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 @property (nonatomic, strong) void (^onData)(NSData *data, BOOL endStream);
 
 /**
- * Called when all metadata gets received on the async HTTP stream.
- * Note that end stream is implied when on_trailers is called.
- * @param metadata the metadata received.
- */
-@property (nonatomic, strong) void (^onMetadata)(EnvoyHeaders *metadata);
-
-/**
  * Called when all trailers get received on the async HTTP stream.
  * Note that end stream is implied when on_trailers is called.
  * @param trailers the trailers received.
@@ -88,13 +81,6 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  @param close True if the stream should be closed after sending.
  */
 - (void)sendData:(NSData *)data close:(BOOL)close;
-
-/**
- Send metadata over the provided stream.
-
- @param metadata Metadata to send over the stream.
- */
-- (void)sendMetadata:(EnvoyHeaders *)metadata;
 
 /**
  Send trailers over the provided stream.

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -105,15 +105,7 @@ static void ios_on_data(envoy_data data, bool end_stream, void *context) {
   });
 }
 
-static void ios_on_metadata(envoy_headers metadata, void *context) {
-  ios_context *c = (ios_context *)context;
-  EnvoyHTTPCallbacks *callbacks = c->callbacks;
-  dispatch_async(callbacks.dispatchQueue, ^{
-    if (callbacks.onMetadata) {
-      callbacks.onMetadata(to_ios_headers(metadata));
-    }
-  });
-}
+static void ios_on_metadata(envoy_headers metadata, void *context) {}
 
 static void ios_on_trailers(envoy_headers trailers, void *context) {
   ios_context *c = (ios_context *)context;
@@ -229,10 +221,6 @@ static void ios_on_error(envoy_error error, void *context) {
 
 - (void)sendData:(NSData *)data close:(BOOL)close {
   send_data(_streamHandle, toNativeData(data), close);
-}
-
-- (void)sendMetadata:(EnvoyHeaders *)metadata {
-  send_metadata(_streamHandle, toNativeHeaders(metadata));
 }
 
 - (void)sendTrailers:(EnvoyHeaders *)trailers {

--- a/library/swift/src/EnvoyStreamEmitter.swift
+++ b/library/swift/src/EnvoyStreamEmitter.swift
@@ -16,11 +16,6 @@ extension EnvoyStreamEmitter: StreamEmitter {
     return self
   }
 
-  func sendMetadata(_ metadata: [String: [String]]) -> StreamEmitter {
-    self.stream.sendMetadata(metadata)
-    return self
-  }
-
   func close(trailers: [String: [String]]) {
     self.stream.sendTrailers(trailers)
   }

--- a/library/swift/src/StreamEmitter.swift
+++ b/library/swift/src/StreamEmitter.swift
@@ -18,14 +18,6 @@ public protocol StreamEmitter: CancelableStream {
   @discardableResult
   func sendData(_ data: Data) -> StreamEmitter
 
-  /// Send metadata over the associated stream.
-  ///
-  /// - parameter metadata: Metadata to send over the stream.
-  ///
-  /// - returns: The stream emitter, for chaining syntax.
-  @discardableResult
-  func sendMetadata(_ metadata: [String: [String]]) -> StreamEmitter
-
   /// Close the stream with trailers.
   ///
   /// - parameter trailers: Trailers with which to close the stream.

--- a/library/swift/test/GRPCStreamEmitterTests.swift
+++ b/library/swift/test/GRPCStreamEmitterTests.swift
@@ -20,10 +20,6 @@ private final class MockEmitter: StreamEmitter {
     return self
   }
 
-  func sendMetadata(_ metadata: [String: [String]]) -> StreamEmitter {
-    return self
-  }
-
   func close(trailers: [String: [String]]) {}
 
   func close(data: Data) {

--- a/library/swift/test/MockEnvoyHTTPStream.swift
+++ b/library/swift/test/MockEnvoyHTTPStream.swift
@@ -25,8 +25,6 @@ extension MockEnvoyHTTPStream: EnvoyHTTPStream {
     MockEnvoyHTTPStream.onData?(data, close)
   }
 
-  func sendMetadata(_ metadata: [String: [String]]) {}
-
   func sendTrailers(_ trailers: [String: [String]]) {
     MockEnvoyHTTPStream.onTrailers?(trailers)
   }


### PR DESCRIPTION
These are never called in practice today. Since we don't want to support them in the initial version of filters, we're removing them from the public interfaces now.

Signed-off-by: Michael Rebello <me@michaelrebello.com>