### PR TITLE
update envoy 05102020

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,10 +25,10 @@ http_archive(
 http_archive(
     name = "com_google_absl",
     patches = ["//bazel:abseil.patch"],
-    sha256 = "190b0c9e65ef0866b44c54b517b5a3e15b67a1001b34547f03f8f4d8553c2851",
-    strip_prefix = "abseil-cpp-63ee2f8877915a3565c29707dba8fe4d7822596a",
-    # 2020-01-08
-    urls = ["https://github.com/abseil/abseil-cpp/archive/63ee2f8877915a3565c29707dba8fe4d7822596a.tar.gz"],
+    sha256 = "14ee08e2089c2a9b6bf27e1d10abc5629c69c4d0bab4b78ec5b65a29ea1c2af7",
+    strip_prefix = "abseil-cpp-cf3a1998e9d41709d4141e2f13375993cba1130e",
+    # 2020-03-05
+    urls = ["https://github.com/abseil/abseil-cpp/archive/cf3a1998e9d41709d4141e2f13375993cba1130e.tar.gz"],
 )
 
 # This should be kept in sync with Envoy itself, we just need to apply this patch

--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis;x86'
 echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-28;google_apis;x86' --force
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'


### PR DESCRIPTION
Description: brings in an envoy update. Relevant commits:
- https://github.com/envoyproxy/envoy/pull/11127 which uses the construct on first use idiom for certain static variables in the histogram code which were causing #688.
Risk Level: low
Testing: fixed local repro of the crash.

Fixes #688 

Signed-off-by: Jose Nino <jnino@lyft.com>