### PR TITLE
swift / grpc: add grpc-status and grpc-message accessors

### DIFF
--- a/envoy-mobile.tulsiproj/Configs/all.tulsigen
+++ b/envoy-mobile.tulsiproj/Configs/all.tulsigen
@@ -11,6 +11,8 @@
     "//library/swift/src:ios_framework_archive",
     "//library/swift/test:grpc_request_headers_builder_tests",
     "//library/swift/test:grpc_request_headers_builder_tests_lib",
+    "//library/swift/test:grpc_response_trailers_builder_tests",
+    "//library/swift/test:grpc_response_trailers_builder_tests_lib",
     "//library/swift/test:grpc_stream_tests",
     "//library/swift/test:grpc_stream_tests_lib",
     "//library/swift/test:headers_builder_tests",

--- a/library/swift/src/grpc/GRPCResponseTrailers.swift
+++ b/library/swift/src/grpc/GRPCResponseTrailers.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Trailers representing an inbound gRPC response.
+@objcMembers
+public final class GRPCResponseTrailers: Headers {
+  /// gRPC status code received with the response.
+  public private(set) lazy var grpcStatus: Int? =
+    self.value(forName: "grpc-status")?.first.flatMap(Int.init)
+
+  /// gRPC message received with the response.
+  public private(set) lazy var grpcMessage: String? =
+    self.value(forName: "grpc-message")?.first
+
+  /// Convert the headers back to a builder for mutation.
+  ///
+  /// - returns: The new builder.
+  public func toGRPCResponseTrailersBuilder() -> GRPCResponseTrailersBuilder {
+    return GRPCResponseTrailersBuilder(headers: self.headers)
+  }
+}

--- a/library/swift/src/grpc/GRPCResponseTrailersBuilder.swift
+++ b/library/swift/src/grpc/GRPCResponseTrailersBuilder.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Builder used for constructing instances of `GRPCResponseTrailers`.
+@objcMembers
+public final class GRPCResponseTrailersBuilder: HeadersBuilder {
+  /// Initialize a new instance of the builder.
+  public convenience init() {
+    self.init(headers: [:])
+  }
+
+  /// Add a gRPC status to the response headers.
+  ///
+  /// - parameter status: The gRPC status to add.
+  ///
+  /// - returns: This builder.
+  public func addGrpcStatus(_ status: Int) -> GRPCResponseTrailersBuilder {
+    self.internalSet(name: "grpc-status", value: ["\(status)"])
+    return self
+  }
+
+  /// Add a gRPC message to the response headers.
+  ///
+  /// - parameter message: The gRPC message to add.
+  ///
+  /// - returns: This builder.
+  public func addGrpcMessage(_ message: String) -> GRPCResponseTrailersBuilder {
+    self.internalSet(name: "grpc-message", value: ["\(message)"])
+    return self
+  }
+
+  /// Build the response trailers using the current builder.
+  ///
+  /// - returns: New instance of response trailers.
+  public func build() -> GRPCResponseTrailers {
+    return GRPCResponseTrailers(headers: self.headers)
+  }
+}

--- a/library/swift/src/grpc/GRPCStreamPrototype.swift
+++ b/library/swift/src/grpc/GRPCStreamPrototype.swift
@@ -75,10 +75,10 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This handler, which may be used for chaining syntax.
   @discardableResult
   public func setOnResponseTrailers(_ closure:
-    @escaping (_ trailers: ResponseTrailers) -> Void)
+    @escaping (_ trailers: GRPCResponseTrailers) -> Void)
     -> GRPCStreamPrototype
   {
-    self.underlyingStream.setOnResponseTrailers(closure: closure)
+    self.underlyingStream.setOnResponseTrailers { closure(GRPCResponseTrailers(headers: $0.headers)) }
     return self
   }
 

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -10,6 +10,13 @@ envoy_mobile_swift_test(
 )
 
 envoy_mobile_swift_test(
+    name = "grpc_response_trailers_builder_tests",
+    srcs = [
+        "GRPCResponseTrailersBuilderTests.swift",
+    ],
+)
+
+envoy_mobile_swift_test(
     name = "grpc_stream_tests",
     srcs = [
         "GRPCStreamTests.swift",

--- a/library/swift/test/GRPCResponseTrailersBuilderTests.swift
+++ b/library/swift/test/GRPCResponseTrailersBuilderTests.swift
@@ -1,0 +1,33 @@
+@testable import Envoy
+import Foundation
+import XCTest
+
+final class GRPCResponseTrailersBuilderTests: XCTestCase {
+  func testParsingGRPCStatusHeader() {
+    let trailers = GRPCResponseTrailers(headers: ["grpc-status": ["7"]])
+    XCTAssertEqual(7, trailers.grpcStatus)
+  }
+
+  func testUpdatingGRPCStatusHeader() {
+    let trailers = GRPCResponseTrailers(headers: ["grpc-status": ["7"]])
+      .toGRPCResponseTrailersBuilder()
+      .addGrpcStatus(14)
+      .build()
+
+    XCTAssertEqual(14, trailers.grpcStatus)
+  }
+
+  func testParsingGRPCMessageHeader() {
+    let trailers = GRPCResponseTrailers(headers: ["grpc-message": ["hello world"]])
+    XCTAssertEqual("hello world", trailers.grpcMessage)
+  }
+
+  func testUpdatingGRPCMessageHeader() {
+    let trailers = GRPCResponseTrailers(headers: ["grpc-message": ["abc"]])
+      .toGRPCResponseTrailersBuilder()
+      .addGrpcMessage("123")
+      .build()
+
+    XCTAssertEqual("123", trailers.grpcMessage)
+  }
+}

--- a/library/swift/test/GRPCStreamTests.swift
+++ b/library/swift/test/GRPCStreamTests.swift
@@ -115,7 +115,7 @@ final class GRPCStreamTests: XCTestCase {
     _ = GRPCClient(streamClient: streamClient)
       .newGRPCStreamPrototype()
       .setOnResponseTrailers { trailers in
-        XCTAssertEqual(expectedTrailers, trailers)
+        XCTAssertEqual(GRPCResponseTrailers(headers: expectedTrailers.headers), trailers)
         expectation.fulfill()
       }
       .start()


### PR DESCRIPTION
Adds a `GRPCResponseTrailers` and associated builder, which expose the `grpc-status` and `grpc-message` values - similarly to how we expose the `:status` from `HTTPResponseHeaders`.

I'll follow up with the Android changes when I port over the existing Android interfaces to match up with those introduced in https://github.com/lyft/envoy-mobile/pull/858.

Docs on these headers: https://chromium.googlesource.com/external/github.com/grpc/grpc/+/HEAD/doc/PROTOCOL-HTTP2.md

Signed-off-by: Michael Rebello <me@michaelrebello.com>