### PR TITLE
kotlin: add `ResponseHeadersBuilder.addHttpStatus()`

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHeadersBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHeadersBuilder.kt
@@ -19,6 +19,18 @@ class ResponseHeadersBuilder: HeadersBuilder {
   internal constructor(headers: MutableMap<String, MutableList<String>>) : super(headers)
 
   /**
+   * Add an HTTP status to the response headers.
+   *
+   * @param status: The HTTP status to add.
+   *
+   * @return ResponseHeadersBuilder, This builder.
+   */
+  fun addHttpStatus(status: Int) : ResponseHeadersBuilder {
+    set(":status", mutableListOf("$status"))
+    return this
+  }
+
+  /**
    * Build the response headers using the current builder.
    *
    * @return ResponseHeaders, New instance of response headers.

--- a/library/kotlin/test/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/BUILD
@@ -23,6 +23,16 @@ envoy_mobile_kt_test(
 )
 
 envoy_mobile_kt_test(
+    name = "response_headers_test",
+    srcs = [
+        "ResponseHeadersTest.kt",
+    ],
+    deps = [
+        "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+    ],
+)
+
+envoy_mobile_kt_test(
     name = "retry_policy_mapper_test",
     srcs = [
         "RetryPolicyMapperTest.kt",

--- a/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHeadersTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHeadersTest.kt
@@ -1,0 +1,32 @@
+package io.envoyproxy.envoymobile
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ResponseHeadersTest {
+    @Test
+    fun `parsing status code from headers returns first status`() {
+        val headers = ResponseHeaders(mapOf(":status" to listOf("204", "200")))
+        assertThat(headers.httpStatus).isEqualTo(204)
+    }
+
+    @Test
+    fun `parsing invalid status code returns null`() {
+        val headers = ResponseHeaders(mapOf(":status" to listOf("invalid"), "other" to listOf("1")))
+        assertThat(headers.httpStatus).isNull()
+    }
+
+    @Test
+    fun `parsing missing status code returns null`() {
+        val headers = ResponseHeaders(emptyMap())
+        assertThat(headers.httpStatus).isNull()
+    }
+
+    @Test
+    fun `adding HTTP status code sets the appropriate header`() {
+        val headers = ResponseHeadersBuilder()
+                .addHttpStatus(200)
+                .build()
+        assertThat(headers.value(":status")).containsExactly("200")
+    }
+}

--- a/library/swift/src/ResponseHeadersBuilder.swift
+++ b/library/swift/src/ResponseHeadersBuilder.swift
@@ -11,6 +11,8 @@ public final class ResponseHeadersBuilder: HeadersBuilder {
   /// Add an HTTP status to the response headers.
   ///
   /// - parameter status: The HTTP status to add.
+  ///
+  /// - returns: This builder.
   public func addHttpStatus(_ status: Int) -> ResponseHeadersBuilder {
     self.internalSet(name: ":status", value: ["\(status)"])
     return self

--- a/library/swift/test/ResponseHeadersTests.swift
+++ b/library/swift/test/ResponseHeadersTests.swift
@@ -16,7 +16,7 @@ final class ResponseHeadersTests: XCTestCase {
     XCTAssertNil(ResponseHeaders(headers: [:]).httpStatus)
   }
 
-  func testAddingHttpStatusCode() {
+  func testAddingHttpStatusCodeSetsTheAppropriateHeader() {
     let headers = ResponseHeadersBuilder()
       .addHttpStatus(200)
       .build()


### PR DESCRIPTION
This was added for swift in https://github.com/lyft/envoy-mobile/pull/893 but I failed to add it on Android as well.

Also adds some tests to mirror iOS' tests for response headers.

Signed-off-by: Michael Rebello <me@michaelrebello.com>