### PR TITLE
ci: increase android linux build timeout to 90m

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,7 +10,7 @@ jobs:
   linuxdist:
     name: linux_dist
     runs-on: ubuntu-18.04
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
@@ -36,7 +36,7 @@ jobs:
   macdist:
     name: mac_dist
     runs-on: macOS-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
@@ -58,7 +58,7 @@ jobs:
     name: mac_java_helloworld
     needs: macdist
     runs-on: macOS-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
@@ -91,7 +91,7 @@ jobs:
     name: mac_kotlin_helloworld
     needs: macdist
     runs-on: macOS-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
@@ -123,7 +123,7 @@ jobs:
   kotlintests:
     name: kotlin_tests
     runs-on: ubuntu-18.04
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
@@ -135,7 +135,7 @@ jobs:
   javatests:
     name: java_tests
     runs-on: ubuntu-18.04
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
This is timing out on PRs.

Signed-off-by: Michael Rebello <me@michaelrebello.com>