### PR TITLE
envoy upstream: update ref and report counters as deltas

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -164,6 +164,7 @@ stats_sinks:
   - name: envoy.metrics_service
     typed_config:
       "@type": type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig
+      report_counters_as_deltas: true
       grpc_service:
         envoy_grpc:
           cluster_name: stats


### PR DESCRIPTION
Description: updates the envoy ref. Brings in the ability to report counters as deltas in the metrics service stats sink https://github.com/envoyproxy/envoy/pull/10889.

Signed-off-by: Jose Nino <jnino@lyft.com>
