### PR TITLE
error handling: add attempt counts to the library's error types

### DIFF
--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -104,8 +104,8 @@ public class MainActivity extends Activity {
               return Unit.INSTANCE;
             })
             .onError((error) -> {
-              String msg = new String("failed with error after " + error.getAttemptCount() +
-                                      " attempts: " + error.getMessage());
+              String msg = "failed with error after " + error.getAttemptCount() +
+                           " attempts: " + error.getMessage();
               Log.d("MainActivity", msg);
               recyclerView.post(() -> viewAdapter.add(new Failure(msg)));
               return Unit.INSTANCE;

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -104,10 +104,10 @@ public class MainActivity extends Activity {
               return Unit.INSTANCE;
             })
             .onError((error) -> {
-              String msg = new String("failed with error after " + error.getAttemptCount() + " attempts: " + error.getMessage());
+              String msg = new String("failed with error after " + error.getAttemptCount() +
+                                      " attempts: " + error.getMessage());
               Log.d("MainActivity", msg);
-              recyclerView.post(
-                  () -> viewAdapter.add(new Failure(msg)));
+              recyclerView.post(() -> viewAdapter.add(new Failure(msg)));
               return Unit.INSTANCE;
             });
 

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -104,8 +104,10 @@ public class MainActivity extends Activity {
               return Unit.INSTANCE;
             })
             .onError((error) -> {
+              String msg = new String("failed with error after " + error.getAttemptCount() + " attempts: " + error.getMessage());
+              Log.d("MainActivity", msg);
               recyclerView.post(
-                  () -> viewAdapter.add(new Failure("failed with error " + error.getMessage())));
+                  () -> viewAdapter.add(new Failure(msg)));
               return Unit.INSTANCE;
             });
 

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -103,7 +103,7 @@ class MainActivity : Activity() {
           Unit
         }
         .onError { error ->
-          val msg = String("failed with error after " + error.attemptCount + " attempts: " + error.message)
+          val msg = "failed with error after ${error.attemptCount ?: -1} attempts: ${error.message}"
           Log.d("MainActivity", msg)
           recyclerView.post { viewAdapter.add(Failure(msg)) }
           Unit

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -103,7 +103,9 @@ class MainActivity : Activity() {
           Unit
         }
         .onError { error ->
-          recyclerView.post { viewAdapter.add(Failure("failed with error " + error.message)) }
+          val msg = String("failed with error after " + error.attemptCount + " attempts: " + error.message)
+          Log.d("MainActivity", msg)
+          recyclerView.post { viewAdapter.add(Failure(msg)) }
           Unit
         }
 

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -92,8 +92,8 @@ NSString *_REQUEST_SCHEME = @"https";
   }];
 
   [handler onError:^(EnvoyError *error) {
-    NSLog(@"Error (%i): Request failed after %i attempts: %@", requestID, error.attemptCount,
-          error.message);
+    // TODO: expose attemptCount. https://github.com/lyft/envoy-mobile/issues/823
+    NSLog(@"Error (%i): Request failed: %@", requestID, error.message);
   }];
 
   [self.envoy send:request body:nil trailers:nil handler:handler];

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -92,7 +92,8 @@ NSString *_REQUEST_SCHEME = @"https";
   }];
 
   [handler onError:^(EnvoyError *error) {
-    NSLog(@"Error (%i): Request failed after %i attempts: %@", requestID, error.attemptCount, error.message);
+    NSLog(@"Error (%i): Request failed after %i attempts: %@", requestID, error.attemptCount,
+          error.message);
   }];
 
   [self.envoy send:request body:nil trailers:nil handler:handler];

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -92,7 +92,7 @@ NSString *_REQUEST_SCHEME = @"https";
   }];
 
   [handler onError:^(EnvoyError *error) {
-    NSLog(@"Error (%i): Request failed: %@", requestID, error.message);
+    NSLog(@"Error (%i): Request failed after %i attempts: %@", requestID, error.attemptCount, error.message);
   }];
 
   [self.envoy send:request body:nil trailers:nil handler:handler];

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -65,7 +65,7 @@ final class ViewController: UITableViewController {
         NSLog("Response data (\(requestID)): \(data.count) bytes")
       }
       .onError { [weak self] error in
-        let message = "failed within Envoy library: \(error.message)"
+        let message = "failed within Envoy library after \(error.attemptCount) attempts: \(error.message)"
         NSLog("Error (\(requestID)): \(message)")
         self?.add(result: .failure(RequestError(id: requestID,
                                                 message: message)))

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -65,7 +65,9 @@ final class ViewController: UITableViewController {
         NSLog("Response data (\(requestID)): \(data.count) bytes")
       }
       .onError { [weak self] error in
-        let message = "failed within Envoy library after \(error.attemptCount) attempts: \(error.message)"
+        let message = """
+        failed within Envoy library after \(error.attemptCount) attempts: \(error.message)
+        """
         NSLog("Error (\(requestID)): \(message)")
         self?.add(result: .failure(RequestError(id: requestID,
                                                 message: message)))

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -65,7 +65,7 @@ final class ViewController: UITableViewController {
         NSLog("Response data (\(requestID)): \(data.count) bytes")
       }
       .onError { [weak self] error in
-        var message: String
+        let message: String
         if let attemptCount = error.attemptCount {
           message = "failed within Envoy library after \(attemptCount) attempts: \(error.message)"
         } else {

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -65,9 +65,13 @@ final class ViewController: UITableViewController {
         NSLog("Response data (\(requestID)): \(data.count) bytes")
       }
       .onError { [weak self] error in
-        let message = """
-        failed within Envoy library after \(error.attemptCount) attempts: \(error.message)
-        """
+        var message: String
+        if let attemptCount = error.attemptCount {
+          message = "failed within Envoy library after \(attemptCount) attempts: \(error.message)"
+        } else {
+          message = "failed within Envoy library: \(error.message)"
+        }
+
         NSLog("Error (\(requestID)): \(message)")
         self?.add(result: .failure(RequestError(id: requestID,
                                                 message: message)))

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -88,6 +88,12 @@ void Dispatcher::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& h
   default:
     error_code_ = ENVOY_UNDEFINED_ERROR;
   }
+
+  uint32_t attempt_count;
+  if (headers.EnvoyAttemptCount() && absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count)) {
+    error_attempt_count_ = attempt_count;
+  }
+
   ENVOY_LOG(debug, "[S{}] intercepted local response", direct_stream_.stream_handle_);
   if (end_stream) {
     // The local stream may or may not have completed.
@@ -186,6 +192,7 @@ void Dispatcher::DirectStreamCallbacks::onReset() {
   ENVOY_LOG(debug, "[S{}] remote reset stream", direct_stream_.stream_handle_);
   envoy_error_code_t code = error_code_.value_or(ENVOY_STREAM_RESET);
   envoy_data message = error_message_.value_or(envoy_nodata);
+  uint32_t attempt_count = error_attempt_count_.value_or(0);
 
   // Testing hook.
   http_dispatcher_.synchronizer_.syncPoint("dispatch_on_error");
@@ -198,7 +205,7 @@ void Dispatcher::DirectStreamCallbacks::onReset() {
   if (direct_stream_.dispatchable(true)) {
     ENVOY_LOG(debug, "[S{}] dispatching to platform remote reset stream",
               direct_stream_.stream_handle_);
-    bridge_callbacks_.on_error({code, message}, bridge_callbacks_.context);
+    bridge_callbacks_.on_error({code, message, attempt_count}, bridge_callbacks_.context);
 
     // All the terminal callbacks only cleanup if they are dispatchable.
     // This ensures that cleanup will happen exactly one time.

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -193,7 +193,7 @@ void Dispatcher::DirectStreamCallbacks::onReset() {
   ENVOY_LOG(debug, "[S{}] remote reset stream", direct_stream_.stream_handle_);
   envoy_error_code_t code = error_code_.value_or(ENVOY_STREAM_RESET);
   envoy_data message = error_message_.value_or(envoy_nodata);
-  uint32_t attempt_count = error_attempt_count_.value_or(0);
+  int32_t attempt_count = error_attempt_count_.value_or(-1);
 
   // Testing hook.
   http_dispatcher_.synchronizer_.syncPoint("dispatch_on_error");

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -90,7 +90,8 @@ void Dispatcher::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& h
   }
 
   uint32_t attempt_count;
-  if (headers.EnvoyAttemptCount() && absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count)) {
+  if (headers.EnvoyAttemptCount() &&
+      absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count)) {
     error_attempt_count_ = attempt_count;
   }
 

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -123,7 +123,7 @@ private:
     const envoy_http_callbacks bridge_callbacks_;
     absl::optional<envoy_error_code_t> error_code_;
     absl::optional<envoy_data> error_message_;
-    absl::optional<uint32_t> error_attempt_count_;
+    absl::optional<int32_t> error_attempt_count_;
     Dispatcher& http_dispatcher_;
   };
 

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -123,6 +123,7 @@ private:
     const envoy_http_callbacks bridge_callbacks_;
     absl::optional<envoy_error_code_t> error_code_;
     absl::optional<envoy_data> error_message_;
+    absl::optional<uint32_t> error_attempt_count_;
     Dispatcher& http_dispatcher_;
   };
 

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -221,7 +221,8 @@ static void jvm_on_error(envoy_error error, void* context) {
   // to the JVM and free the c array, where applicable.
   env->ReleasePrimitiveArrayCritical(j_error_message, critical_error_message, 0);
 
-  env->CallVoidMethod(j_context, jmid_onError, error.error_code, j_error_message, error.attempt_count);
+  env->CallVoidMethod(j_context, jmid_onError, error.error_code, j_error_message,
+                      error.attempt_count);
 
   error.message.release(error.message.context);
   // No further callbacks happen on this context. Delete the reference held by native code.

--- a/library/common/jni_interface.cc
+++ b/library/common/jni_interface.cc
@@ -209,7 +209,7 @@ static void jvm_on_error(envoy_error error, void* context) {
   jobject j_context = static_cast<jobject>(context);
 
   jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
-  jmethodID jmid_onError = env->GetMethodID(jcls_JvmObserverContext, "onError", "([BI)V");
+  jmethodID jmid_onError = env->GetMethodID(jcls_JvmObserverContext, "onError", "(I[BI)V");
 
   jbyteArray j_error_message = env->NewByteArray(error.message.length);
   // TODO: check if copied via isCopy.
@@ -221,7 +221,7 @@ static void jvm_on_error(envoy_error error, void* context) {
   // to the JVM and free the c array, where applicable.
   env->ReleasePrimitiveArrayCritical(j_error_message, critical_error_message, 0);
 
-  env->CallVoidMethod(j_context, jmid_onError, j_error_message, error.error_code);
+  env->CallVoidMethod(j_context, jmid_onError, error.error_code, j_error_message, error.attempt_count);
 
   error.message.release(error.message.context);
   // No further callbacks happen on this context. Delete the reference held by native code.

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -138,6 +138,10 @@ extern const envoy_data envoy_nodata;
 typedef struct {
   envoy_error_code_t error_code;
   envoy_data message;
+  // the number of times an operation was attempted before firing this error.
+  // For instance this is used in envoy_on_error_f to account for the number of upstream requests
+  // made in a retry series before the on error callback fired.
+  uint32_t attempt_count;
 } envoy_error;
 
 #ifdef __cplusplus

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -141,7 +141,9 @@ typedef struct {
   // the number of times an operation was attempted before firing this error.
   // For instance this is used in envoy_on_error_f to account for the number of upstream requests
   // made in a retry series before the on error callback fired.
-  uint32_t attempt_count;
+  // -1 is used in scenarios where it does not make sense to have an attempt count for an error.
+  // This is different from 0, which intentionally conveys that the action was _not_ executed.
+  int32_t attempt_count;
 } envoy_error;
 
 #ifdef __cplusplus

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -127,14 +127,15 @@ class JvmCallbackContext {
   /**
    * Dispatches error received from the JNI layer up to the platform.
    *
-   * @param message,   the error message.
-   * @param errorCode, the envoy_error_code_t.
+   * @param errorCode,    the envoy_error_code_t.
+   * @param message,      the error message.
+   * @param attemptCount, the number of times an operation was attempted before firing this error.
    */
-  public void onError(byte[] message, int errorCode) {
+  public void onError(int errorCode, byte[] message, int attemptCount) {
     callbacks.getExecutor().execute(new Runnable() {
       public void run() {
         String errorMessage = new String(message);
-        callbacks.onError(errorCode, errorMessage);
+        callbacks.onError(errorCode, errorMessage, attemptCount);
       }
     });
   }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -127,7 +127,7 @@ class JvmCallbackContext {
   /**
    * Dispatches error received from the JNI layer up to the platform.
    *
-   * @param errorCode,    the envoy_error_code_t.
+   * @param errorCode,    the error code.
    * @param message,      the error message.
    * @param attemptCount, the number of times an operation was attempted before firing this error.
    */

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
@@ -37,9 +37,12 @@ public interface EnvoyHTTPCallbacks {
   /**
    * Called when the async HTTP stream has an error.
    *
-   * @param errorCode, the error code.
-   * @param message,   the error message.
+   * @param errorCode,    the error code.
+   * @param message,      the error message.
    * @param attemptCount, the number of times an operation was attempted before firing this error.
+   *                      -1 is used in scenarios where it does not make sense to have an attempt
+   *                      count for an error. This is different from 0, which intentionally conveys
+   *                      that the action was _not_ executed.
    */
   void onError(int errorCode, String message, int attemptCount);
 

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
@@ -39,8 +39,9 @@ public interface EnvoyHTTPCallbacks {
    *
    * @param errorCode, the error code.
    * @param message,   the error message.
+   * @param attemptCount, the number of times an operation was attempted before firing this error.
    */
-  void onError(int errorCode, String message);
+  void onError(int errorCode, String message, int attemptCount);
 
   /**
    * Called when the async HTTP stream is canceled.

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyError.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyError.kt
@@ -5,10 +5,12 @@ package io.envoyproxy.envoymobile
  *
  * @param errorCode internal error code associated with the exception that occurred.
  * @param message a description of what exception that occurred.
+ * @param attemptCount the number of times an operation was attempted before firing this error.
  * @param cause an optional cause for the exception.
  */
 class EnvoyError internal constructor(
     val errorCode: Int,
     val message: String,
+    val attemptCount: Int,
     val cause: Throwable? = null
 )

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyError.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyError.kt
@@ -5,12 +5,13 @@ package io.envoyproxy.envoymobile
  *
  * @param errorCode internal error code associated with the exception that occurred.
  * @param message a description of what exception that occurred.
- * @param attemptCount the number of times an operation was attempted before firing this error.
+ * @param attemptCount an optional number of times an operation was attempted before firing
+ *                     this error.
  * @param cause an optional cause for the exception.
  */
 class EnvoyError internal constructor(
     val errorCode: Int,
     val message: String,
-    val attemptCount: Int,
+    val attemptCount: Int? = null,
     val cause: Throwable? = null
 )

--- a/library/kotlin/src/io/envoyproxy/envoymobile/GRPCResponseHandler.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/GRPCResponseHandler.kt
@@ -123,7 +123,7 @@ class GRPCResponseHandler(
         val compressionFlag = byteArray[0]
         // TODO: Support gRPC compression https://github.com/lyft/envoy-mobile/issues/501.
         if (compressionFlag.compareTo(0) != 0) {
-          errorClosure(EnvoyError(0, "Unable to read compressed gRPC response message"))
+          errorClosure(EnvoyError(0, "Unable to read compressed gRPC response message", 1))
 
           // no op the current onData and clean up
           errorClosure = { }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/GRPCResponseHandler.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/GRPCResponseHandler.kt
@@ -123,7 +123,7 @@ class GRPCResponseHandler(
         val compressionFlag = byteArray[0]
         // TODO: Support gRPC compression https://github.com/lyft/envoy-mobile/issues/501.
         if (compressionFlag.compareTo(0) != 0) {
-          errorClosure(EnvoyError(0, "Unable to read compressed gRPC response message", 0))
+          errorClosure(EnvoyError(0, "Unable to read compressed gRPC response message"))
 
           // no op the current onData and clean up
           errorClosure = { }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/GRPCResponseHandler.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/GRPCResponseHandler.kt
@@ -123,7 +123,7 @@ class GRPCResponseHandler(
         val compressionFlag = byteArray[0]
         // TODO: Support gRPC compression https://github.com/lyft/envoy-mobile/issues/501.
         if (compressionFlag.compareTo(0) != 0) {
-          errorClosure(EnvoyError(0, "Unable to read compressed gRPC response message", 1))
+          errorClosure(EnvoyError(0, "Unable to read compressed gRPC response message", 0))
 
           // no op the current onData and clean up
           errorClosure = { }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
@@ -20,7 +20,7 @@ class ResponseHandler(val executor: Executor) {
       byteBuffer: ByteBuffer, endStream: Boolean
     ) -> Unit = { _, _ -> Unit }
     internal var onTrailersClosure: (trailers: Map<String, List<String>>) -> Unit = { Unit }
-    internal var onErrorClosure: (errorCode: Int, message: String) -> Unit = { _, _ -> Unit }
+    internal var onErrorClosure: (errorCode: Int, message: String, attemptCount: Int) -> Unit = { _, _, _ -> Unit }
     internal var onCancelClosure: () -> Unit = { Unit }
 
     override fun getExecutor(): Executor {
@@ -40,8 +40,8 @@ class ResponseHandler(val executor: Executor) {
       onTrailersClosure(trailers)
     }
 
-    override fun onError(errorCode: Int, message: String) {
-      onErrorClosure(errorCode, message)
+    override fun onError(errorCode: Int, message: String, attemptCount: Int) {
+      onErrorClosure(errorCode, message, attemptCount)
     }
 
     override fun onCancel() {
@@ -99,8 +99,8 @@ class ResponseHandler(val executor: Executor) {
    * @return ResponseHandler, this ResponseHandler.
    */
   fun onError(closure: (error: EnvoyError) -> Unit): ResponseHandler {
-    underlyingCallbacks.onErrorClosure = { errorCode, message ->
-      closure(EnvoyError(errorCode, message))
+    underlyingCallbacks.onErrorClosure = { errorCode, message, attemptCount ->
+      closure(EnvoyError(errorCode, message, attemptCount))
       Unit
     }
     return this

--- a/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHandler.kt
@@ -100,7 +100,7 @@ class ResponseHandler(val executor: Executor) {
    */
   fun onError(closure: (error: EnvoyError) -> Unit): ResponseHandler {
     underlyingCallbacks.onErrorClosure = { errorCode, message, attemptCount ->
-      closure(EnvoyError(errorCode, message, attemptCount))
+      closure(EnvoyError(errorCode, message, if (attemptCount < 0) null else attemptCount))
       Unit
     }
     return this

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -43,7 +43,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
  * Called when the async HTTP stream has an error.
  */
 @property (nonatomic, strong) void (^onError)
-    (uint64_t errorCode, NSString *message, uint32_t attemptCount);
+    (uint64_t errorCode, NSString *message, int32_t attemptCount);
 
 /**
  * Called when the async HTTP stream is canceled.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -42,7 +42,8 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 /**
  * Called when the async HTTP stream has an error.
  */
-@property (nonatomic, strong) void (^onError)(uint64_t errorCode, NSString *message, uint32_t attemptCount);
+@property (nonatomic, strong) void (^onError)
+    (uint64_t errorCode, NSString *message, uint32_t attemptCount);
 
 /**
  * Called when the async HTTP stream is canceled.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -42,7 +42,7 @@ typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
 /**
  * Called when the async HTTP stream has an error.
  */
-@property (nonatomic, strong) void (^onError)(uint64_t errorCode, NSString *message);
+@property (nonatomic, strong) void (^onError)(uint64_t errorCode, NSString *message, uint32_t attemptCount);
 
 /**
  * Called when the async HTTP stream is canceled.

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -156,7 +156,7 @@ static void ios_on_error(envoy_error error, void *context) {
                                                         length:error.message.length
                                                       encoding:NSUTF8StringEncoding];
       error.message.release(error.message.context);
-      callbacks.onError(error.error_code, errorMessage);
+      callbacks.onError(error.error_code, errorMessage, error.attempt_count);
     }
 
     // TODO: If the callback queue is not serial, clean up is not currently thread-safe.

--- a/library/swift/src/EnvoyError.swift
+++ b/library/swift/src/EnvoyError.swift
@@ -7,12 +7,12 @@ public final class EnvoyError: NSObject, Error {
   public let errorCode: UInt64
   /// A description of what exception that occurred.
   public let message: String
-  /// The number of times an operation was attempted before firing this error.
-  public let attemptCount: UInt32
+  /// Optional number of times an operation was attempted before firing this error.
+  public let attemptCount: UInt32?
   /// Optional cause for the error.
   public let cause: Error?
 
-  public init(errorCode: UInt64, message: String, attemptCount: UInt32, cause: Error?) {
+  public init(errorCode: UInt64, message: String, attemptCount: UInt32?, cause: Error?) {
     self.errorCode = errorCode
     self.message = message
     self.attemptCount = attemptCount

--- a/library/swift/src/EnvoyError.swift
+++ b/library/swift/src/EnvoyError.swift
@@ -7,12 +7,15 @@ public final class EnvoyError: NSObject, Error {
   public let errorCode: UInt64
   /// A description of what exception that occurred.
   public let message: String
+  /// The number of times an operation was attempted before firing this error.
+  public let attemptCount: UInt32
   /// Optional cause for the error.
   public let cause: Error?
 
-  public init(errorCode: UInt64, message: String, cause: Error?) {
+  public init(errorCode: UInt64, message: String, attemptCount: UInt32, cause: Error?) {
     self.errorCode = errorCode
     self.message = message
+    self.attemptCount = attemptCount
     self.cause = cause
   }
 }

--- a/library/swift/src/GRPCResponseHandler.swift
+++ b/library/swift/src/GRPCResponseHandler.swift
@@ -132,7 +132,8 @@ public final class GRPCResponseHandler: NSObject {
         // TODO: Support gRPC compression https://github.com/lyft/envoy-mobile/issues/501
         // Call the handler with an error and ignore all future updates.
         let error = EnvoyError(
-          errorCode: 0, message: "Unable to read compressed gRPC response message", attemptCount: 1, cause: nil)
+          errorCode: 0, message: "Unable to read compressed gRPC response message",
+          attemptCount: 1, cause: nil)
         self.internalErrorClosure?(error)
         self.resetHandlers()
         buffer.removeAll()

--- a/library/swift/src/GRPCResponseHandler.swift
+++ b/library/swift/src/GRPCResponseHandler.swift
@@ -133,7 +133,7 @@ public final class GRPCResponseHandler: NSObject {
         // Call the handler with an error and ignore all future updates.
         let error = EnvoyError(
           errorCode: 0, message: "Unable to read compressed gRPC response message",
-          attemptCount: 0, cause: nil)
+          attemptCount: nil, cause: nil)
         self.internalErrorClosure?(error)
         self.resetHandlers()
         buffer.removeAll()

--- a/library/swift/src/GRPCResponseHandler.swift
+++ b/library/swift/src/GRPCResponseHandler.swift
@@ -133,7 +133,7 @@ public final class GRPCResponseHandler: NSObject {
         // Call the handler with an error and ignore all future updates.
         let error = EnvoyError(
           errorCode: 0, message: "Unable to read compressed gRPC response message",
-          attemptCount: 1, cause: nil)
+          attemptCount: 0, cause: nil)
         self.internalErrorClosure?(error)
         self.resetHandlers()
         buffer.removeAll()

--- a/library/swift/src/GRPCResponseHandler.swift
+++ b/library/swift/src/GRPCResponseHandler.swift
@@ -132,7 +132,7 @@ public final class GRPCResponseHandler: NSObject {
         // TODO: Support gRPC compression https://github.com/lyft/envoy-mobile/issues/501
         // Call the handler with an error and ignore all future updates.
         let error = EnvoyError(
-          errorCode: 0, message: "Unable to read compressed gRPC response message", cause: nil)
+          errorCode: 0, message: "Unable to read compressed gRPC response message", attemptCount: 1, cause: nil)
         self.internalErrorClosure?(error)
         self.resetHandlers()
         buffer.removeAll()

--- a/library/swift/src/ResponseHandler.swift
+++ b/library/swift/src/ResponseHandler.swift
@@ -67,8 +67,8 @@ public final class ResponseHandler: NSObject {
     -> ResponseHandler
   {
     self.underlyingCallbacks.onError = { errorCode, message, attemptCount in
-      closure(EnvoyError(errorCode: errorCode, message: message, attemptCount: attemptCount,
-                         cause: nil))
+      closure(EnvoyError(errorCode: errorCode, message: message,
+                         attemptCount: attemptCount < 0 ? nil : UInt32(attemptCount), cause: nil))
     }
     return self
   }

--- a/library/swift/src/ResponseHandler.swift
+++ b/library/swift/src/ResponseHandler.swift
@@ -68,7 +68,11 @@ public final class ResponseHandler: NSObject {
   {
     self.underlyingCallbacks.onError = { errorCode, message, attemptCount in
       closure(EnvoyError(errorCode: errorCode, message: message,
-                         attemptCount: attemptCount < 0 ? nil : UInt32(attemptCount), cause: nil))
+                         // Note that the cast will return nil if attemptCount was negative
+                         // This is the desired behavior because the bridge layer uses -1 to
+                         // signify absence.
+                         attemptCount: UInt32(exactly: attemptCount),
+                         cause: nil))
     }
     return self
   }

--- a/library/swift/src/ResponseHandler.swift
+++ b/library/swift/src/ResponseHandler.swift
@@ -67,7 +67,8 @@ public final class ResponseHandler: NSObject {
     -> ResponseHandler
   {
     self.underlyingCallbacks.onError = { errorCode, message, attemptCount in
-      closure(EnvoyError(errorCode: errorCode, message: message, attemptCount: attemptCount, cause: nil))
+      closure(EnvoyError(errorCode: errorCode, message: message, attemptCount: attemptCount,
+                         cause: nil))
     }
     return self
   }

--- a/library/swift/src/ResponseHandler.swift
+++ b/library/swift/src/ResponseHandler.swift
@@ -66,8 +66,8 @@ public final class ResponseHandler: NSObject {
     @escaping (_ error: EnvoyError) -> Void)
     -> ResponseHandler
   {
-    self.underlyingCallbacks.onError = { errorCode, message in
-      closure(EnvoyError(errorCode: errorCode, message: message, cause: nil))
+    self.underlyingCallbacks.onError = { errorCode, message, attemptCount in
+      closure(EnvoyError(errorCode: errorCode, message: message, attemptCount: attemptCount, cause: nil))
     }
     return self
   }

--- a/library/swift/test/GRPCResponseHandlerTests.swift
+++ b/library/swift/test/GRPCResponseHandlerTests.swift
@@ -142,6 +142,7 @@ final class GRPCResponseHandlerTests: XCTestCase {
       .onError { error in
         let message = "Unable to read compressed gRPC response message"
         XCTAssertEqual(message, error.message)
+        XCTAssertEqual(0, error.attemptCount)
         expectation.fulfill()
       }
 

--- a/library/swift/test/GRPCResponseHandlerTests.swift
+++ b/library/swift/test/GRPCResponseHandlerTests.swift
@@ -142,7 +142,7 @@ final class GRPCResponseHandlerTests: XCTestCase {
       .onError { error in
         let message = "Unable to read compressed gRPC response message"
         XCTAssertEqual(message, error.message)
-        XCTAssertEqual(0, error.attemptCount)
+        XCTAssertNil(error.attemptCount)
         expectation.fulfill()
       }
 

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -787,6 +787,7 @@ TEST_F(DispatcherTest, EnvoyLocalReply) {
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
+    ASSERT_EQ(error.attempt_count, 0);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -844,6 +845,7 @@ TEST_F(DispatcherTest, EnvoyLocalReplyNon503) {
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_UNDEFINED_ERROR);
+    ASSERT_EQ(error.attempt_count, 0);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -902,6 +904,7 @@ TEST_F(DispatcherTest, EnvoyLocalReplyWithData) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
     ASSERT_EQ(Http::Utility::convertToString(error.message), "error message");
+    ASSERT_EQ(error.attempt_count, 0);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
     error.message.release(error.message.context);
@@ -947,6 +950,64 @@ TEST_F(DispatcherTest, EnvoyLocalReplyWithData) {
   Buffer::InstancePtr response_data{new Buffer::OwnedImpl("error message")};
   response_encoder_->encodeData(*response_data, true);
   ASSERT_EQ(cc.on_data_calls, 0);
+  stream_deletion_post_cb();
+
+  // Ensure that the callbacks on the bridge_callbacks were called.
+  ASSERT_EQ(cc.on_complete_calls, 0);
+  ASSERT_EQ(cc.on_error_calls, 1);
+}
+
+TEST_F(DispatcherTest, EnvoyLocalReplyWithAttemptCount) {
+  ready();
+
+  envoy_stream_t stream = 1;
+  // Setup bridge_callbacks to handle the response headers.
+  envoy_http_callbacks bridge_callbacks;
+  callbacks_called cc = {0, 0, 0, 0, 0, 0};
+  bridge_callbacks.context = &cc;
+  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
+    ASSERT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
+    ASSERT_EQ(error.attempt_count, 123);
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_error_calls++;
+  };
+
+  // Build a set of request headers.
+  TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
+
+  // Create a stream.
+  Event::PostCb start_stream_post_cb;
+  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
+  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+
+  // Grab the response encoder in order to dispatch responses on the stream.
+  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
+  // API.
+  EXPECT_CALL(api_listener_, newStream(_, _))
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+        response_encoder_ = &encoder;
+        return request_decoder_;
+      }));
+  start_stream_post_cb();
+
+  // Send request headers.
+  Event::PostCb send_headers_post_cb;
+  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&send_headers_post_cb));
+  http_dispatcher_.sendHeaders(stream, c_headers, true);
+
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
+  send_headers_post_cb();
+
+  // Encode response headers. A non-200 code triggers an on_error callback chain. In particular, a
+  // 503 should have an ENVOY_CONNECTION_FAILURE error code.
+  Event::PostCb stream_deletion_post_cb;
+  EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
+  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&stream_deletion_post_cb));
+  TestResponseHeaderMapImpl response_headers{{":status", "503"}, {"x-envoy-attempt-count", "123"}};
+  response_encoder_->encodeHeaders(response_headers, true);
+  ASSERT_EQ(cc.on_headers_calls, 0);
   stream_deletion_post_cb();
 
   // Ensure that the callbacks on the bridge_callbacks were called.
@@ -1028,6 +1089,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
+    ASSERT_EQ(error.attempt_count, 0);
     // This will use envoy_noop_release.
     error.message.release(error.message.context);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -1174,6 +1236,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRaceLocalWins) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
+    ASSERT_EQ(error.attempt_count, 0);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -1267,6 +1330,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWinsDeletesStream) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
+    ASSERT_EQ(error.attempt_count, 0);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -1359,6 +1423,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRemoteWins) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
+    ASSERT_EQ(error.attempt_count, 0);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -1453,6 +1518,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRaceLocalWins) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
+    ASSERT_EQ(error.attempt_count, 0);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -1543,6 +1609,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWinsDeletesStream) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
+    ASSERT_EQ(error.attempt_count, 0);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -1632,6 +1699,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWins) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
+    ASSERT_EQ(error.attempt_count, 0);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -787,7 +787,7 @@ TEST_F(DispatcherTest, EnvoyLocalReply) {
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
-    ASSERT_EQ(error.attempt_count, 0);
+    ASSERT_EQ(error.attempt_count, -1);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -845,7 +845,7 @@ TEST_F(DispatcherTest, EnvoyLocalReplyNon503) {
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_UNDEFINED_ERROR);
-    ASSERT_EQ(error.attempt_count, 0);
+    ASSERT_EQ(error.attempt_count, -1);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -904,7 +904,7 @@ TEST_F(DispatcherTest, EnvoyLocalReplyWithData) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
     ASSERT_EQ(Http::Utility::convertToString(error.message), "error message");
-    ASSERT_EQ(error.attempt_count, 0);
+    ASSERT_EQ(error.attempt_count, -1);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
     error.message.release(error.message.context);
@@ -1089,7 +1089,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
-    ASSERT_EQ(error.attempt_count, 0);
+    ASSERT_EQ(error.attempt_count, -1);
     // This will use envoy_noop_release.
     error.message.release(error.message.context);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -1236,7 +1236,7 @@ TEST_F(DispatcherTest, ResetStreamLocalHeadersRemoteRaceLocalWins) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
-    ASSERT_EQ(error.attempt_count, 0);
+    ASSERT_EQ(error.attempt_count, -1);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -1609,7 +1609,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWinsDeletesStream) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
-    ASSERT_EQ(error.attempt_count, 0);
+    ASSERT_EQ(error.attempt_count, -1);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };
@@ -1699,7 +1699,7 @@ TEST_F(DispatcherTest, ResetStreamLocalResetRemoteRemoteWins) {
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
     ASSERT_EQ(error.error_code, ENVOY_STREAM_RESET);
     ASSERT_EQ(error.message.length, 0);
-    ASSERT_EQ(error.attempt_count, 0);
+    ASSERT_EQ(error.attempt_count, -1);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
   };


### PR DESCRIPTION
Description: this PR updates the error objects in the library to contain an attempt count. Additionally it wires up the attempt count as reported via envoy headers to the error object used by the Http::Dispatcher.
Risk Level: low - no breaking API changes.
Testing: unit tests, plus local end-to-end tests.
Docs Changes: updated the types docstrings

Signed-off-by: Jose Nino <jnino@lyft.com>