### PR TITLE
kotlin: split LogLevel into its own file

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -44,6 +44,7 @@ envoy_mobile_kt_library(
         "GRPCResponseHandler.kt",
         "GRPCStreamEmitter.kt",
         "HTTPClient.kt",
+        "LogLevel.kt",
         "Request.kt",
         "RequestBuilder.kt",
         "RequestMapper.kt",

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClient.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyClient.kt
@@ -5,19 +5,6 @@ import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import java.nio.ByteBuffer
 
 /**
- * Available logging levels for an Envoy instance. Note some levels may be compiled out.
- */
-enum class LogLevel(internal val level: String) {
-  TRACE("trace"),
-  DEBUG("debug"),
-  INFO("info"),
-  WARN("warn"),
-  ERROR("error"),
-  CRITICAL("critical"),
-  OFF("off");
-}
-
-/**
  * Wrapper class that allows for easy calling of Envoy's JNI interface in native Java.
  */
 class Envoy private constructor(

--- a/library/kotlin/src/io/envoyproxy/envoymobile/LogLevel.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/LogLevel.kt
@@ -1,0 +1,14 @@
+package io.envoyproxy.envoymobile
+
+/**
+ * Available logging levels for an Envoy instance. Note some levels may be compiled out.
+ */
+enum class LogLevel(internal val level: String) {
+  TRACE("trace"),
+  DEBUG("debug"),
+  INFO("info"),
+  WARN("warn"),
+  ERROR("error"),
+  CRITICAL("critical"),
+  OFF("off");
+}


### PR DESCRIPTION
Cleaner/easier to find, as well as maintaining parity with iOS.

Signed-off-by: Michael Rebello <me@michaelrebello.com>