### PR TITLE
android: fixate api_level to be 29

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,7 @@ envoy_mobile_dependencies()
 load("@envoy_mobile//bazel:envoy_mobile_toolchains.bzl", "envoy_mobile_toolchains")
 envoy_mobile_toolchains()
 
+# Fixing to API 29 since proguard seems to be failing for 30+
 android_sdk_repository(name = "androidsdk", api_level = 29)
 
 android_ndk_repository(name = "androidndk")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,6 @@ envoy_mobile_dependencies()
 load("@envoy_mobile//bazel:envoy_mobile_toolchains.bzl", "envoy_mobile_toolchains")
 envoy_mobile_toolchains()
 
-android_sdk_repository(name = "androidsdk")
+android_sdk_repository(name = "androidsdk", api_level = 29)
 
 android_ndk_repository(name = "androidndk")


### PR DESCRIPTION
Fixing android's api to 29 since it seems like api 30 has some bazel proguard issues which are similar to: bazelbuild/bazel#3777

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: fixate api_level to be 29
Risk Level: low
Testing: ci
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
