### PR TITLE
android: update version to 29

### DIFF
--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis;x86'
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-28;google_apis;x86' --force
+echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-29;google_apis;x86'
+echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86' --force
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -31,7 +31,7 @@ Follow the Envoy instructions `here <https://github.com/envoyproxy/envoy/blob/ma
 Android requirements
 --------------------
 
-- Android SDK Platform 28
+- Android SDK Platform 29
 - Android NDK 19.2.5345600
 
 ----------------


### PR DESCRIPTION
Description: actions infra is failing to start android 28. However, android 29 works fine. This PR updates CI to start the android emulator with android 29.
Risk Level: low
Testing: local and CI
Docs Changes: updated the docs to SDK version 29 for requirements

Fixes #841 

Signed-off-by: Jose Nino <jnino@lyft.com>
