### PR TITLE
swift: add x-envoy-retriable-status-codes support

### DIFF
--- a/library/swift/test/RetryPolicyMapperTests.swift
+++ b/library/swift/test/RetryPolicyMapperTests.swift
@@ -5,9 +5,11 @@ final class RetryPolicyMapperTests: XCTestCase {
   func testConvertingToHeadersWithPerRetryTimeoutIncludesAllHeaders() {
     let policy = RetryPolicy(maxRetryCount: 3,
                              retryOn: RetryRule.allCases,
+                             retryStatusCodes: [400, 422, 500],
                              perRetryTimeoutMS: 15_000,
                              totalUpstreamTimeoutMS: 60_000)
     let expectedHeaders = [
+      "x-envoy-retriable-status-codes": ["400", "422", "500"],
       "x-envoy-max-retries": ["3"],
       "x-envoy-retry-on": [
         "5xx", "gateway-error", "connect-failure", "refused-stream", "retriable-4xx",
@@ -29,5 +31,13 @@ final class RetryPolicyMapperTests: XCTestCase {
     let policy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases,
                              totalUpstreamTimeoutMS: nil)
     XCTAssertEqual(["0"], policy.outboundHeaders()["x-envoy-upstream-rq-timeout-ms"])
+  }
+
+  func testConvertingToHeadersWithoutRetryStatusCodesDoesNotSetRetriableStatusCodeHeaders() throws {
+    let policy = RetryPolicy(maxRetryCount: 123, retryOn: RetryRule.allCases,
+                             retryStatusCodes: [])
+    let headers = policy.outboundHeaders()
+    XCTAssertNil(headers["x-envoy-retriable-status-codes"])
+    XCTAssertFalse((try XCTUnwrap(headers["x-envoy-retry-on"])).contains("retriable-status-codes"))
   }
 }

--- a/library/swift/test/RetryPolicyMapperTests.swift
+++ b/library/swift/test/RetryPolicyMapperTests.swift
@@ -13,7 +13,7 @@ final class RetryPolicyMapperTests: XCTestCase {
       "x-envoy-max-retries": ["3"],
       "x-envoy-retry-on": [
         "5xx", "gateway-error", "connect-failure", "refused-stream", "retriable-4xx",
-        "retriable-status-codes", "retriable-headers", "reset",
+        "retriable-headers", "reset", "retriable-status-codes",
       ],
       "x-envoy-upstream-rq-per-try-timeout-ms": ["15000"],
       "x-envoy-upstream-rq-timeout-ms": ["60000"],


### PR DESCRIPTION
Adding support for setting the `x-envoy-retriable-status-codes` header to allow consumers to specify the retriable status codes that are not supported by `RetryRule` out of the box.

From the [docs](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#config-http-filters-router-x-envoy-retriable-status-codes):

> Setting this header informs Envoy about what status codes should be considered retriable when used in conjunction with the retriable-status-code retry policy. When the corresponding retry policy is set, the list of retriable status codes will be considered retriable in addition to the status codes enabled for retry through other retry policies.

Mirrors Android: https://github.com/lyft/envoy-mobile/pull/820

Signed-off-by: Michael Rebello <me@michaelrebello.com>