### PR TITLE
bazel: Update swift_static_framework to use swiftinterfaces

### DIFF
--- a/bazel/swift_static_framework.bzl
+++ b/bazel/swift_static_framework.bzl
@@ -66,6 +66,7 @@ def _swift_static_framework_impl(ctx):
             fail("Expected exactly 1 '-Swift.h' header, got {}".format(", ".join(header_names)))
 
         swiftdoc = swift_info.direct_swiftdocs[0]
+        swiftmodule = swift_info.direct_swiftmodules[0]
         swiftinterfaces = swift_info.transitive_swiftinterfaces.to_list()
         if len(swiftinterfaces) != 1:
             fail("Expected a single swiftinterface file, got: {}".format(swiftinterfaces))
@@ -95,9 +96,10 @@ def _swift_static_framework_impl(ctx):
 
         input_archives.append(platform_archive)
 
-        input_modules_docs += [swiftdoc, swiftinterface]
+        input_modules_docs += [swiftdoc, swiftmodule, swiftinterface]
         zip_args += [
             _zip_swift_arg(module_name, swiftmodule_identifier, swiftdoc),
+            _zip_swift_arg(module_name, swiftmodule_identifier, swiftmodule),
             _zip_swift_arg(module_name, swiftmodule_identifier, swiftinterface),
         ]
 

--- a/bazel/swift_test.bzl
+++ b/bazel/swift_test.bzl
@@ -17,14 +17,14 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 #     ],
 # )
 #
-def envoy_mobile_swift_test(name, srcs):
+def envoy_mobile_swift_test(name, srcs, deps = []):
     test_lib_name = name + "_lib"
     swift_library(
         name = test_lib_name,
         srcs = srcs,
         deps = [
             "//library/swift/src:ios_framework_archive",
-        ],
+        ] + deps,
         linkopts = ["-lresolv.9"],
         visibility = ["//visibility:private"],
     )

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -16,6 +16,7 @@ objc_library(
     hdrs = [
         "EnvoyEngine.h",
     ],
+    module_name = "EnvoyEngine",
     sdk_frameworks = [
         "SystemConfiguration",
         "UIKit",

--- a/library/swift/src/BUILD
+++ b/library/swift/src/BUILD
@@ -35,9 +35,6 @@ swift_static_framework(
         "grpc/*.swift",
     ]),
     module_name = "Envoy",
-    objc_includes = [
-        "//library/objective-c:EnvoyEngine.h",
-    ],
+    private_deps = ["//library/objective-c:envoy_engine_objc_lib"],
     visibility = ["//visibility:public"],
-    deps = ["//library/objective-c:envoy_engine_objc_lib"],
 )

--- a/library/swift/src/EnvoyClient.swift
+++ b/library/swift/src/EnvoyClient.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import EnvoyEngine
 import Foundation
 
 /// Envoy's implementation of `HTTPClient`, buildable using `EnvoyClientBuilder`.

--- a/library/swift/src/EnvoyClientBuilder.swift
+++ b/library/swift/src/EnvoyClientBuilder.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import EnvoyEngine
 import Foundation
 
 /// Builder used for creating new instances of EnvoyClient.

--- a/library/swift/src/EnvoyStreamEmitter.swift
+++ b/library/swift/src/EnvoyStreamEmitter.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import EnvoyEngine
 import Foundation
 
 /// Default implementation of the `StreamEmitter` interface.

--- a/library/swift/src/ResponseHandler.swift
+++ b/library/swift/src/ResponseHandler.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import EnvoyEngine
 import Foundation
 
 /// Callback interface for receiving stream events.

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -9,6 +9,9 @@ envoy_mobile_swift_test(
         "MockEnvoyEngine.swift",
         "MockEnvoyHTTPStream.swift",
     ],
+    deps = [
+        "//library/objective-c:envoy_engine_objc_lib",
+    ],
 )
 
 envoy_mobile_swift_test(
@@ -17,6 +20,9 @@ envoy_mobile_swift_test(
         "EnvoyClientBuilderTests.swift",
         "MockEnvoyEngine.swift",
         "MockEnvoyHTTPStream.swift",
+    ],
+    deps = [
+        "//library/objective-c:envoy_engine_objc_lib",
     ],
 )
 
@@ -31,6 +37,9 @@ envoy_mobile_swift_test(
     name = "grpc_response_handler_tests",
     srcs = [
         "GRPCResponseHandlerTests.swift",
+    ],
+    deps = [
+        "//library/objective-c:envoy_engine_objc_lib",
     ],
 )
 

--- a/library/swift/test/EnvoyClientBuilderTests.swift
+++ b/library/swift/test/EnvoyClientBuilderTests.swift
@@ -1,4 +1,5 @@
 @testable import Envoy
+import EnvoyEngine
 import Foundation
 import XCTest
 

--- a/library/swift/test/GRPCResponseHandlerTests.swift
+++ b/library/swift/test/GRPCResponseHandlerTests.swift
@@ -1,4 +1,5 @@
 @testable import Envoy
+import EnvoyEngine
 import Foundation
 import XCTest
 

--- a/library/swift/test/MockEnvoyEngine.swift
+++ b/library/swift/test/MockEnvoyEngine.swift
@@ -1,5 +1,5 @@
-import EnvoyEngine
 @testable import Envoy
+import EnvoyEngine
 import Foundation
 
 final class MockEnvoyEngine: NSObject {

--- a/library/swift/test/MockEnvoyEngine.swift
+++ b/library/swift/test/MockEnvoyEngine.swift
@@ -1,3 +1,4 @@
+import EnvoyEngine
 @testable import Envoy
 import Foundation
 

--- a/library/swift/test/MockEnvoyHTTPStream.swift
+++ b/library/swift/test/MockEnvoyHTTPStream.swift
@@ -1,4 +1,5 @@
 import Envoy
+import EnvoyEngine
 import Foundation
 
 final class MockEnvoyHTTPStream {


### PR DESCRIPTION
This is an in between to https://github.com/lyft/envoy-mobile/pull/797
which starts building the archive with swiftinterface files, but does
it with our existing swift_static_framework rule because of issues
linked on that PR.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>