### PR TITLE
update envoy: update interfaces, and fix broken macos ci

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 45
     container:
-      image: envoyproxy/envoy-build-ubuntu:5a096881181dbe478f642b7ac02a68e9591e933d
+      image: envoyproxy/envoy-build-ubuntu:04f06115b6ee7cfea74930353fb47a41149cbec3
     steps:
       - uses: actions/checkout@v1
         with:

--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
+
+licenses(["notice"])  # Apache 2
 
 alias(
     name = "ios_framework",

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,7 +1,7 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_android//android:rules.bzl", "android_binary")
 load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
 
 # This file is based on https://github.com/aj-michael/aar_with_jni which is

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_android//android:rules.bzl", "android_binary")
 load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
 
 # This file is based on https://github.com/aj-michael/aar_with_jni which is
@@ -63,13 +65,13 @@ EOF
     # We wrap our native so dependencies in a cc_library because android_binaries
     # require a library target as dependencies in order to generate the appropriate
     # architectures in the directory `lib/`
-    native.cc_library(
+    cc_library(
         name = cc_lib_name,
         srcs = native_deps,
     )
 
     # This outputs {jni_archive_name}_unsigned.apk which will contain the base files for our aar
-    native.android_binary(
+    android_binary(
         name = jni_archive_name,
         manifest = archive_name + "_generated_AndroidManifest.xml",
         custom_package = "does.not.matter",
@@ -79,7 +81,7 @@ EOF
 
     # This creates bazel-bin/library/kotlin/src/io/envoyproxy/envoymobile/name_bin_deploy.jar
     # This jar has all the classes needed for our aar and will be our `classes.jar`
-    native.android_binary(
+    android_binary(
         name = android_binary_name,
         manifest = manifest,
         srcs = [],

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_android//android:rules.bzl", "android_binary")
 load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
 
 # This file is based on https://github.com/aj-michael/aar_with_jni which is

--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_android//android:rules.bzl", "android_binary")
+load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
 load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
 
 # This file is based on https://github.com/aj-michael/aar_with_jni which is

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -11,6 +11,7 @@ def envoy_mobile_repositories():
     upstream_envoy_overrides()
     swift_repos()
     kotlin_repos()
+    android_repos()
 
 def upstream_envoy_overrides():
     # Patch protobuf to prevent duplicate symbols: https://github.com/lyft/envoy-mobile/issues/617
@@ -121,4 +122,12 @@ def kotlin_repos():
         name = "kotlin_dokka",
         sha256 = "4c73eee92dd652ea8e2afd7b20732cf863d4938a30f634d12c88fe64def89fd8",
         url = "https://github.com/Kotlin/dokka/releases/download/0.9.18/dokka-fatjar-0.9.18.jar",
+    )
+
+def android_repos():
+    http_archive(
+        name = "build_bazel_rules_android",
+        urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
+        sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+        strip_prefix = "rules_android-0.1.1",
     )

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 
 def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = []):
     # These source files must be re-exported to the kotlin custom library rule to ensure their

--- a/dist/BUILD
+++ b/dist/BUILD
@@ -1,6 +1,7 @@
-licenses(["notice"])  # Apache 2
-
+load("@rules_android//android:rules.bzl", "aar_import")
 load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_framework_import")
+
+licenses(["notice"])  # Apache 2
 
 # NOTE: You must first build the top-level targets //:ios_dist and //:android_dist to use the
 # artifacts referenced here.

--- a/dist/BUILD
+++ b/dist/BUILD
@@ -1,4 +1,4 @@
-load("@rules_android//android:rules.bzl", "aar_import")
+load("@build_bazel_rules_android//android:rules.bzl", "aar_import")
 load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_framework_import")
 
 licenses(["notice"])  # Apache 2

--- a/examples/java/hello_world/BUILD
+++ b/examples/java/hello_world/BUILD
@@ -1,6 +1,7 @@
-licenses(["notice"])  # Apache 2
-
+load("@rules_android//android:rules.bzl", "android_binary")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
+
+licenses(["notice"])  # Apache 2
 
 android_binary(
     name = "hello_envoy",

--- a/examples/java/hello_world/BUILD
+++ b/examples/java/hello_world/BUILD
@@ -1,4 +1,4 @@
-load("@rules_android//android:rules.bzl", "android_binary")
+load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 
 licenses(["notice"])  # Apache 2

--- a/examples/kotlin/hello_world/BUILD
+++ b/examples/kotlin/hello_world/BUILD
@@ -1,7 +1,8 @@
-licenses(["notice"])  # Apache 2
-
+load("@rules_android//android:rules.bzl", "android_binary")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 load("@rules_detekt//detekt:defs.bzl", "detekt")
+
+licenses(["notice"])  # Apache 2
 
 android_binary(
     name = "hello_envoy_kt",

--- a/examples/kotlin/hello_world/BUILD
+++ b/examples/kotlin/hello_world/BUILD
@@ -1,4 +1,4 @@
-load("@rules_android//android:rules.bzl", "android_binary")
+load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 load("@rules_detekt//detekt:defs.bzl", "detekt")
 

--- a/examples/kotlin/shared/BUILD
+++ b/examples/kotlin/shared/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
+
+licenses(["notice"])  # Apache 2
 
 kt_android_library(
     name = "hello_envoy_shared_lib",

--- a/examples/objective-c/hello_world/BUILD
+++ b/examples/objective-c/hello_world/BUILD
@@ -1,6 +1,7 @@
-licenses(["notice"])  # Apache 2
-
+load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+
+licenses(["notice"])  # Apache 2
 
 objc_library(
     name = "appmain",

--- a/examples/swift/hello_world/BUILD
+++ b/examples/swift/hello_world/BUILD
@@ -1,7 +1,7 @@
-licenses(["notice"])  # Apache 2
-
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+licenses(["notice"])  # Apache 2
 
 swift_library(
     name = "appmain",

--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -1,6 +1,7 @@
-licenses(["notice"])  # Apache 2
-
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/library/common/buffer/BUILD
+++ b/library/common/buffer/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/library/common/extensions/BUILD
+++ b/library/common/extensions/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/library/common/extensions/BUILD
+++ b/library/common/extensions/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     hdrs = ["registry.h"],
     repository = "@envoy",
     deps = [
+        "@envoy//source/common/network:socket_lib",
         "@envoy//source/common/upstream:logical_dns_cluster_lib",
         "@envoy//source/extensions/clusters/dynamic_forward_proxy:cluster",
         "@envoy//source/extensions/compression/gzip/decompressor:config",

--- a/library/common/extensions/registry.cc
+++ b/library/common/extensions/registry.cc
@@ -1,5 +1,7 @@
 #include "library/common/extensions/registry.h"
 
+#include "common/network/socket_interface_impl.h"
+
 namespace Envoy {
 
 void ExtensionRegistry::registerFactories() {
@@ -14,6 +16,16 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::StatSinks::MetricsService::forceRegisterMetricsServiceSinkFactory();
   Envoy::Extensions::TransportSockets::Tls::forceRegisterUpstreamSslSocketFactory();
   Envoy::Upstream::forceRegisterLogicalDnsClusterFactory();
+
+  // TODO: add a "force initialize" function to the upstream code, or clean up the upstream code
+  // in such a way that does not depend on the statically initialized variable.
+  // The current setup exposes in iOS the same problem as the one described in:
+  // https://github.com/envoyproxy/envoy/pull/7185 with the static variable declared in:
+  // https://github.com/envoyproxy/envoy/pull/11380/files#diff-8a5c90e5a39b2ea975170edc4434345bR138.
+  // For now force the compilation unit to run by creating an instance of the class declared in
+  // socket_interface_impl.h and immediately destroy.
+  auto ptr = std::make_unique<Network::SocketInterfaceImpl>();
+  ptr.reset(nullptr);
 }
 
 } // namespace Envoy

--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/library/common/network/BUILD
+++ b/library/common/network/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/library/common/network/synthetic_address_impl.h
+++ b/library/common/network/synthetic_address_impl.h
@@ -31,19 +31,13 @@ public:
 
   const std::string& logicalName() const { return address_; }
 
-  Api::SysCallIntResult bind(int) const {
-    // a socket should never be bound to a synthetic address.
-    return {-1, EADDRNOTAVAIL};
-  }
-
-  Api::SysCallIntResult connect(int) const {
-    // a socket should never connect to a synthetic address.
-    return {-1, EPROTOTYPE};
-  }
-
   const Ip* ip() const { return nullptr; }
 
-  IoHandlePtr socket(SocketType) const { return nullptr; }
+  const Pipe* pipe() const { return nullptr; }
+
+  const sockaddr* sockAddr() const { return nullptr; }
+
+  socklen_t sockAddrLen() const { return 0; }
 
   Type type() const {
     // TODO(junr03): consider adding another type of address.

--- a/library/common/thread/BUILD
+++ b/library/common/thread/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/library/common/types/BUILD
+++ b/library/common/types/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
@@ -1,5 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_library")
-load("@rules_android//android:rules.bzl", "android_library")
+load("@build_bazel_rules_android//android:rules.bzl", "android_library")
 
 licenses(["notice"])  # Apache 2
 

--- a/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
@@ -1,3 +1,6 @@
+load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_android//android:rules.bzl", "android_library")
+
 licenses(["notice"])  # Apache 2
 
 android_library(

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2
 
 java_library(

--- a/library/java/test/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("//bazel:kotlin_test.bzl", "envoy_mobile_kt_test")
+
+licenses(["notice"])  # Apache 2
 
 envoy_mobile_kt_test(
     name = "envoy_configuration_test",

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -1,9 +1,9 @@
-licenses(["notice"])  # Apache 2
-
 load("//bazel:aar_with_jni.bzl", "aar_with_jni")
 load("//bazel:kotlin_lib.bzl", "envoy_mobile_kt_library")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 load("@rules_detekt//detekt:defs.bzl", "detekt")
+
+licenses(["notice"])  # Apache 2
 
 aar_with_jni(
     name = "android_aar",

--- a/library/kotlin/test/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("//bazel:kotlin_test.bzl", "envoy_mobile_kt_test")
+
+licenses(["notice"])  # Apache 2
 
 envoy_mobile_kt_test(
     name = "request_builder_test",

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "objc_library")
+
 licenses(["notice"])  # Apache 2
 
 exports_files([

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("//bazel:swift_test.bzl", "envoy_mobile_swift_test")
+
+licenses(["notice"])  # Apache 2
 
 envoy_mobile_swift_test(
     name = "envoy_client_tests",

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/test/common/network/synthetic_address_impl_test.cc
+++ b/test/common/network/synthetic_address_impl_test.cc
@@ -18,23 +18,12 @@ TEST(SyntheticAddressImplTest, Names) {
   ASSERT_EQ(address.logicalName(), "synthetic");
 }
 
-TEST(SyntheticAddressImplTest, Syscalls) {
-  SyntheticAddressImpl address;
-
-  const Api::SysCallIntResult bind_rc = address.bind(0);
-  ASSERT_EQ(bind_rc.rc_, -1);
-  ASSERT_EQ(bind_rc.errno_, EADDRNOTAVAIL);
-
-  const Api::SysCallIntResult connect_rc = address.connect(0);
-  ASSERT_EQ(connect_rc.rc_, -1);
-  ASSERT_EQ(connect_rc.errno_, EPROTOTYPE);
-}
-
 TEST(SyntheticAddressImplTest, Accessors) {
   SyntheticAddressImpl address;
   ASSERT_EQ(address.ip(), nullptr);
-  ASSERT_EQ(address.socket(SocketType::Datagram), nullptr);
-  ASSERT_EQ(address.socket(SocketType::Stream), nullptr);
+  ASSERT_EQ(address.pipe(), nullptr);
+  ASSERT_EQ(address.sockAddr(), nullptr);
+  ASSERT_EQ(address.sockAddrLen(), 0);
 }
 
 TEST(SyntheticAddressImplTest, Type) {

--- a/test/common/thread/BUILD
+++ b/test/common/thread/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/test/performance/BUILD
+++ b/test/performance/BUILD
@@ -1,6 +1,6 @@
-licenses(["notice"])  # Apache 2
-
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_binary", "envoy_package")
+
+licenses(["notice"])  # Apache 2
 
 envoy_package()
 

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -11,7 +11,7 @@ fi
 # TODO(mattklein123): WORKSPACE is excluded due to warning about @bazel_tools reference. Fix here
 #                     or in the upstream checker.
 envoy/tools/code_format/check_format.py \
-    --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./dist/Envoy.framework/ ./library/common/config_template.cc  ./bazel/aar_with_jni.bzl \
+    --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./dist/Envoy.framework/ ./library/common/config_template.cc \
     --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" \
     --namespace_check_excluded_paths ./examples/ ./library/java/ ./library/kotlin ./library/objective-c \
     --build_fixer_check_excluded_paths ./BUILD ./dist ./examples ./library/java ./library/kotlin ./library/objective-c ./library/swift

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -11,7 +11,7 @@ fi
 # TODO(mattklein123): WORKSPACE is excluded due to warning about @bazel_tools reference. Fix here
 #                     or in the upstream checker.
 envoy/tools/code_format/check_format.py \
-    --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./dist/Envoy.framework/ ./library/common/config_template.cc \
+    --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./dist/Envoy.framework/ ./library/common/config_template.cc  ./bazel/aar_with_jni.bzl \
     --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" \
     --namespace_check_excluded_paths ./examples/ ./library/java/ ./library/kotlin ./library/objective-c \
     --build_fixer_check_excluded_paths ./BUILD ./dist ./examples ./library/java ./library/kotlin ./library/objective-c ./library/swift


### PR DESCRIPTION
Description: this submodule update brings in an updated macOS ci setup script that correctly install bazelisk. https://github.com/envoyproxy/envoy/pull/11444
Risk Level: low
Testing: CI

Signed-off-by: Jose Nino <jnino@lyft.com>