### PR TITLE
[jvm demos] ensure we set successful colors to white

### DIFF
--- a/examples/kotlin/shared/ResponseViewHolder.kt
+++ b/examples/kotlin/shared/ResponseViewHolder.kt
@@ -20,6 +20,7 @@ class ResponseViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
             .getString(R.string.title_string, success.title)
           headerTextView.text = headerTextView.resources
             .getString(R.string.header_string, success.header)
+          headerTextView.visibility = View.VISIBLE
           itemView.setBackgroundResource(R.color.failed_color)
         },
         { failure ->

--- a/examples/kotlin/shared/ResponseViewHolder.kt
+++ b/examples/kotlin/shared/ResponseViewHolder.kt
@@ -20,6 +20,7 @@ class ResponseViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
             .getString(R.string.title_string, success.title)
           headerTextView.text = headerTextView.resources
             .getString(R.string.header_string, success.header)
+          itemView.setBackgroundResource(R.color.failed_color)
         },
         { failure ->
           responseTextView.text = responseTextView.resources

--- a/examples/kotlin/shared/res/values/colors.xml
+++ b/examples/kotlin/shared/res/values/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="success_color">#ffffff</color>
     <color name="failed_color">#ff3651</color>
 </resources>


### PR DESCRIPTION
Making sure we set the colors on success and failures since the views are recycled (and might present the wrong color)

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: ensure we set successful colors to white
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
