### PR TITLE
release: increase android release ci time limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   android_aar_sonatype_deploy:
     name: android_deploy
     runs-on: ubuntu-18.04
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Description: the current time limit was exceeded in the last release I cut: https://github.com/lyft/envoy-mobile/runs/668659114

Signed-off-by: Jose Nino <jnino@lyft.com>