### PR TITLE
build: Add java_binary to produce sources jar

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -35,7 +35,7 @@ alias(
 
 alias(
     name = "android_sources",
-    actual = "//library:sources_jar",
+    actual = "//library/kotlin/src/io/envoyproxy/envoymobile:sources_jar_deploy-src.jar",
 )
 
 genrule(

--- a/library/BUILD
+++ b/library/BUILD
@@ -24,18 +24,3 @@ zip -r $$orig_dir/$@ . > /dev/null
     tools = ["@kotlin_dokka//jar"],
     visibility = ["//visibility:public"],
 )
-
-genrule(
-    name = "sources_jar",
-    srcs = [],
-    outs = ["envoy-sources.jar"],
-    cmd = """
-orig_dir=$$PWD
-tmp_dir=$$(mktemp -d)
-cp -r library/java/src/io/envoyproxy/envoymobile/ $$tmp_dir
-cp -r library/kotlin/src/io/envoyproxy/envoymobile/ $$tmp_dir
-cd $$tmp_dir
-zip -r $$orig_dir/$@ . > /dev/null
-    """,
-    visibility = ["//visibility:public"],
-)

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -17,6 +17,12 @@ aar_with_jni(
     visibility = ["//visibility:public"],
 )
 
+java_binary(
+    name = "sources_jar",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":envoy_lib"],
+)
+
 kt_android_library(
     name = "envoy_lib",
     srcs = [


### PR DESCRIPTION
Every `java_library` rule (but maybe not kt_library rules) has a
implicit sources jar target that  can be requested. Unfortunately these
only contain the direct sources of the library. `java_binary` on the
other hand can produce one with all transitive sources. This adds the
smallest possible `java_binary` rule so we can produce this.

This behavior is lightly documented here: https://docs.bazel.build/versions/master/be/java.html

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>