### PR TITLE
bazel: Fix sonatype uploads

### DIFF
--- a/bazel/aar_with_jni.bzl
+++ b/bazel/aar_with_jni.bzl
@@ -65,7 +65,7 @@ def aar_with_jni(name, android_library, manifest, archive_name, native_deps = []
         ],
         outs = [
             archive_name + ".aar",
-            archive_name + "_pom.xml",
+            archive_name + "-pom.xml",
             archive_name + "-sources.jar",
             archive_name + "-javadoc.jar",
         ],


### PR DESCRIPTION
The release task is relying on the output artifact to be of this format

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: bazel: Fix sonatype uploads
Risk Level: none
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
