### PR TITLE
ci: Remove bazel before job

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "envoy"]
 	path = envoy
-	url = https://github.com/envoyproxy/envoy.git
+	url = https://github.com/keith/envoy.git

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-# Uninstall bazel so bazelisk has to be used
-brew uninstall --force bazel
+brew unlink bazelbuild/tap/bazelisk || true
 
 # Leverage Envoy upstream's setup scripts to avoid repeating here.
 ./envoy/ci/mac_ci_setup.sh

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Uninstall bazel so bazelisk has to be used
+brew uninstall --force bazel
+
 # Leverage Envoy upstream's setup scripts to avoid repeating here.
 ./envoy/ci/mac_ci_setup.sh
 


### PR DESCRIPTION
I'm hoping this fixes:

```
ERROR: The project you're trying to build requires Bazel 3.0.0 (specified in /Users/runner/runners/2.169.1/work/envoy-mobile/envoy-mobile/.bazelversion), but it wasn't found in /usr/local/Cellar/bazel/3.1.0/libexec/bin.
```

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>