### PR TITLE
[kotlin] make constructor public visibility for EnvoyError

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyError.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EnvoyError.kt
@@ -7,7 +7,7 @@ package io.envoyproxy.envoymobile
  * @param message a description of what exception that occurred.
  * @param cause an optional cause for the exception.
  */
-class EnvoyError internal constructor(
+class EnvoyError constructor(
     val errorCode: Int,
     val message: String,
     val cause: Throwable? = null


### PR DESCRIPTION
Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: [kotlin] make constructor public visibility for EnvoyError
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
