### PR TITLE
[kotlin] add x-envoy-retriable-status-codes header

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicy.kt
@@ -5,6 +5,7 @@ package io.envoyproxy.envoymobile
  *
  * @param maxRetryCount Maximum number of retries that a request may be performed.
  * @param retryOn Whitelist of rules used for retrying.
+ * @param retryStatusCodes Additional list of status codes that should be retried.
  * @param perRetryTimeoutMS Timeout (in milliseconds) to apply to each retry.
  * Must be <= `totalUpstreamTimeoutMS` if it's a positive number.
  * @param totalUpstreamTimeoutMS Total timeout (in milliseconds) that includes all retries.
@@ -12,10 +13,11 @@ package io.envoyproxy.envoymobile
  * upstream response has been completely processed. Null or 0 may be specified to disable it.
  */
 data class RetryPolicy(
-  val maxRetryCount: Int,
-  val retryOn: List<RetryRule>,
-  val perRetryTimeoutMS: Long? = null,
-  val totalUpstreamTimeoutMS: Long? = 15000
+    val maxRetryCount: Int,
+    val retryOn: List<RetryRule>,
+    val retryStatusCodes: List<Int> = emptyList(),
+    val perRetryTimeoutMS: Long? = null,
+    val totalUpstreamTimeoutMS: Long? = 15000
 ) {
   init {
     if (perRetryTimeoutMS != null && totalUpstreamTimeoutMS != null &&
@@ -35,7 +37,6 @@ enum class RetryRule {
   CONNECT_FAILURE,
   REFUSED_STREAM,
   RETRIABLE_4XX,
-  RETRIABLE_STATUS_CODES,
   RETRIABLE_HEADERS,
   RESET,
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicyMapper.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicyMapper.kt
@@ -9,7 +9,6 @@ internal fun RetryPolicy.outboundHeaders(): Map<String, List<String>> {
   val upstreamTimeoutMS = totalUpstreamTimeoutMS ?: 0L
   val headers = mutableMapOf(
       "x-envoy-max-retries" to listOf("$maxRetryCount"),
-      "x-envoy-retry-on" to retryOn.map { elm -> elm.stringValue() },
       "x-envoy-upstream-rq-timeout-ms" to listOf("$upstreamTimeoutMS")
   )
 
@@ -17,9 +16,12 @@ internal fun RetryPolicy.outboundHeaders(): Map<String, List<String>> {
     headers["x-envoy-upstream-rq-per-try-timeout-ms"] = listOf("$perRetryTimeoutMS")
   }
 
+  val retryOn = retryOn.map { elm -> elm.stringValue() }.toMutableList()
   if (retryStatusCodes.isNotEmpty()) {
-    headers["x-envoy-retriable-status-codes"] = retryStatusCodes.map { value -> value.toString() }
+    retryOn.add("retriable-status-codes")
+    headers["x-envoy-retriable-status-codes"] = retryStatusCodes.map { value -> "$value" }
   }
+  headers["x-envoy-retry-on"] = retryOn
   return headers
 }
 

--- a/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicyMapper.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/RetryPolicyMapper.kt
@@ -16,6 +16,10 @@ internal fun RetryPolicy.outboundHeaders(): Map<String, List<String>> {
   if (perRetryTimeoutMS != null) {
     headers["x-envoy-upstream-rq-per-try-timeout-ms"] = listOf("$perRetryTimeoutMS")
   }
+
+  if (retryStatusCodes.isNotEmpty()) {
+    headers["x-envoy-retriable-status-codes"] = retryStatusCodes.map { value -> value.toString() }
+  }
   return headers
 }
 
@@ -31,7 +35,6 @@ private fun RetryRule.stringValue(): String {
     RetryRule.CONNECT_FAILURE -> "connect-failure"
     RetryRule.REFUSED_STREAM -> "refused-stream"
     RetryRule.RETRIABLE_4XX -> "retriable-4xx"
-    RetryRule.RETRIABLE_STATUS_CODES -> "retriable-status-codes"
     RetryRule.RETRIABLE_HEADERS -> "retriable-headers"
     RetryRule.RESET -> "reset"
   }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
@@ -14,8 +14,12 @@ class RequestBuilderTest {
         .addRetryPolicy(retryPolicy)
         .build()
 
-    assertThat(request.retryPolicy)
-      .isEqualTo(RetryPolicy(23, listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), 1234))
+    assertThat(request.retryPolicy).isEqualTo(
+        RetryPolicy(
+            maxRetryCount =23,
+            retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE),
+            perRetryTimeoutMS = 1234)
+    )
   }
 
   @Test
@@ -29,8 +33,10 @@ class RequestBuilderTest {
 
   @Test
   fun `adding upstream http protocol should have hint present in request`() {
-    val retryPolicy = RetryPolicy(maxRetryCount = 23,
-      retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), perRetryTimeoutMS = 1234)
+    val retryPolicy = RetryPolicy(
+        maxRetryCount = 23,
+        retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE),
+        perRetryTimeoutMS = 1234)
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
       authority = "api.foo.com", path = "foo")
         .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
@@ -8,15 +8,15 @@ class RequestBuilderTest {
   fun `adding retry policy should have policy present in request`() {
 
     val retryPolicy = RetryPolicy(maxRetryCount = 23,
-      retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), perRetryTimeoutMS = 1234)
+        retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), perRetryTimeoutMS = 1234)
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .addRetryPolicy(retryPolicy)
         .build()
 
     assertThat(request.retryPolicy).isEqualTo(
         RetryPolicy(
-            maxRetryCount =23,
+            maxRetryCount = 23,
             retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE),
             perRetryTimeoutMS = 1234)
     )
@@ -25,7 +25,7 @@ class RequestBuilderTest {
   @Test
   fun `not adding retry policy should have null body in request`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .build()
 
     assertThat(request.retryPolicy).isNull()
@@ -38,7 +38,7 @@ class RequestBuilderTest {
         retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE),
         perRetryTimeoutMS = 1234)
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
         .build()
 
@@ -48,7 +48,7 @@ class RequestBuilderTest {
   @Test
   fun `not adding upstream http protocol should have null upstream protocol in request`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .build()
 
     assertThat(request.upstreamHttpProtocol).isNull()
@@ -57,7 +57,7 @@ class RequestBuilderTest {
   @Test
   fun `adding new headers should append to the list of header keys`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .build()
 
@@ -67,7 +67,7 @@ class RequestBuilderTest {
   @Test
   fun `removing headers should clear headers in request`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .removeHeaders("header_a")
         .build()
@@ -78,7 +78,7 @@ class RequestBuilderTest {
   @Test
   fun `removing a specific header value should not be in request`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -90,7 +90,7 @@ class RequestBuilderTest {
   @Test
   fun `removing a specific header value should keep the other header values in request`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .removeHeader("header_a", "value_a1")
@@ -102,7 +102,7 @@ class RequestBuilderTest {
   @Test
   fun `adding a specific header value should keep the other header values in request`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .addHeader("header_a", "value_a2")
         .build()
@@ -113,7 +113,7 @@ class RequestBuilderTest {
   @Test
   fun `removing all header values should remove header list in request`() {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
-      authority = "api.foo.com", path = "foo")
+        authority = "api.foo.com", path = "foo")
         .addHeader("header_a", "value_a1")
         .removeHeader("header_a", "value_a1")
         .build()

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestBuilderTest.kt
@@ -7,8 +7,10 @@ class RequestBuilderTest {
   @Test
   fun `adding retry policy should have policy present in request`() {
 
-    val retryPolicy = RetryPolicy(maxRetryCount = 23,
-        retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), perRetryTimeoutMS = 1234)
+    val retryPolicy = RetryPolicy(
+        maxRetryCount = 23,
+        retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE),
+        perRetryTimeoutMS = 1234)
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
         authority = "api.foo.com", path = "foo")
         .addRetryPolicy(retryPolicy)

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RequestTest.kt
@@ -30,7 +30,10 @@ class RequestTest {
     val request = RequestBuilder(method = RequestMethod.POST, scheme = "https",
       authority = "api.foo.com", path = "foo")
         .addRetryPolicy(
-          RetryPolicy(23, listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE), 1234)
+          RetryPolicy(
+              maxRetryCount = 23,
+              retryOn = listOf(RetryRule.STATUS_5XX, RetryRule.CONNECT_FAILURE),
+              perRetryTimeoutMS = 1234)
         )
         .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
         .addHeader("header_a", "value_a1")

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -82,8 +82,8 @@ class RetryPolicyMapperTest {
         totalUpstreamTimeoutMS = null)
 
     val headers = retryPolicy.outboundHeaders()
-    assertThat(headers["x-envoy-retriable-status-codes"]).isNotNull()
-    assertThat(headers["x-envoy-retry-on"]).contains("retriable-status-codes")
+    assertThat(headers["x-envoy-retriable-status-codes"]).isNull()
+    assertThat(headers["x-envoy-retry-on"]).doesNotContain("retriable-status-codes")
 
   }
 }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -14,17 +14,18 @@ class RetryPolicyMapperTest {
             RetryRule.CONNECT_FAILURE,
             RetryRule.REFUSED_STREAM,
             RetryRule.RETRIABLE_4XX,
-            RetryRule.RETRIABLE_STATUS_CODES,
             RetryRule.RETRIABLE_HEADERS,
             RetryRule.RESET),
+        retryStatusCodes = listOf(400, 422, 500),
         perRetryTimeoutMS = 15000,
         totalUpstreamTimeoutMS = 60000)
 
     assertThat(retryPolicy.outboundHeaders()).isEqualTo(mapOf(
         "x-envoy-max-retries" to listOf("3"),
+        "x-envoy-retriable-status-codes" to listOf("400", "422", "500"),
         "x-envoy-retry-on" to listOf(
           "5xx", "gateway-error", "connect-failure", "refused-stream", "retriable-4xx",
-          "retriable-status-codes", "retriable-headers", "reset"
+          "retriable-headers", "reset"
         ),
         "x-envoy-upstream-rq-per-try-timeout-ms" to listOf("15000"),
         "x-envoy-upstream-rq-timeout-ms" to listOf("60000")


### PR DESCRIPTION
Adding `x-envoy-retriable-status-codes` header to allow consumers to specify the retriable status codes

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: [kotlin] add x-envoy-retriable-status-codes header
Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
