### PR TITLE
ios: centralize MockEnvoyEngine

### DIFF
--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -6,6 +6,7 @@ envoy_mobile_swift_test(
     name = "envoy_client_tests",
     srcs = [
         "EnvoyClientTests.swift",
+        "MockEnvoyEngine.swift",
         "MockEnvoyHTTPStream.swift",
     ],
 )
@@ -14,6 +15,7 @@ envoy_mobile_swift_test(
     name = "envoy_client_builder_tests",
     srcs = [
         "EnvoyClientBuilderTests.swift",
+        "MockEnvoyEngine.swift",
         "MockEnvoyHTTPStream.swift",
     ],
 )

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -18,25 +18,6 @@ mock_template:
   virtual_clusters: {{ virtual_clusters }}
 """
 
-private final class MockEnvoyEngine: NSObject, EnvoyEngine {
-  static var onRunWithConfig: ((_ config: EnvoyConfiguration, _ logLevel: String?) -> Void)?
-  static var onRunWithYAML: ((_ configYAML: String, _ logLevel: String?) -> Void)?
-
-  func run(withConfig config: EnvoyConfiguration, logLevel: String) -> Int32 {
-    MockEnvoyEngine.onRunWithConfig?(config, logLevel)
-    return 0
-  }
-
-  func run(withConfigYAML configYAML: String, logLevel: String) -> Int32 {
-    MockEnvoyEngine.onRunWithYAML?(configYAML, logLevel)
-    return 0
-  }
-
-  func startStream(with callbacks: EnvoyHTTPCallbacks) -> EnvoyHTTPStream {
-    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
-  }
-}
-
 final class EnvoyClientBuilderTests: XCTestCase {
   override func tearDown() {
     super.tearDown()

--- a/library/swift/test/EnvoyClientTests.swift
+++ b/library/swift/test/EnvoyClientTests.swift
@@ -2,20 +2,6 @@
 import Foundation
 import XCTest
 
-private final class MockEnvoyEngine: EnvoyEngine {
-  func run(withConfig config: EnvoyConfiguration, logLevel: String) -> Int32 {
-    return 0
-  }
-
-  func run(withConfigYAML configYAML: String, logLevel: String) -> Int32 {
-    return 0
-  }
-
-  func startStream(with callbacks: EnvoyHTTPCallbacks) -> EnvoyHTTPStream {
-    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
-  }
-}
-
 final class EnvoyClientTests: XCTestCase {
   override func tearDown() {
     super.tearDown()

--- a/library/swift/test/MockEnvoyEngine.swift
+++ b/library/swift/test/MockEnvoyEngine.swift
@@ -1,0 +1,23 @@
+@testable import Envoy
+import Foundation
+
+final class MockEnvoyEngine: NSObject {
+  static var onRunWithConfig: ((_ config: EnvoyConfiguration, _ logLevel: String?) -> Void)?
+  static var onRunWithYAML: ((_ configYAML: String, _ logLevel: String?) -> Void)?
+}
+
+extension MockEnvoyEngine: EnvoyEngine {
+  func run(withConfig config: EnvoyConfiguration, logLevel: String) -> Int32 {
+    MockEnvoyEngine.onRunWithConfig?(config, logLevel)
+    return 0
+  }
+
+  func run(withConfigYAML configYAML: String, logLevel: String) -> Int32 {
+    MockEnvoyEngine.onRunWithYAML?(configYAML, logLevel)
+    return 0
+  }
+
+  func startStream(with callbacks: EnvoyHTTPCallbacks) -> EnvoyHTTPStream {
+    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
+  }
+}


### PR DESCRIPTION
We don't need to replicate this type in multiple places.

Signed-off-by: Michael Rebello <me@michaelrebello.com>