### PR TITLE
Swift: Workaround Swift 5.1 swiftinterface bug

### DIFF
--- a/library/swift/src/HeadersBuilder.swift
+++ b/library/swift/src/HeadersBuilder.swift
@@ -73,6 +73,13 @@ public class HeadersBuilder: NSObject {
     return self
   }
 
+  // Only explicitly implemented to work around a swiftinterface issue in Swift 5.1. This can be removed once
+  // envoy is only built with Swift 5.2+
+  public override init() {
+    self.headers = [:]
+    super.init()
+  }
+
   /// Initialize a new builder. Subclasses should provide their own public convenience initializers.
   ///
   /// - parameter headers: The headers with which to start.

--- a/library/swift/src/HeadersBuilder.swift
+++ b/library/swift/src/HeadersBuilder.swift
@@ -73,8 +73,8 @@ public class HeadersBuilder: NSObject {
     return self
   }
 
-  // Only explicitly implemented to work around a swiftinterface issue in Swift 5.1. This can be removed once
-  // envoy is only built with Swift 5.2+
+  // Only explicitly implemented to work around a swiftinterface issue in Swift 5.1. This can be
+  // removed once envoy is only built with Swift 5.2+
   public override init() {
     self.headers = [:]
     super.init()

--- a/library/swift/src/RequestTrailersBuilder.swift
+++ b/library/swift/src/RequestTrailersBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 @objcMembers
 public final class RequestTrailersBuilder: HeadersBuilder {
   /// Initialize a new instance of the builder.
-  public convenience init() {
+  public override convenience init() {
     self.init(headers: [:])
   }
 

--- a/library/swift/src/ResponseHeadersBuilder.swift
+++ b/library/swift/src/ResponseHeadersBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 @objcMembers
 public final class ResponseHeadersBuilder: HeadersBuilder {
   /// Initialize a new instance of the builder.
-  public convenience init() {
+  public override convenience init() {
     self.init(headers: [:])
   }
 

--- a/library/swift/src/ResponseTrailersBuilder.swift
+++ b/library/swift/src/ResponseTrailersBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 @objcMembers
 public final class ResponseTrailersBuilder: HeadersBuilder {
   /// Initialize a new instance of the builder.
-  public convenience init() {
+  public override convenience init() {
     self.init(headers: [:])
   }
 


### PR DESCRIPTION
With Swift < 5.2 there's an issue where if you implicitly inheret
initializer from `NSObject` the generated swiftinterface doesn't include
the `override` keyword for subclasses and fails when trying to import
the framework. This makes that explicit which adds the keyword. Once we
upgrade to build with Swift 5.2 we can revert this.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>