### PR TITLE
bazel: fixup patches

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -33,7 +33,7 @@ genrule(
     outs = ["envoy_mobile.zip"],
     cmd = "$(location //bazel:zipper) fc $@ $(SRCS)",
     stamp = True,
-    tools = ["@envoy_mobile//bazel:zipper"],
+    tools = ["//bazel:zipper"],
     visibility = ["//visibility:public"],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -33,7 +33,7 @@ genrule(
     outs = ["envoy_mobile.zip"],
     cmd = "$(location //bazel:zipper) fc $@ $(SRCS)",
     stamp = True,
-    tools = ["//bazel:zipper"],
+    tools = ["@envoy_mobile//bazel:zipper"],
     visibility = ["//visibility:public"],
 )
 

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -25,7 +25,7 @@ def upstream_envoy_overrides():
         patch_args = ["-p1"],
         patches = [
             "@envoy//bazel:protobuf.patch",
-            "//bazel:protobuf.patch",
+            "@envoy_mobile//bazel:protobuf.patch",
         ],
         sha256 = "d7cfd31620a352b2ee8c1ed883222a0d77e44346643458e062e86b1d069ace3e",
         strip_prefix = "protobuf-3.10.1",
@@ -38,7 +38,7 @@ def upstream_envoy_overrides():
     # supports platform toolchains.
     http_archive(
         name = "com_google_absl",
-        patches = ["//bazel:abseil.patch"],
+        patches = ["@envoy_mobile//bazel:abseil.patch"],
         sha256 = "14ee08e2089c2a9b6bf27e1d10abc5629c69c4d0bab4b78ec5b65a29ea1c2af7",
         strip_prefix = "abseil-cpp-cf3a1998e9d41709d4141e2f13375993cba1130e",
         # 2020-03-05
@@ -49,7 +49,7 @@ def upstream_envoy_overrides():
     # Remove this once https://boringssl-review.googlesource.com/c/boringssl/+/37804 is in master-with-bazel
     http_archive(
         name = "boringssl",
-        patches = ["//bazel:boringssl.patch"],
+        patches = ["@envoy_mobile//bazel:boringssl.patch"],
         sha256 = "36049e6cd09b353c83878cae0dd84e8b603ba1a40dcd74e44ebad101fc5c672d",
         strip_prefix = "boringssl-37b57ed537987f1b4c60c60fa1aba20f3a0f6d26",
         urls = ["https://github.com/google/boringssl/archive/37b57ed537987f1b4c60c60fa1aba20f3a0f6d26.tar.gz"],


### PR DESCRIPTION
Patches need to be referenced using the workspace alias

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: bazel: fixup patches 
Risk Level: low
Testing: ci
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
