### PR TITLE
ci: Linux workaround for installing mongodb

### DIFF
--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -6,7 +6,7 @@ set -e
 # workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
 sudo rm -rf /var/lib/apt/lists/*
 
-wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
+wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
 
 # We have seen problems with heroku's keys.
 # We do not use heroku, but it is pre-installed in the github actions machines.

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -14,7 +14,7 @@ curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
 curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 
 wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
-echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
 
 sudo apt-get clean
 sudo apt-get update

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -13,6 +13,7 @@ curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
 # https://github.com/bazelbuild/bazel/issues/11470#issuecomment-633205152
 curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 
+wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
 sudo apt-get clean
 sudo apt-get update
 

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -14,6 +14,8 @@ curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
 curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 
 wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
+echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+
 sudo apt-get clean
 sudo apt-get update
 

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -16,8 +16,7 @@ curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
 curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 
 sudo apt-get clean
-sudo apt-get update -y
-apt-get install mongodb-org -y
+sudo apt-get update
 
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y wget software-properties-common make cmake git \

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -6,7 +6,7 @@ set -e
 # workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
 sudo rm -rf /var/lib/apt/lists/*
 
-wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 656408E390CFB1F5
 
 # We have seen problems with heroku's keys.
 # We do not use heroku, but it is pre-installed in the github actions machines.

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -6,15 +6,14 @@ set -e
 # workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
 sudo rm -rf /var/lib/apt/lists/*
 
+wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
+
 # We have seen problems with heroku's keys.
 # We do not use heroku, but it is pre-installed in the github actions machines.
 curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
 
 # https://github.com/bazelbuild/bazel/issues/11470#issuecomment-633205152
 curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-
-wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
-echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
 
 sudo apt-get clean
 sudo apt-get update -y

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -17,7 +17,8 @@ wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add 
 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
 
 sudo apt-get clean
-sudo apt-get update
+sudo apt-get update -y
+apt-get install mongodb-org -y
 
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y wget software-properties-common make cmake git \

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -6,6 +6,8 @@ set -e
 # workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
 sudo rm -rf /var/lib/apt/lists/*
 
+# Workaround for the mongdb issue where they are tying the 4.4 gpg key to the 4.2 version
+# https://github.com/actions/virtual-environments/issues/1019
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 656408E390CFB1F5
 
 # We have seen problems with heroku's keys.


### PR DESCRIPTION
Due to a [mongo issue](https://github.com/actions/virtual-environments/issues/1019), we're adding a workaround for getting the gpg key

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: ci: Linux workaround for installing mongodb
Risk Level: low
Testing: ci
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
