### PR TITLE
platform: update interfaces for unary/streamed requests

### DIFF
--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -75,7 +75,8 @@ public class MainActivity extends Activity {
 
   private void makeRequest() {
     // Note: this request will use an http/1.1 stream for the upstream request.
-    // The Kotlin example uses h2. This is done on purpose to test both paths in end-to-end tests
+    // The Kotlin example uses h2. This is done on purpose to test both paths in
+    // end-to-end tests
     // in CI.
     Request request =
         new RequestBuilder(RequestMethod.GET, REQUEST_SCHEME, REQUEST_AUTHORITY, REQUEST_PATH)
@@ -108,6 +109,6 @@ public class MainActivity extends Activity {
               return Unit.INSTANCE;
             });
 
-    envoy.send(request, null, Collections.emptyMap(), handler);
+    envoy.send(request, null, null, handler);
   }
 }

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -104,6 +104,6 @@ class MainActivity : Activity() {
           Unit
         }
 
-    envoy.send(request, null, emptyMap(), handler)
+    envoy.send(request, null, null, handler)
   }
 }

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -95,7 +95,7 @@ NSString *_REQUEST_SCHEME = @"https";
     NSLog(@"Error (%i): Request failed: %@", requestID, error.message);
   }];
 
-  [self.envoy send:request body:nil trailers:[NSDictionary new] handler:handler];
+  [self.envoy send:request body:nil trailers:nil handler:handler];
 }
 
 - (void)addResponseBody:(NSString *)body

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -71,7 +71,7 @@ final class ViewController: UITableViewController {
                                                 message: message)))
       }
 
-    envoy.send(request, body: nil, handler: handler)
+    envoy.send(request, body: nil, trailers: nil, handler: handler)
   }
 
   private func add(result: Result<Response, RequestError>) {

--- a/library/kotlin/src/io/envoyproxy/envoymobile/GRPCClient.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/GRPCClient.kt
@@ -13,15 +13,15 @@ class GRPCClient(
 ) {
 
   /**
-   * Send a gRPC request with the provided handler.
+   * Start a gRPC request with the provided handler.
    *
    * @param request The outbound gRPC request. See `GRPCRequestBuilder` for creation.
    * @param handler Handler for receiving responses.
    *
    * @returns GRPCStreamEmitter, An emitter that can be used for sending more traffic over the stream.
    */
-  fun send(request: Request, grpcResponseHandler: GRPCResponseHandler): GRPCStreamEmitter {
-    val emitter = httpClient.send(request, grpcResponseHandler.underlyingHandler)
+  fun start(request: Request, grpcResponseHandler: GRPCResponseHandler): GRPCStreamEmitter {
+    val emitter = httpClient.start(request, grpcResponseHandler.underlyingHandler)
     return GRPCStreamEmitter(emitter)
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/HTTPClient.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/HTTPClient.kt
@@ -4,32 +4,25 @@ import java.nio.ByteBuffer
 
 interface HTTPClient {
   /**
-   * For starting a stream.
+   * Start a new stream.
    *
-   * @param request the request for opening a stream.
-   * @param responseHandler the callback for receiving stream events.
-   * @return the emitter for streaming data outward.
+   * @param request The request headers for opening a stream.
+   * @param responseHandler Handler for receiving stream events.
+   * @return Emitter for sending streaming data outward.
    */
-  fun send(request: Request, responseHandler: ResponseHandler): StreamEmitter
+  fun start(request: Request, responseHandler: ResponseHandler): StreamEmitter
 
   /**
-   * Convenience function for sending a unary request.
+   * Send a unary (non-streamed) request.
+   * Close with headers-only: Pass a nil body and nil trailers.
+   * Close with data:         Pass a body and nil trailers.
+   * Close with trailers:     Pass non-nil trailers.
    *
-   * @param request  The request to send.
-   * @param body Serialized data to send as the body of the request.
+   * @param request  The request headers to send.
+   * @param body Data to send as the body.
    * @param trailers Trailers to send with the request.
-   * @param responseHandler the callback for receiving stream events.
-   * @return CancelableStream, a cancelable request.
+   * @param responseHandler Handler for receiving response events.
+   * @return A cancelable request.
    */
-  fun send(request: Request, body: ByteBuffer?, trailers: Map<String, List<String>>, responseHandler: ResponseHandler): CancelableStream
-
-  /**
-   * Convenience function for sending a unary request.
-   *
-   * @param request The request to send.
-   * @param body Serialized data to send as the body of the request.
-   * @param responseHandler the callback for receiving stream events.
-   * @return CancelableStream, a cancelable request.
-   */
-  fun send(request: Request, body: ByteBuffer?, responseHandler: ResponseHandler): CancelableStream
+  fun send(request: Request, body: ByteBuffer?, trailers: Map<String, List<String>>?, responseHandler: ResponseHandler): CancelableStream
 }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -29,7 +29,7 @@ class EnvoyClientTest {
         ":authority" to listOf("api.foo.com"),
         ":path" to listOf("foo")
     )
-    envoy.send(
+    envoy.start(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
@@ -47,7 +47,7 @@ class EnvoyClientTest {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
-    val emitter = envoy.send(
+    val emitter = envoy.start(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
@@ -68,7 +68,7 @@ class EnvoyClientTest {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
-    val emitter = envoy.send(
+    val emitter = envoy.start(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
@@ -88,7 +88,7 @@ class EnvoyClientTest {
     val envoy = Envoy(engine, config)
 
     val trailers = mapOf("key_1" to listOf("value_a"))
-    val emitter = envoy.send(
+    val emitter = envoy.start(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
@@ -123,13 +123,14 @@ class EnvoyClientTest {
             .setHeaders(mapOf("key_1" to listOf("value_a")))
             .build(),
         ByteBuffer.allocate(0),
+        null,
         ResponseHandler(Executor {}))
 
     verify(stream).sendHeaders(expectedHeaders, false)
   }
 
   @Test
-  fun `sending request on envoy passes the body buffer`() {
+  fun `sending request buffer without trailers passes the body buffer and closes stream`() {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
@@ -142,9 +143,10 @@ class EnvoyClientTest {
             path = "foo")
             .build(),
         body,
+        null,
         ResponseHandler(Executor {}))
 
-    verify(stream).sendData(body, false)
+    verify(stream).sendData(body, true)
   }
 
   @Test
@@ -161,6 +163,7 @@ class EnvoyClientTest {
             path = "foo")
             .build(),
         body,
+        emptyMap(),
         ResponseHandler(Executor {}))
 
     verify(stream).sendTrailers(emptyMap())

--- a/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/EnvoyClientTest.kt
@@ -12,13 +12,12 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 
 class EnvoyClientTest {
-
   private val engine = mock(EnvoyEngine::class.java)
   private val stream = mock(EnvoyHTTPStream::class.java)
   private val config = EnvoyConfiguration("stats.foo.com", 0, 0, 0, 0, 0, "v1.2.3", "com.mydomain.myapp", "[test]")
 
   @Test
-  fun `starting a stream on envoy sends headers`() {
+  fun `starting a stream sends headers`() {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
@@ -26,15 +25,15 @@ class EnvoyClientTest {
         "key_1" to listOf("value_a"),
         ":method" to listOf("POST"),
         ":scheme" to listOf("https"),
-        ":authority" to listOf("api.foo.com"),
-        ":path" to listOf("foo")
+        ":authority" to listOf("www.envoyproxy.io"),
+        ":path" to listOf("/test")
     )
     envoy.start(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
+            authority = "www.envoyproxy.io",
+            path = "/test")
             .setHeaders(mapOf("key_1" to listOf("value_a")))
             .build(),
         ResponseHandler(Executor {}))
@@ -43,7 +42,7 @@ class EnvoyClientTest {
   }
 
   @Test
-  fun `sending data on stream stream forwards data to the underlying stream`() {
+  fun `sending data on stream passes data to the underlying stream`() {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
@@ -51,8 +50,8 @@ class EnvoyClientTest {
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
+            authority = "www.envoyproxy.io",
+            path = "/test")
             .build(),
         ResponseHandler(Executor {}))
 
@@ -64,7 +63,7 @@ class EnvoyClientTest {
   }
 
   @Test
-  fun `closing stream sends empty data to the underlying stream`() {
+  fun `closing stream with data sends empty data to the underlying stream`() {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
@@ -72,8 +71,8 @@ class EnvoyClientTest {
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
+            authority = "www.envoyproxy.io",
+            path = "/test")
             .build(),
         ResponseHandler(Executor {}))
 
@@ -92,8 +91,8 @@ class EnvoyClientTest {
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
+            authority = "www.envoyproxy.io",
+            path = "/test")
             .build(),
         ResponseHandler(Executor {}))
 
@@ -103,7 +102,7 @@ class EnvoyClientTest {
   }
 
   @Test
-  fun `sending request on envoy sends headers`() {
+  fun `sending unary headers only request closes stream with headers`() {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
@@ -111,82 +110,64 @@ class EnvoyClientTest {
         "key_1" to listOf("value_a"),
         ":method" to listOf("POST"),
         ":scheme" to listOf("https"),
-        ":authority" to listOf("api.foo.com"),
-        ":path" to listOf("foo")
+        ":authority" to listOf("www.envoyproxy.io"),
+        ":path" to listOf("/test")
     )
     envoy.send(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
+            authority = "www.envoyproxy.io",
+            path = "/test")
             .setHeaders(mapOf("key_1" to listOf("value_a")))
             .build(),
-        ByteBuffer.allocate(0),
+        null,
         null,
         ResponseHandler(Executor {}))
 
-    verify(stream).sendHeaders(expectedHeaders, false)
+    verify(stream).sendHeaders(expectedHeaders, true)
   }
 
   @Test
-  fun `sending request buffer without trailers passes the body buffer and closes stream`() {
+  fun `sending unary headers and data with no trailers closes stream with data`() {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
-    val body = ByteBuffer.allocate(0)
+    val expectedBody = ByteBuffer.allocate(0)
     envoy.send(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
+            authority = "www.envoyproxy.io",
+            path = "/test")
             .build(),
-        body,
+        expectedBody,
         null,
         ResponseHandler(Executor {}))
 
-    verify(stream).sendData(body, true)
+    verify(stream).sendData(expectedBody, true)
   }
 
   @Test
-  fun `sending request on envoy without trailers sends empty trailers`() {
+  fun `sending unary trailers closes stream with trailers`() {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
-    val body = ByteBuffer.allocate(0)
+    val expectedBody = ByteBuffer.allocate(0)
+    val expectedTrailers = mapOf("key_1" to listOf("value_a"))
     envoy.send(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
+            authority = "www.envoyproxy.io",
+            path = "/test")
             .build(),
-        body,
-        emptyMap(),
+        expectedBody,
+        expectedTrailers,
         ResponseHandler(Executor {}))
 
-    verify(stream).sendTrailers(emptyMap())
-  }
-
-  @Test
-  fun `sending request on envoy sends trailers`() {
-    `when`(engine.startStream(any())).thenReturn(stream)
-    val envoy = Envoy(engine, config)
-
-    val trailers = mapOf("key_1" to listOf("value_a"))
-    envoy.send(
-        RequestBuilder(
-            method = RequestMethod.POST,
-            scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
-            .build(),
-        ByteBuffer.allocate(0),
-        trailers,
-        ResponseHandler(Executor {}))
-
-    verify(stream).sendTrailers(trailers)
+    verify(stream).sendData(expectedBody, false)
+    verify(stream).sendTrailers(expectedTrailers)
   }
 
   @Test
@@ -194,16 +175,15 @@ class EnvoyClientTest {
     `when`(engine.startStream(any())).thenReturn(stream)
     val envoy = Envoy(engine, config)
 
-    val trailers = mapOf("key_1" to listOf("value_a"))
     val emitter = envoy.send(
         RequestBuilder(
             method = RequestMethod.POST,
             scheme = "https",
-            authority = "api.foo.com",
-            path = "foo")
+            authority = "www.envoyproxy.io",
+            path = "/test")
             .build(),
         ByteBuffer.allocate(0),
-        trailers,
+        mapOf("key_1" to listOf("value_a")),
         ResponseHandler(Executor {}))
 
     emitter.cancel()

--- a/library/swift/src/GRPCClient.swift
+++ b/library/swift/src/GRPCClient.swift
@@ -12,13 +12,13 @@ public final class GRPCClient: NSObject {
     self.httpClient = httpClient
   }
 
-  /// Send a gRPC request with the provided handler.
+  /// Start a gRPC request with the provided handler.
   ///
   /// - parameter request: The outbound gRPC request. See `GRPCRequestBuilder` for creation.
   /// - parameter handler: Handler for receiving responses.
   ///
   /// - returns: An emitter that can be used for sending more traffic over the stream.
-  public func send(_ request: Request, handler: GRPCResponseHandler) -> GRPCStreamEmitter {
+  public func start(_ request: Request, handler: GRPCResponseHandler) -> GRPCStreamEmitter {
     let emitter = self.httpClient.start(request, handler: handler.underlyingHandler)
     return GRPCStreamEmitter(emitter: emitter)
   }

--- a/library/swift/src/GRPCClient.swift
+++ b/library/swift/src/GRPCClient.swift
@@ -19,7 +19,7 @@ public final class GRPCClient: NSObject {
   ///
   /// - returns: An emitter that can be used for sending more traffic over the stream.
   public func send(_ request: Request, handler: GRPCResponseHandler) -> GRPCStreamEmitter {
-    let emitter = self.httpClient.send(request, handler: handler.underlyingHandler)
+    let emitter = self.httpClient.start(request, handler: handler.underlyingHandler)
     return GRPCStreamEmitter(emitter: emitter)
   }
 }

--- a/library/swift/src/HTTPClient.swift
+++ b/library/swift/src/HTTPClient.swift
@@ -5,21 +5,25 @@ import Foundation
 public protocol HTTPClient {
   /// Start a new stream.
   ///
-  /// - parameter request: The request for opening a stream.
+  /// - parameter request: The request headers for opening a stream.
   /// - parameter handler: Handler for receiving stream events.
   ///
   /// - returns: Emitter for sending streaming data outward.
-  func send(_ request: Request, handler: ResponseHandler) -> StreamEmitter
+  func start(_ request: Request, handler: ResponseHandler) -> StreamEmitter
 
-  /// Convenience function for sending a complete (non-streamed) request.
+  /// Send a unary (non-streamed) request.
   ///
-  /// - parameter request:  The request to send.
-  /// - parameter body:     Serialized data to send as the body of the request.
+  /// Close with headers-only: Pass a nil body and nil trailers.
+  /// Close with data:         Pass a body and nil trailers.
+  /// Close with trailers:     Pass non-nil trailers.
+  ///
+  /// - parameter request:  The request headers to send.
+  /// - parameter body:     Data to send as the body.
   /// - parameter trailers: Trailers to send with the request.
   ///
   /// - returns: A cancelable request.
   @discardableResult
   func send(_ request: Request, body: Data?,
-            trailers: [String: [String]], handler: ResponseHandler)
+            trailers: [String: [String]]?, handler: ResponseHandler)
     -> CancelableStream
 }

--- a/library/swift/src/HTTPClient.swift
+++ b/library/swift/src/HTTPClient.swift
@@ -20,6 +20,7 @@ public protocol HTTPClient {
   /// - parameter request:  The request headers to send.
   /// - parameter body:     Data to send as the body.
   /// - parameter trailers: Trailers to send with the request.
+  /// - parameter handler:  Handler for receiving response events.
   ///
   /// - returns: A cancelable request.
   @discardableResult

--- a/library/swift/test/EnvoyClientTests.swift
+++ b/library/swift/test/EnvoyClientTests.swift
@@ -17,26 +17,163 @@ private final class MockEnvoyEngine: EnvoyEngine {
 }
 
 final class EnvoyClientTests: XCTestCase {
+  private var envoy: EnvoyClient!
+
+  override func setUp() {
+    super.setUp()
+    self.envoy = try! EnvoyClientBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .build()
+  }
+
   override func tearDown() {
     super.tearDown()
     MockEnvoyHTTPStream.reset()
   }
 
-  func testNonStreamingExtensionSendsRequestDetailsThroughStream() throws {
-    let requestExpectation = self.expectation(description: "Sends request")
-    let dataExpectation = self.expectation(description: "Sends data")
-    let closeExpectation = self.expectation(description: "Calls close")
+  // MARK: - Streaming
 
-    let expectedRequest = RequestBuilder(
-      method: .get, scheme: "https", authority: "www.envoyproxy.io", path: "/docs")
-      .build()
-    let expectedData = Data([1, 2, 3])
-    let expectedTrailers = ["foo": ["bar", "baz"]]
+  func testStartingAStreamSendsHeaders() {
+    let expectation = self.expectation(description: "Sends stream headers")
+    let expectedHeaders = [
+      "key_1": ["value_a"],
+      ":method": ["POST"],
+      ":scheme": ["https"],
+      ":authority": ["www.envoyproxy.io"],
+      ":path": ["/test"],
+    ]
 
     MockEnvoyHTTPStream.onHeaders = { headers, closeStream in
-      XCTAssertEqual(expectedRequest.outboundHeaders(), headers)
+      XCTAssertEqual(expectedHeaders, headers)
       XCTAssertFalse(closeStream)
-      requestExpectation.fulfill()
+      expectation.fulfill()
+    }
+
+    let request = RequestBuilder(
+      method: .post, scheme: "https", authority: "www.envoyproxy.io", path: "/test")
+      .addHeader(name: "key_1", value: "value_a")
+      .build()
+    _ = self.envoy.start(request, handler: ResponseHandler())
+    self.wait(for: [expectation], timeout: 0.1)
+  }
+
+  func testSendingDataOnStreamPassesDataToTheUnderlyingStream() {
+    let expectation = self.expectation(description: "Sends stream data")
+
+    let expectedData = Data([0x0, 0x1, 0x2])
+    MockEnvoyHTTPStream.onData = { data, closeStream in
+      XCTAssertEqual(expectedData, data)
+      XCTAssertFalse(closeStream)
+      expectation.fulfill()
+    }
+
+    let request = RequestBuilder(
+      method: .post, scheme: "https", authority: "www.envoyproxy.io", path: "/test")
+      .build()
+    let emitter = self.envoy.start(request, handler: ResponseHandler())
+    emitter.sendData(expectedData)
+    self.wait(for: [expectation], timeout: 0.1)
+  }
+
+  func testClosingStreamWithDataSendsEmptyDataToTheUnderlyingStream() {
+    let expectation = self.expectation(description: "Sends stream data")
+
+    MockEnvoyHTTPStream.onTrailers = { _ in XCTFail("Should not call onTrailers") }
+    MockEnvoyHTTPStream.onData = { data, closeStream in
+      XCTAssertTrue(data.isEmpty)
+      XCTAssertTrue(closeStream)
+      expectation.fulfill()
+    }
+
+    let request = RequestBuilder(
+      method: .post, scheme: "https", authority: "www.envoyproxy.io", path: "/test")
+      .build()
+    let emitter = self.envoy.start(request, handler: ResponseHandler())
+    emitter.close(data: Data())
+    self.wait(for: [expectation], timeout: 0.1)
+  }
+
+  func testClosingStreamWithTrailersSendsTrailersToTheUnderlyingStream() {
+    let expectation = self.expectation(description: "Sends stream trailers")
+
+    let expectedTrailers = ["key_1": ["value_a"]]
+    MockEnvoyHTTPStream.onData = { _, _ in XCTFail("Should not call onData") }
+    MockEnvoyHTTPStream.onTrailers = { trailers in
+      XCTAssertEqual(expectedTrailers, trailers)
+      expectation.fulfill()
+    }
+
+    let request = RequestBuilder(
+      method: .post, scheme: "https", authority: "www.envoyproxy.io", path: "/test")
+      .build()
+    let emitter = self.envoy.start(request, handler: ResponseHandler())
+    emitter.close(trailers: expectedTrailers)
+    self.wait(for: [expectation], timeout: 0.1)
+  }
+
+  // MARK: - Unary
+
+  func testSendingUnaryHeadersOnlyRequestClosesStreamWithHeaders() {
+    let expectation = self.expectation(description: "Sends unary headers")
+    let expectedHeaders = [
+      "key_1": ["value_a"],
+      ":method": ["POST"],
+      ":scheme": ["https"],
+      ":authority": ["www.envoyproxy.io"],
+      ":path": ["/test"],
+    ]
+
+    MockEnvoyHTTPStream.onData = { _, _ in XCTFail("Should not call onData") }
+    MockEnvoyHTTPStream.onTrailers = { _ in XCTFail("Should not call onTrailers") }
+    MockEnvoyHTTPStream.onHeaders = { headers, closeStream in
+      XCTAssertEqual(expectedHeaders, headers)
+      XCTAssertTrue(closeStream)
+      expectation.fulfill()
+    }
+
+    let request = RequestBuilder(
+      method: .post, scheme: "https", authority: "www.envoyproxy.io", path: "/test")
+      .addHeader(name: "key_1", value: "value_a")
+      .build()
+    self.envoy.send(request, body: nil, trailers: nil, handler: ResponseHandler())
+    self.wait(for: [expectation], timeout: 0.1)
+  }
+
+  func testSendingUnaryHeadersAndDataWithNoTrailersClosesStreamWithData() {
+    let headersExpectation = self.expectation(description: "Sends unary headers")
+    let dataExpectation = self.expectation(description: "Sends unary data")
+
+    let expectedData = Data([0x0, 0x1, 0x2])
+    MockEnvoyHTTPStream.onTrailers = { _ in XCTFail("Should not call onTrailers") }
+    MockEnvoyHTTPStream.onHeaders = { _, closeStream in
+      XCTAssertFalse(closeStream)
+      headersExpectation.fulfill()
+    }
+
+    MockEnvoyHTTPStream.onData = { data, closeStream in
+      XCTAssertEqual(expectedData, data)
+      XCTAssertTrue(closeStream)
+      dataExpectation.fulfill()
+    }
+
+    let request = RequestBuilder(
+      method: .post, scheme: "https", authority: "www.envoyproxy.io", path: "/test")
+      .build()
+    self.envoy.send(request, body: expectedData, trailers: nil, handler: ResponseHandler())
+    self.wait(for: [headersExpectation, dataExpectation],
+              timeout: 0.1, enforceOrder: true)
+  }
+
+  func testSendingUnaryTrailersClosesStreamWithTrailers() {
+    let headersExpectation = self.expectation(description: "Sends unary headers")
+    let dataExpectation = self.expectation(description: "Sends unary data")
+    let trailersExpectation = self.expectation(description: "Sends unary trailers")
+
+    let expectedData = Data([0x0, 0x1, 0x2])
+    let expectedTrailers = ["key_1": ["value_a"]]
+    MockEnvoyHTTPStream.onHeaders = { _, closeStream in
+      XCTAssertFalse(closeStream)
+      headersExpectation.fulfill()
     }
 
     MockEnvoyHTTPStream.onData = { data, closeStream in
@@ -47,15 +184,15 @@ final class EnvoyClientTests: XCTestCase {
 
     MockEnvoyHTTPStream.onTrailers = { trailers in
       XCTAssertEqual(expectedTrailers, trailers)
-      closeExpectation.fulfill()
+      trailersExpectation.fulfill()
     }
 
-    let envoy = try EnvoyClientBuilder()
-      .addEngineType(MockEnvoyEngine.self)
+    let request = RequestBuilder(
+      method: .post, scheme: "https", authority: "www.envoyproxy.io", path: "/test")
       .build()
-    envoy.send(expectedRequest, body: expectedData, trailers: expectedTrailers,
-               handler: ResponseHandler())
-    self.wait(for: [requestExpectation, dataExpectation, closeExpectation],
+    self.envoy.send(request, body: expectedData,
+                    trailers: expectedTrailers, handler: ResponseHandler())
+    self.wait(for: [headersExpectation, dataExpectation, trailersExpectation],
               timeout: 0.1, enforceOrder: true)
   }
 }


### PR DESCRIPTION
Currently, our platform-level unary interfaces have the following limitations:

- It's not very clear when sending a request if it's going to be unary or streamed
- It's not possible to send headers-only requests
- Trailers are non-optional

This PR introduces the following changes to improve these interfaces:

- `send(...)` is used for unary requests, and `start(...)` is used for streaming
- `send(...)` provides the ability to send headers-only requests
- Callers can specify whether they'd like to close with body data or trailers by explicitly passing one as `nil` (see inline documentation)

Additionally, this PR introduces a new set of `EnvoyClient` tests which are 1:1 on iOS and Android.

This change is being made as a precursor to L7 Swift/Kotlin filters.

Signed-off-by: Michael Rebello <me@michaelrebello.com>