### PR TITLE
ci: temporarily disable coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,15 +14,16 @@ jobs:
     name: coverage
     runs-on: ubuntu-18.04
     timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
-      - name: 'Install dependencies'
-        run: ./ci/linux_ci_setup.sh
-      - name: 'Run coverage'
-        run: |
-          export PATH=/usr/lib/llvm-8/bin:$PATH
-          export CC=clang
-          export CXX=clang++
-          ./test/coverage/run_coverage.sh
+    # TODO: Re-enable coverage https://github.com/lyft/envoy-mobile/issues/863
+    # steps:
+    #   - uses: actions/checkout@v1
+    #     with:
+    #       submodules: true
+    #   - name: 'Install dependencies'
+    #     run: ./ci/linux_ci_setup.sh
+    #   - name: 'Run coverage'
+    #     run: |
+    #       export PATH=/usr/lib/llvm-8/bin:$PATH
+    #       export CC=clang
+    #       export CXX=clang++
+    #       ./test/coverage/run_coverage.sh


### PR DESCRIPTION
I'm temporarily disabling coverage for now since it's blocking PRs. It'll be fixed/re-enabled in https://github.com/lyft/envoy-mobile/issues/863.

I spent a few minutes looking into fixing the breakage from https://github.com/envoyproxy/envoy/pull/10909, but it looks like the fix won't be trivial since we [rely on](https://github.com/lyft/envoy-mobile/blob/f50aaa57033decf68d2e961f7716ecb9a5f42402/test/coverage/run_coverage.sh#L6-L8) `EXTRA_QUERY_PATHS` and `ONLY_EXTRA_QUERY_PATHS` (the latter of which was [added upstream](https://github.com/envoyproxy/envoy/commit/9931239df99abda9ec69d450177730826d985c25) by @junr03 recently), and the file that used those was deleted in the above PR.

Signed-off-by: Michael Rebello <me@michaelrebello.com>