### PR TITLE
Add missing Foundation import

### DIFF
--- a/library/swift/src/FilterDataStatus.swift
+++ b/library/swift/src/FilterDataStatus.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Status returned by filters when transmitting or receiving data.
 public enum FilterDataStatus {
   /// Continue filter chain iteration. If headers have not yet been sent to the next filter, they


### PR DESCRIPTION
This is currently being used for `Data` but is currently being polluted
by the Objective-C bridging header.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>