### PR TITLE
swift/kotlin: add `Headers.allHeaders()`

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/Headers.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/Headers.kt
@@ -27,4 +27,13 @@ open class Headers {
   fun value(name: String): List<String>? {
     return headers[name]
   }
+
+  /**
+   * Accessor for all underlying headers as a map.
+   *
+   * @return Map<String, List<String>>, The underlying headers.
+   */
+  fun allHeaders(): Map<String, List<String>> {
+    return headers
+  }
 }

--- a/library/swift/src/Headers.swift
+++ b/library/swift/src/Headers.swift
@@ -15,6 +15,13 @@ public class Headers: NSObject {
     return self.headers[name]
   }
 
+  /// Accessor for all underlying headers as a map.
+  ///
+  /// - returns: The underlying headers.
+  public func allHeaders() -> [String: [String]] {
+    return self.headers
+  }
+
   /// Internal initializer used by builders.
   ///
   /// - parameter headers: Headers to set.


### PR DESCRIPTION
After some discussions, we decided to expose the underlying map of headers as a convenience accessor for public consumption in order to enable iterating over the key-value pairs from other consumers.

Signed-off-by: Michael Rebello <me@michaelrebello.com>