### PR TITLE
android: Add missing `-s` linkopt

### DIFF
--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -47,6 +47,7 @@ cc_binary(
     linkopts = [
         "-lm",
         "-llog",
+        "-Wl,-s",
     ],
     linkshared = True,
     deps = [":envoy_main_interface_lib"],


### PR DESCRIPTION
In this commit https://github.com/lyft/envoy-mobile/pull/830 I removed
the `-s` linkopt because 1) I didn't realize it did anything since for
ld64 on macOS it does not and 2) I expected `-g0` in envoy to be enough
to remove all debug info.

It turns out that when linking this dynamic framework having `-g0` on
all the compiles is not enough, this restores `-s` just for the
`cc_binary`'s `linkopts`:

```
-s, --strip-all
  Strip all symbols
```

Theoretically we might eventually want just `-S`:

```
-S, --strip-debug
  Strip debugging information
```

To improve crash log quality, but for now this restores the previous
behavior.

Reference: https://manpages.ubuntu.com/manpages/trusty/man1/ld.gold.1.html

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>