### PR TITLE
stats: add stats for specific 4xx codes

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -193,6 +193,15 @@ stats_config:
             regex: 'cluster\.[\w]+?\.upstream_rq_[1|2|3|4|5]xx'
         - safe_regex:
             google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_40[0|1|3|4|9]'
+        - safe_regex:
+            google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_41[2|3]'
+        - safe_regex:
+            google_re2: {}
+            regex: 'cluster\.[\w]+?\.upstream_rq_42[2|3|9]'
+        - safe_regex:
+            google_re2: {}
             regex: 'cluster\.[\w]+?\.upstream_rq_active'
         - safe_regex:
             google_re2: {}


### PR DESCRIPTION
Description: add individual stats for some 4xx codes of interest at Lyft. In the future, like other stats we can have this be configurable.
Risk Level: low
Testing: local

Signed-off-by: Jose Nino <jnino@lyft.com>