### PR TITLE
swift: add builder initializers

### DIFF
--- a/library/swift/src/Headers.swift
+++ b/library/swift/src/Headers.swift
@@ -20,6 +20,7 @@ public class Headers: NSObject {
   /// - parameter headers: Headers to set.
   required init(headers: [String: [String]]) {
     self.headers = headers
+    super.init()
   }
 }
 

--- a/library/swift/src/HeadersBuilder.swift
+++ b/library/swift/src/HeadersBuilder.swift
@@ -73,11 +73,12 @@ public class HeadersBuilder: NSObject {
     return self
   }
 
-  /// Instantiate a new builder.
+  /// Initialize a new builder. Subclasses should provide their own public convenience initializers.
   ///
-  /// - parameter headers: The headers to start with.
-  init(headers: [String: [String]]) {
+  /// - parameter headers: The headers with which to start.
+  required init(headers: [String: [String]]) {
     self.headers = headers
+    super.init()
   }
 }
 

--- a/library/swift/src/RequestTrailersBuilder.swift
+++ b/library/swift/src/RequestTrailersBuilder.swift
@@ -3,6 +3,11 @@ import Foundation
 /// Builder used for constructing instances of `RequestTrailers`.
 @objcMembers
 public final class RequestTrailersBuilder: HeadersBuilder {
+  /// Initialize a new instance of the builder.
+  public convenience init() {
+    self.init(headers: [:])
+  }
+
   /// Build the request trailers using the current builder.
   ///
   /// - returns: New instance of request trailers.

--- a/library/swift/src/ResponseHeadersBuilder.swift
+++ b/library/swift/src/ResponseHeadersBuilder.swift
@@ -3,6 +3,19 @@ import Foundation
 /// Builder used for constructing instances of `ResponseHeaders`.
 @objcMembers
 public final class ResponseHeadersBuilder: HeadersBuilder {
+  /// Initialize a new instance of the builder.
+  public convenience init() {
+    self.init(headers: [:])
+  }
+
+  /// Add an HTTP status to the response headers.
+  ///
+  /// - parameter status: The HTTP status to add.
+  public func addHttpStatus(_ status: Int) -> ResponseHeadersBuilder {
+    self.internalSet(name: ":status", value: ["\(status)"])
+    return self
+  }
+
   /// Build the response headers using the current builder.
   ///
   /// - returns: New instance of response headers.

--- a/library/swift/src/ResponseTrailersBuilder.swift
+++ b/library/swift/src/ResponseTrailersBuilder.swift
@@ -3,6 +3,11 @@ import Foundation
 /// Builder used for constructing instances of `ResponseTrailers`.
 @objcMembers
 public final class ResponseTrailersBuilder: HeadersBuilder {
+  /// Initialize a new instance of the builder.
+  public convenience init() {
+    self.init(headers: [:])
+  }
+
   /// Build the response trailers using the current builder.
   ///
   /// - returns: New instance of response trailers.

--- a/library/swift/src/grpc/GRPCStream.swift
+++ b/library/swift/src/grpc/GRPCStream.swift
@@ -17,6 +17,7 @@ public final class GRPCStream: NSObject {
   /// - parameter underlyingStream: The underlying stream to use for sending data.
   required init(underlyingStream: Stream) {
     self.underlyingStream = underlyingStream
+    super.init()
   }
 
   // MARK: - Public

--- a/library/swift/test/ResponseHeadersTests.swift
+++ b/library/swift/test/ResponseHeadersTests.swift
@@ -15,4 +15,11 @@ final class ResponseHeadersTests: XCTestCase {
   func testParsingMissingStatusCodeReturnsNil() {
     XCTAssertNil(ResponseHeaders(headers: [:]).httpStatus)
   }
+
+  func testAddingHttpStatusCode() {
+    let headers = ResponseHeadersBuilder()
+      .addHttpStatus(200)
+      .build()
+    XCTAssertEqual(200, headers.httpStatus)
+  }
 }


### PR DESCRIPTION
- Add public initializers for remaining headers/trailers builders. These are being done on each subclass rather than once in the superclass in order to allow subclasses (like `GRPCRequestHeaders`) to require certain values on initialization
- Add missing `super.init()` calls for `NSObject` subclasses
- Add a function for setting the HTTP status code on response headers, as setting `:status` publicly is restricted

Signed-off-by: Michael Rebello <me@michaelrebello.com>