### PR TITLE
[sonatype] update max retries to be 500

### DIFF
--- a/dist/sonatype_nexus_upload.py
+++ b/dist/sonatype_nexus_upload.py
@@ -76,7 +76,7 @@ def _urlopen_retried(request, max_retries=500, attempt=1, delay_sec=1):
     """
     Retries a request via recursion. Retries happen with a default delay of 1 second. We do not exponentially back off.
     :param request: the request to be made
-    :param max_retries: Number of retries to use, default is 20. The reason we are using such a high retry is because
+    :param max_retries: Number of retries to use, default is 500. The reason we are using such a high retry is because
     sonatype fails quite frequently
     :param attempt: The current attempt number for the request
     :param delay_sec: The delay before making a retried request

--- a/dist/sonatype_nexus_upload.py
+++ b/dist/sonatype_nexus_upload.py
@@ -72,7 +72,7 @@ def _install_locally(version, files):
         shutil.copyfile(file, os.path.join(path, basename))
 
 
-def _urlopen_retried(request, max_retries=20, attempt=1, delay_sec=1):
+def _urlopen_retried(request, max_retries=500, attempt=1, delay_sec=1):
     """
     Retries a request via recursion. Retries happen with a default delay of 1 second. We do not exponentially back off.
     :param request: the request to be made


### PR DESCRIPTION
Using 500 since sonatype fails more than 20 times in a given attempt.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: update sonatype retries to be 500
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
