### PR TITLE
dispatcher: fix crashes from NOT_IMPLEMENTED_GCOVR_EXCL_LINE

### DIFF
--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -113,8 +113,10 @@ private:
     Stream& getStream() override;
     Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override { return absl::nullopt; }
     // TODO: implement
-    void encode100ContinueHeaders(const ResponseHeaderMap&) override {}
-    void encodeMetadata(const MetadataMapVector&) override {}
+    void encode100ContinueHeaders(const ResponseHeaderMap&) override {
+      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    }
+    void encodeMetadata(const MetadataMapVector&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
   private:
     DirectStream& direct_stream_;
@@ -145,8 +147,8 @@ private:
     const Network::Address::InstanceConstSharedPtr& connectionLocalAddress() override {
       return parent_.address_;
     }
-    // TODO: stream watermark control.
-    void readDisable(bool) override {}
+    // TODO: https://github.com/lyft/envoy-mobile/issues/825
+    void readDisable(bool /*disable*/) override {}
     uint32_t bufferLimit() override { return 65000; }
 
     void closeLocal(bool end_stream);

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -113,10 +113,8 @@ private:
     Stream& getStream() override;
     Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override { return absl::nullopt; }
     // TODO: implement
-    void encode100ContinueHeaders(const ResponseHeaderMap&) override {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-    }
-    void encodeMetadata(const MetadataMapVector&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+    void encode100ContinueHeaders(const ResponseHeaderMap&) override {}
+    void encodeMetadata(const MetadataMapVector&) override {}
 
   private:
     DirectStream& direct_stream_;
@@ -147,7 +145,7 @@ private:
       return parent_.address_;
     }
     // TODO: stream watermark control.
-    void readDisable(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+    void readDisable(bool) override {}
     uint32_t bufferLimit() override { return 65000; }
 
     void closeLocal(bool end_stream);


### PR DESCRIPTION
We've started seeing `SIGABRT` crashes in this file coming from `readDisable()`.

The `NOT_IMPLEMENTED_GCOVR_EXCL_LINE` tag was added a nice-to-have in https://github.com/lyft/envoy-mobile/commit/7ea53ab2f0a6263694cad21a0da6b872e1d6cae0, but is now causing problems because `readDisable` is being called.

I'm removing this for now, and filed https://github.com/lyft/envoy-mobile/issues/825 to properly implement this function.

Crash:

```
SIGABRT
[critical][assert] [./library/common/http/dispatcher.h:150] panic: not implemented
```

Signed-off-by: Michael Rebello <me@michaelrebello.com>