### PR TITLE
ci: Switch to bazelisk explicitly

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,7 +44,7 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
       - name: 'Build envoy.aar distributable'
-        run: bazel build --fat_apk_cpu=x86 //:android_dist
+        run: bazelisk build --fat_apk_cpu=x86 //:android_dist
       - uses: actions/upload-artifact@v1
         with:
           name: envoy.aar
@@ -67,7 +67,7 @@ jobs:
       - run: ls -lh dist/
       - name: start simulator
         run: ./ci/mac_start_emulator.sh
-      - run: bazel mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
+      - run: bazelisk mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
         name: 'Start java app'
       - run: 'adb logcat -e "successful response" -m 1'
         name: 'Check liveliness'
@@ -89,7 +89,7 @@ jobs:
       - run: ls -lh dist/
       - name: start simulator
         run: ./ci/mac_start_emulator.sh
-      - run: bazel mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
+      - run: bazelisk mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
         name: 'Start kotlin app'
       - run: 'adb logcat -e "successful response" -m 1'
         name: 'Check liveliness'

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -45,7 +45,7 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Build Envoy.framework distributable'
-        run: bazel build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 //:ios_dist
+        run: bazelisk build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 //:ios_dist
       - name: 'Create temporary directory for artifact to produce properly named zip'
         run: mkdir -p dist/ios_artifact/Envoy.framework
       - name: 'Move artifact to directory for zipping'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Run tests'
-        run: bazel test --test_output=all //test/...
+        run: bazelisk test --test_output=all //test/...
   tsan:
     name: tsan
     runs-on: ubuntu-18.04

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Build Envoy.framework distributable'
-        run: bazel build --config=ios //:ios_dist
+        run: bazelisk build --config=ios //:ios_dist
       - name: 'Zip Envoy.framework.zip distributable'
         run: zip -r dist/Envoy.framework.zip dist/Envoy.framework
       - run: ls -lh dist/
@@ -44,10 +44,10 @@ jobs:
       - run: unzip dist/Envoy.framework.zip
       - run: ls -lh dist/
       - name: 'Build swift app'
-        run: bazel build --config=ios //examples/swift/hello_world:app
+        run: bazelisk build --config=ios //examples/swift/hello_world:app
       # Run the app in the background and redirect logs.
       - name: 'Run swift app'
-        run: bazel run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
+        run: bazelisk run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
       # Wait for the app to start and get some requests/responses.
       - name: 'Sleep'
         run: sleep 120
@@ -76,10 +76,10 @@ jobs:
       - run: unzip dist/Envoy.framework.zip
       - run: ls -lh dist/
       - name: 'Build objective-c app'
-        run: bazel build --config=ios //examples/objective-c/hello_world:app
+        run: bazelisk build --config=ios //examples/objective-c/hello_world:app
       # Run the app in the background and redirect logs.
       - name: 'Run objective-c app'
-        run: bazel run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+        run: bazelisk run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
       # Wait for the app to start and get some requests/responses.
       - name: 'Sleep'
         run: sleep 120
@@ -101,4 +101,4 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Run swift library tests'
-        run: bazel test --test_output=all --config=ios --build_tests_only //library/swift/test/...
+        run: bazelisk test --test_output=all --config=ios --build_tests_only //library/swift/test/...


### PR DESCRIPTION
GitHub actions borked the images symlinks for bazel to mean bazelisk,
instead we can use it directly

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>