### PR TITLE
compression: add response decompression

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,6 +84,10 @@ load("@envoy//bazel:repositories.bzl", "envoy_dependencies")
 
 envoy_dependencies()
 
+load("@envoy//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
+
+envoy_dependencies_extra()
+
 load("@envoy//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
 envoy_dependency_imports()

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -10,6 +10,9 @@ sudo rm -rf /var/lib/apt/lists/*
 # We do not use heroku, but it is pre-installed in the github actions machines.
 curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
 
+# https://github.com/bazelbuild/bazel/issues/11470#issuecomment-633205152
+curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+
 sudo apt-get clean
 sudo apt-get update
 

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -42,6 +42,19 @@ static_resources:
                 dns_failure_refresh_rate:
                   base_interval: {{ dns_failure_refresh_rate_seconds_base }}s
                   max_interval: {{ dns_failure_refresh_rate_seconds_max }}s
+          # TODO: make this configurable for users.
+          - name: envoy.filters.http.decompressor
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.decompressor.v3.Decompressor
+              decompressor_library:
+                name: basic
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.compression.gzip.decompressor.v3.Gzip
+              request_direction_config:
+                common_config:
+                  enabled:
+                    default_value: false
+                    runtime_key: request_decompressor_enabled
           - name: envoy.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -217,7 +217,7 @@ stats_config:
             regex: 'cluster\.[\w]+?\.upstream_rq_unknown'
         - safe_regex:
             google_re2: {}
-            regex: '^http.hcm.decompressor'
+            regex: '^http.hcm.decompressor.*'
         - safe_regex:
             google_re2: {}
             regex: 'http.hcm.downstream_rq_[1|2|3|4|5]xx'

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -217,6 +217,9 @@ stats_config:
             regex: 'cluster\.[\w]+?\.upstream_rq_unknown'
         - safe_regex:
             google_re2: {}
+            regex: '^http.hcm.decompressor'
+        - safe_regex:
+            google_re2: {}
             regex: 'http.hcm.downstream_rq_[1|2|3|4|5]xx'
         - exact: 'http.hcm.downstream_rq_total'
         - exact: 'http.hcm.downstream_rq_completed'

--- a/library/common/extensions/BUILD
+++ b/library/common/extensions/BUILD
@@ -14,6 +14,8 @@ envoy_cc_library(
     deps = [
         "@envoy//source/common/upstream:logical_dns_cluster_lib",
         "@envoy//source/extensions/clusters/dynamic_forward_proxy:cluster",
+        "@envoy//source/extensions/compression/gzip/decompressor:config",
+        "@envoy//source/extensions/filters/http/decompressor:config",
         "@envoy//source/extensions/filters/http/dynamic_forward_proxy:config",
         "@envoy//source/extensions/filters/http/router:config",
         "@envoy//source/extensions/filters/network/http_connection_manager:config",

--- a/library/common/extensions/registry.cc
+++ b/library/common/extensions/registry.cc
@@ -4,6 +4,8 @@ namespace Envoy {
 
 void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::Clusters::DynamicForwardProxy::forceRegisterClusterFactory();
+  Envoy::Extensions::Compression::Gzip::Decompressor::forceRegisterGzipDecompressorLibraryFactory();
+  Envoy::Extensions::HttpFilters::Decompressor::forceRegisterDecompressorFilterFactory();
   Envoy::Extensions::HttpFilters::DynamicForwardProxy::
       forceRegisterDynamicForwardProxyFilterFactory();
   Envoy::Extensions::HttpFilters::RouterFilter::forceRegisterRouterFilterConfig();

--- a/library/common/extensions/registry.h
+++ b/library/common/extensions/registry.h
@@ -8,6 +8,8 @@
 #include "extensions/filters/network/http_connection_manager/config.h"
 #include "extensions/stat_sinks/metrics_service/config.h"
 #include "extensions/transport_sockets/tls/config.h"
+#include "extensions/filters/http/decompressor/config.h"
+#include "extensions/compression/gzip/decompressor/config.h"
 
 namespace Envoy {
 class ExtensionRegistry {

--- a/library/common/extensions/registry.h
+++ b/library/common/extensions/registry.h
@@ -3,13 +3,13 @@
 #include "common/upstream/logical_dns_cluster.h"
 
 #include "extensions/clusters/dynamic_forward_proxy/cluster.h"
+#include "extensions/compression/gzip/decompressor/config.h"
+#include "extensions/filters/http/decompressor/config.h"
 #include "extensions/filters/http/dynamic_forward_proxy/config.h"
 #include "extensions/filters/http/router/config.h"
 #include "extensions/filters/network/http_connection_manager/config.h"
 #include "extensions/stat_sinks/metrics_service/config.h"
 #include "extensions/transport_sockets/tls/config.h"
-#include "extensions/filters/http/decompressor/config.h"
-#include "extensions/compression/gzip/decompressor/config.h"
 
 namespace Envoy {
 class ExtensionRegistry {


### PR DESCRIPTION
Description: this PR pulls in the new decompressor filter in Envoy and configures response decompression in Envoy Mobile for gzip encoding.
Risk Level: med - new filter in envoy, not tested in production environments.
Testing: local build of the Lyft app. 

Signed-off-by: Jose Nino <jnino@lyft.com>
