### PR TITLE
swift: lazily compute {Request/Response}Headers properties

### DIFF
--- a/library/swift/src/RequestHeaders.swift
+++ b/library/swift/src/RequestHeaders.swift
@@ -4,35 +4,25 @@ import Foundation
 @objcMembers
 public class RequestHeaders: Headers {
   /// Method for the request.
-  public var method: RequestMethod! {
-    return self.value(forName: ":method")?.first.flatMap(RequestMethod.init)
-  }
+  public private(set) lazy var method: RequestMethod =
+    (self.value(forName: ":method")?.first.flatMap(RequestMethod.init))!
 
   /// The URL scheme for the request (i.e., "https").
-  public var scheme: String! {
-    return self.value(forName: ":scheme")?.first
-  }
+  public private(set) lazy var scheme: String = (self.value(forName: ":scheme")?.first)!
 
   /// The URL authority for the request (i.e., "api.foo.com").
-  public var authority: String! {
-    return self.value(forName: ":authority")?.first
-  }
+  public private(set) lazy var authority: String = (self.value(forName: ":authority")?.first)!
 
   /// The URL path for the request (i.e., "/foo").
-  public var path: String! {
-    return self.value(forName: ":path")?.first
-  }
+  public private(set) lazy var path: String = (self.value(forName: ":path")?.first)!
 
   /// Retry policy to use for this request.
-  public var retryPolicy: RetryPolicy? {
-    return RetryPolicy.from(headers: self)
-  }
+  public private(set) lazy var retryPolicy: RetryPolicy? = .from(headers: self)
 
   /// The protocol version to use for upstream requests.
-  public var upstreamHttpProtocol: UpstreamHttpProtocol? {
-    return self.value(forName: "x-envoy-mobile-upstream-protocol")?.first
+  public private(set) lazy var upstreamHttpProtocol: UpstreamHttpProtocol? =
+    self.value(forName: "x-envoy-mobile-upstream-protocol")?.first
       .flatMap(UpstreamHttpProtocol.init)
-  }
 
   /// Convert the headers back to a builder for mutation.
   ///

--- a/library/swift/src/RequestHeaders.swift
+++ b/library/swift/src/RequestHeaders.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable:force_unwrapping - Programmer error if properties are nil when accessed
 import Foundation
 
 /// Headers representing an outbound request.

--- a/library/swift/src/RequestHeaders.swift
+++ b/library/swift/src/RequestHeaders.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable:force_unwrapping - Programmer error if properties are nil when accessed
+// swiftlint:disable force_unwrapping - Programmer error if properties are nil when accessed
 import Foundation
 
 /// Headers representing an outbound request.

--- a/library/swift/src/ResponseHeaders.swift
+++ b/library/swift/src/ResponseHeaders.swift
@@ -4,9 +4,8 @@ import Foundation
 @objcMembers
 public final class ResponseHeaders: Headers {
   /// HTTP status code received with the response.
-  public var httpStatus: Int? {
-    return self.value(forName: ":status")?.first.flatMap(Int.init)
-  }
+  public private(set) lazy var httpStatus: Int? =
+    self.value(forName: ":status")?.first.flatMap(Int.init)
 
   /// Convert the headers back to a builder for mutation.
   ///


### PR DESCRIPTION
Android's implementation lazily computes these properties, then stores them so that they are not recalculated each time they're accessed. Conversely, iOS recomputes them each time.

This PR updates iOS to mirror Android's behavior since we actually don't need to recompute these each time since `Headers` types are immutable (modifications are done via builders).

Signed-off-by: Michael Rebello <me@michaelrebello.com>