### PR TITLE
config: fix max concurrent retries circuit breaker

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -79,7 +79,14 @@ static_resources:
           # This configuration uses the default for max concurrent requests (1024) because there is
           # no reasonable scenario where a mobile client should have even close to that many concurrent
           # requests.
-          max_retries: 1024
+          #
+          # `max_retries` could be used but maintainers advised against it, as there are plans to
+          # deprecate that setting.
+          # https://github.com/lyft/envoy-mobile/pull/811#issuecomment-619169529.
+          retry_budget:
+            budget_percent:
+              value: 100
+            min_retry_concurrency: 1024
   - name: base_wlan
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -74,14 +74,12 @@ static_resources:
       thresholds:
         - priority: DEFAULT
           # n.b: with mobile clients there are scenarios where all concurrent requests might be
-          # retries (e.g., when the phone goes offline). Therefore, Envoy Mobile allows all concurrent
-          # requests to be retries by setting the concurrent retry budget to 100%.
+          # retries (e.g., when the phone goes offline). Therefore, Envoy Mobile allows for the same
+          # amount of concurrency for retries as the default value for concurrency for requests.
           # This configuration uses the default for max concurrent requests (1024) because there is
           # no reasonable scenario where a mobile client should have even close to that many concurrent
           # requests.
-          retry_budget:
-            budget_percent:
-              value: 100
+          max_retries: 1024
   - name: base_wlan
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED


### PR DESCRIPTION
Description: while investigating retry scenarios I noticed that some retries were not getting performed due to overflow. This PR actually increases the concurrency limit. More information can be found in the PR comments.
Risk Level: med - this change actually allows higher retry concurrency.
Testing: local testing

Signed-off-by: Jose Nino <jnino@lyft.com>