### PR TITLE
docs: update docs for swift/kotlin interfaces

### DIFF
--- a/docs/root/api/grpc.rst
+++ b/docs/root/api/grpc.rst
@@ -16,103 +16,151 @@ Envoy Mobile implements the gRPC protocol, accepting and returning serialized pr
   In the future, Envoy Mobile will provide much more comprehensive integration with gRPC and protobuf,
   utilizing annotations for enhanced functionality.
 
+-----------
+Quick start
+-----------
+
+Below are some quick examples for getting started with gRPC streams. See the individual class references
+in the later sections of this page for in-depth information on how each type is used.
+
+Start and interact with a gRPC stream in **Kotlin**::
+
+  val headers = GRPCRequestHeadersBuilder("https", "envoyproxy.io", "/pb.api.v1.Foo/GetBar")
+    .build()
+
+  val streamClient = AndroidStreamClientBuilder(application).build()
+    GRPCClient(streamClient)
+      .newGRPCStreamPrototype()
+      .setOnResponseHeaders { headers, endStream ->
+        Log.d("MainActivity", "Headers received: $headers, end stream: $endStream")
+      }
+      .setOnResponseMessage { messageData in
+        Log.d("MainActivity", "Received gRPC message")
+      }
+      .setOnResponseTrailers { trailers in
+        Log.d("MainActivity", "Trailers received: $trailers")
+      }
+      .setOnError { ... }
+      .setOnCancel { ... }
+      .start(Executor { it.run() })
+      .sendHeaders(headers, false)
+      .sendMessage(...)
+      ...
+      .close()
+
+Start and interact with a gRPC stream in **Swift**::
+
+  let headers = GRPCRequestHeadersBuilder(scheme: "https", authority: "envoyproxy.io", path: "/pb.api.v1.Foo/GetBar")
+    .build()
+
+  let streamClient = try StreamClientBuilder().build()
+  GRPCClient(streamClient: streamClient)
+    .newGRPCStreamPrototype()
+    .setOnResponseHeaders { headers, endStream in
+      print("Headers received: \(headers), end stream: \(endStream)")
+    }
+    .setOnResponseMessage { messageData in
+      print("Received gRPC message")
+    }
+    .setOnResponseTrailers { trailers in
+      print("Trailers received: \(trailers)")
+    }
+    .setOnError { ... }
+    .setOnCancel { ... }
+    .start(queue: .main)
+    .sendHeaders(headers, endStream: false)
+    .sendMessage(...)
+    ...
+    .close()
+
 --------------
 ``GRPCClient``
 --------------
 
 The ``GRPCClient`` type provides the ability to start gRPC streams, and is backed by Envoy Mobile's
-``HTTPClient`` type that is instantiated using the ``EnvoyClientBuilder``.
+``StreamClient`` interface (typically instantiated using a ``StreamClientBuilder``).
 
-To create a ``GRPCClient``, simply :ref:`create an HTTP client <api_starting_envoy>` and pass it to the initializer:
+To create a ``GRPCClient``, simply :ref:`create a stream client <api_starting_envoy>` and pass it to the initializer:
 
-``grpcClient = GRPCClient(httpClient)``
+``grpcClient = GRPCClient(streamClient)``
 
 This client can then be used with the types outlined below for starting gRPC streams.
 
-----------------------
-``GRPCRequestBuilder``
-----------------------
+-----------------------------
+``GRPCRequestHeadersBuilder``
+-----------------------------
 
-Envoy Mobile provides a ``GRPCRequestBuilder`` which acts very similarly to the ``RequestBuilder``
-type. Upon calling ``build()``, it returns a ``Request`` (the same type used for standard HTTP
-requests/streams) which is preconfigured for gRPC.
+Envoy Mobile provides a ``GRPCRequestHeadersBuilder`` which acts very similarly to the ``RequestHeadersBuilder``
+type. Upon calling ``build()``, it returns a ``GRPCRequestHeaders`` instance - a subclass of ``RequestHeaders``
+configured specifically for gRPC streams.
 
-To start a gRPC stream, create a ``Request`` using the ``GRPCRequestBuilder``.
+To start a gRPC stream, first create an instance of ``GRPCRequestHeaders`` using the ``GRPCRequestHeadersBuilder``.
 
 **Kotlin**::
 
-  val request = GRPCRequestBuilder("/pb.api.v1.Foo/GetBar", "api.envoyproxy.io", true)
-    .addHeader("x-custom-header", "foobar")
+  val headers = GRPCRequestHeadersBuilder("https", "envoyproxy.io", "/pb.api.v1.Foo/GetBar")
+    .add("x-foo", "123")
     ...
     .build()
 
 **Swift**::
 
-  let request = GRPCRequestBuilder(path: "/pb.api.v1.Foo/GetBar", authority: "api.envoyproxy.io", useHTTPS: true)
-    .addHeader(name: "x-custom-header", value: "foobar")
+  let headers = GRPCRequestHeadersBuilder(scheme: "https", authority: "envoyproxy.io", path: "/pb.api.v1.Foo/GetBar")
+    .add(name: "x-foo", value: "123")
     ...
     .build()
 
 -----------------------
-``GRPCResponseHandler``
+``GRPCStreamPrototype``
 -----------------------
 
-Very similarly to the HTTP ``ResponseHandler``, the ``GRPCResponseHandler`` allows for receiving
-updates to the gRPC stream and contains a set of callbacks that are called whenever an update
-occurs on the stream.
-
-This handler processes inbound gRPC responses, buffers data as necessary while chunks of
-protobuf messages are received, then finally passes fully formed protobuf data to the callbacks
-provided.
+The ``GRPCStreamPrototype`` is used to configure gRPC streams prior to starting them by assigning callbacks
+to be invoked when response data is received on the stream.
 
 Typically, consumers should listen to ``onMessage`` and use a protobuf library to deserialize
 the complete protobuf message data.
 
+To create a ``GRPCStreamPrototype``, use an instance of ``GRPCClient``.
+
 **Kotlin**::
 
-  val handler = GRPCResponseHandler(Executor { })
-    .onHeaders { headers, grpcStatus, _ ->
-      Log.d("MainActivity", "Received gRPC status: " + statusCode + " and headers: " + headers)
-      Unit
+  val prototype = grpcClient
+    .newGRPCStreamPrototype()
+    .setOnResponseHeaders { headers, endStream ->
+      Log.d("MainActivity", "Headers received: $headers, end stream: $endStream")
     }
-    .onMessage { messageData ->
-      // Deserialize message data here
+    .setOnResponseMessage { messageData ->
+      Log.d("MainActivity", "Received gRPC message")
     }
-    .onTrailers { trailers ->
-      Log.d("MainActivity", "Trailers received: " + trailers)
-      Unit
+    .setOnResponseTrailers { trailers ->
+      Log.d("MainActivity", "Trailers received: $trailers")
     }
-    .onError { error ->
-      Log.d("MainActivity", "Error received: " + error.message)
-      Unit
-    }
-    ...
+    .setOnError { ... }
+    .setOnCancel { ... }
 
 **Swift**::
 
-  let handler = GRPCResponseHandler()
-    .onHeaders { headers, grpcStatus, _ in
-      print("Received gRPC status: \(grpcStatus) and headers: \(headers)")
+  let prototype = grpcClient
+    .newGRPCStreamPrototype()
+    .setOnResponseHeaders { headers, endStream in
+      print("Headers received: \(headers), end stream: \(endStream)")
     }
-    .onMessage { messageData in
-      // Deserialize message data here
+    .setOnResponseMessage { messageData in
+      print("Received gRPC message")
     }
-    .onTrailers { trailers in
+    .setOnResponseTrailers { trailers in
       print("Trailers received: \(trailers)")
     }
-    .onError { error in
-      print("Error received: \(error.message)")
-    }
-    ...
+    .setOnError { ... }
+    .setOnCancel { ... }
 
+--------------
+``GRPCStream``
+--------------
 
----------------------
-``GRPCStreamEmitter``
----------------------
+Finally, the gRPC stream can be started by calling ``start()`` on a ``GRPCStreamPrototype``.
 
-Finally, a gRPC stream may be opened using a ``GRPCClient`` instance.
-
-Doing so returns a ``GRPCStreamEmitter`` which allows the sender to interact with the stream.
+Doing so returns a ``GRPCStream`` which allows the sender to interact with the stream.
 
 The ``sendMessage`` function should be invoked with the serialized data from a protobuf message.
 The emitter will then transform the provided data into the gRPC wire format and send it over the
@@ -120,28 +168,42 @@ stream.
 
 **Kotlin**::
 
-  val envoy = AndroidEnvoyClientBuilder(...).build()
-  val grpcClient = GRPCClient(envoy)
+  val streamClient = AndroidStreamClientBuilder()
+    ...
+    .build()
+  val grpcClient = GRPCClient(streamClient)
 
-  val request = GRPCRequestBuilder(...).build()
-  val responseHandler = GRPCResponseHandler(...)
-  val grpcEmitter = grpcClient.start(request, responseHandler)
-    .sendMessage(...)
+  val requestHeaders = GRPCRequestHeadersBuilder()
+    ...
+    .build()
+  val prototype = grpcClient
+    .newGRPCStreamPrototype()
+    ...
+  val stream = prototype
+    .start(Executor { it.run() })
+    .sendHeaders(...)
     .sendMessage(...)
 
   ...
-  grpcEmitter.close(...)
+  stream.close(...)
 
 **Swift**::
 
-  let envoy = try EnvoyClientBuilder(...).build()
-  let grpcClient = GRPCClient(httpClient: envoy)
+  let streamClient = StreamClientBuilder()
+    ...
+    .build()
+  let grpcClient = GRPCClient(streamClient: streamClient)
 
-  let request = GRPCRequestBuilder(...).build()
-  let responseHandler = GRPCResponseHandler(...)
-  let grpcEmitter = grpcClient.start(request, handler: responseHandler)
-    .sendMessage(...)
+  let requestHeaders = GRPCRequestHeadersBuilder()
+    ...
+    .build()
+  let prototype = grpcClient
+    .newGRPCStreamPrototype()
+    ...
+  let stream = prototype
+    .start(queue: .main)
+    .sendHeaders(...)
     .sendMessage(...)
 
   ...
-  grpcEmitter.close(...)
+  stream.close(...)

--- a/docs/root/api/grpc.rst
+++ b/docs/root/api/grpc.rst
@@ -42,7 +42,7 @@ Start and interact with a gRPC stream in **Kotlin**::
       }
       .setOnError { ... }
       .setOnCancel { ... }
-      .start(Executor { it.run() })
+      .start(Executors.newSingleThreadExecutor())
       .sendHeaders(headers, false)
       .sendMessage(...)
       ...
@@ -86,9 +86,9 @@ To create a ``GRPCClient``, simply :ref:`create a stream client <api_starting_en
 
 This client can then be used with the types outlined below for starting gRPC streams.
 
------------------------------
-``GRPCRequestHeadersBuilder``
------------------------------
+----------------------
+``GRPCRequestHeaders``
+----------------------
 
 Envoy Mobile provides a ``GRPCRequestHeadersBuilder`` which acts very similarly to the ``RequestHeadersBuilder``
 type. Upon calling ``build()``, it returns a ``GRPCRequestHeaders`` instance - a subclass of ``RequestHeaders``
@@ -114,7 +114,7 @@ To start a gRPC stream, first create an instance of ``GRPCRequestHeaders`` using
 ``GRPCStreamPrototype``
 -----------------------
 
-The ``GRPCStreamPrototype`` is used to configure gRPC streams prior to starting them by assigning callbacks
+A ``GRPCStreamPrototype`` is used to configure gRPC streams prior to starting them by assigning callbacks
 to be invoked when response data is received on the stream.
 
 Typically, consumers should listen to ``onMessage`` and use a protobuf library to deserialize
@@ -158,7 +158,7 @@ To create a ``GRPCStreamPrototype``, use an instance of ``GRPCClient``.
 ``GRPCStream``
 --------------
 
-Finally, the gRPC stream can be started by calling ``start()`` on a ``GRPCStreamPrototype``.
+gRPC streams are started by calling ``start()`` on a ``GRPCStreamPrototype``.
 
 Doing so returns a ``GRPCStream`` which allows the sender to interact with the stream.
 
@@ -180,7 +180,7 @@ stream.
     .newGRPCStreamPrototype()
     ...
   val stream = prototype
-    .start(Executor { it.run() })
+    .start(Executors.newSingleThreadExecutor())
     .sendHeaders(...)
     .sendMessage(...)
 

--- a/docs/root/api/grpc.rst
+++ b/docs/root/api/grpc.rst
@@ -25,7 +25,7 @@ in the later sections of this page for in-depth information on how each type is 
 
 Start and interact with a gRPC stream in **Kotlin**::
 
-  val headers = GRPCRequestHeadersBuilder("https", "envoyproxy.io", "/pb.api.v1.Foo/GetBar")
+  val headers = GRPCRequestHeadersBuilder(scheme = "https", authority = "envoyproxy.io", path = "/pb.api.v1.Foo/GetBar")
     .build()
 
   val streamClient = AndroidStreamClientBuilder(application).build()

--- a/docs/root/api/http.rst
+++ b/docs/root/api/http.rst
@@ -5,188 +5,251 @@ HTTP requests and streams
 
 Streams are first-class citizens in Envoy Mobile, and are supported out-of-the-box.
 
-In fact, unary (single request, single response) HTTP requests are actually written as simply
-convenience functions on top of streams.
+Unary requests (single request / single response) are also supported using the same interfaces.
 
 -----------
-``Request``
+Quick start
 -----------
 
-Creating a stream is done by initializing a ``Request`` via a ``RequestBuilder``, then passing it to
-a previously created :ref:`Envoy instance <api_starting_envoy>`.
+Below are some quick examples for getting started with HTTP streams. See the individual class references
+in the later sections of this page for in-depth information on how each type is used.
+
+Start and interact with an HTTP stream in **Kotlin**::
+
+  val streamClient = AndroidStreamClientBuilder(application).build()
+
+  val headers = RequestHeadersBuilder(RequestMethod.POST, "https", "api.envoyproxy.io", "/foo")
+    .build()
+  val stream = streamClient
+    .newStreamPrototype()
+    .setOnResponseHeaders { headers, endStream ->
+      Log.d("MainActivity", "[${headers.httpStatus}] Headers received: $headers, end stream: $endStream")
+    }
+    .setOnResponseData { data, endStream ->
+      Log.d("MainActivity", "Received data, end stream: $endStream")
+    }
+    .setOnResponseTrailers { trailers ->
+      Log.d("MainActivity", "Trailers received: $trailers")
+    }
+    .setOnError { ... }
+    .setOnCancel { ... }
+    .start(Executors.newSingleThreadExecutor())
+    .sendHeaders(...)
+    .sendData(...)
+
+  ...
+  stream.close(...)
+
+Start and interact with an HTTP stream in **Swift**::
+
+  let headers = RequestHeadersBuilder(method: .post, scheme: "https", authority: "api.envoyproxy.io", path: "/foo")
+    .build()
+
+  let streamClient = try StreamClientBuilder().build()
+  let stream = streamClient
+    .newStreamPrototype()
+    .setOnResponseHeaders { headers, endStream in
+      print("[\(headers.httpStatus)] Headers received: \(headers), end stream: \(endStream)")
+    }
+    .setOnResponseData { data, endStream in
+      print("Received data, end stream: \(endStream)")
+    }
+    .setOnResponseTrailers { trailers in
+      print("Trailers received: \(trailers)")
+    }
+    .setOnError { ... }
+    .setOnCancel { ... }
+    .start(queue: .main)
+    .sendHeaders()
+    .sendData(...)
+
+  ...
+  stream.close(...)
+
+------------------
+``RequestHeaders``
+------------------
+
+Creating a stream is done by initializing a ``RequestHeaders`` instance via a ``RequestHeadersBuilder``,
+then passing it to a previously created :ref:`StreamClient instance <api_starting_envoy>`.
 
 **Kotlin**::
 
-  val request = RequestBuilder(RequestMethod.POST, "https", "api.envoyproxy.io", "/foo")
+  val headers = RequestHeadersBuilder(RequestMethod.POST, "https", "api.envoyproxy.io", "/foo")
     .addRetryPolicy(RetryPolicy(...))
     .addUpstreamHttpProtocol(UpstreamRequestProtocol.HTTP2)
-    .addHeader("x-custom-header", "foobar")
+    .add("x-custom-header", "foobar")
     ...
     .build()
 
 **Swift**::
 
-  let request = RequestBuilder(method: .post, scheme: "https", authority: "api.envoyproxy.io", path: "/foo")
+  let headers = RequestHeadersBuilder(method: .post, scheme: "https", authority: "api.envoyproxy.io", path: "/foo")
     .addRetryPolicy(RetryPolicy(...))
     .addUpstreamHttpProtocol(.http2)
-    .addHeader(name: "x-custom-header", value: "foobar")
+    .add(name: "x-custom-header", value: "foobar")
     ...
     .build()
 
 -------------------
-``ResponseHandler``
+``StreamPrototype``
 -------------------
 
-In order to receive updates for a given request/stream, a ``ResponseHandler`` must be created.
-This class contains a set of callbacks that are called whenever an update occurs on the stream.
+A ``StreamPrototype`` is used to configure streams prior to starting them by assigning callbacks
+to be invoked when response data is received on the stream.
+
+To create a ``StreamPrototype``, use an instance of ``StreamClient``.
 
 **Kotlin**::
 
-  val handler = ResponseHandler(Executor {})
-    .onHeaders { headers, statusCode, _ ->
-      Log.d("MainActivity", "Received status: " + statusCode + " and headers: " + headers)
-      Unit
+  val prototype = streamClient
+    .newStreamPrototype()
+    .setOnResponseHeaders { headers, endStream ->
+      Log.d("MainActivity", "[${headers.httpStatus}] Headers received: $headers, end stream: $endStream")
     }
-    .onData { buffer, endStream ->
-      if (endStream) {
-        Log.d("MainActivity", "Finished receiving body data")
-      } else {
-        Log.d("MainActivity", "Received body data, more incoming")
-      }
-      Unit
+    .setOnResponseData { data, endStream ->
+      Log.d("MainActivity", "Received data, end stream: $endStream")
     }
-    .onError { error ->
-      Log.d("MainActivity", "Error received: " + error.message)
-      Unit
+    .setOnResponseTrailers { trailers ->
+      Log.d("MainActivity", "Trailers received: $trailers")
     }
-    ...
+    .setOnError { ... }
+    .setOnCancel { ... }
 
 **Swift**::
 
-  let handler = ResponseHandler()
-    .onHeaders { headers, statusCode, _ in
-      print("Received status: \(statusCode) and headers: \(headers)")
+  let prototype = streamClient
+    .newStreamPrototype()
+    .setOnResponseHeaders { headers, endStream in
+      print("[\(headers.httpStatus)] Headers received: \(headers), end stream: \(endStream)")
     }
-    .onData { buffer, endStream in
-      if endStream {
-        print("Finished receiving body data")
-      } else {
-        print("Received body data, more incoming")
-      }
+    .setOnResponseData { data, endStream in
+      print("Received data, end stream: \(endStream)")
     }
-    .onError { error in
-      print("Error received: \(error.message)")
+    .setOnResponseTrailers { trailers in
+      print("Trailers received: \(trailers)")
     }
-    ...
+    .setOnError { ... }
+    .setOnCancel { ... }
 
 ---------------
 ``RetryPolicy``
 ---------------
 
 The ``RetryPolicy`` type allows for customizing retry rules that should be applied to an outbound
-request. These rules are added by calling ``addRetryPolicy(...)`` on the ``RequestBuilder``, and
-are applied when the request is sent.
+request. These rules are added by calling ``addRetryPolicy(...)`` on the ``RequestHeadersBuilder``,
+and are applied when the request headers are sent.
 
 For full documentation of how these retry rules perform, see Envoy's documentation:
 
 - `Automatic retries <https://www.envoyproxy.io/learn/automatic-retries>`_
 - `Retry semantics <https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_routing.html?highlight=exponential#retry-semantics>`_
 
------------------
-``StreamEmitter``
------------------
+----------
+``Stream``
+----------
 
-Once a ``Request`` and ``ResponseHandler`` have been created, a stream can be opened using an
-:ref:`Envoy instance <api_starting_envoy>`.
+Streams are started by calling ``start()`` on a ``StreamPrototype``.
 
-Doing so returns a ``StreamEmitter`` which allows the sender to interact with the stream.
-
-**Kotlin**::
-
-  val envoy = AndroidEnvoyClientBuilder(...).build()
-
-  val request = RequestBuilder(...).build()
-  val responseHandler = ResponseHandler(...)
-  val emitter = envoy.start(request, responseHandler)
-    .sendData(...)
-    .sendData(...)
-
-  ...
-  emitter.close(...)
-
-**Swift**::
-
-  let envoy = try EnvoyClientBuilder(...).build()
-
-  let request = RequestBuilder(...).build()
-  let responseHandler = ResponseHandler(...)
-  let emitter = envoy.start(request, handler: responseHandler)
-    .sendData(...)
-    .sendData(...)
-
-  ...
-  emitter.close(...)
-
---------------
-Unary Requests
---------------
-
-As mentioned above, unary requests are made using the same types that perform streaming requests.
-
-Sending a unary request may be done by either closing the ``StreamEmitter`` after the
-set of headers/data has been written, or by using the helper function that returns a
-``CancelableStream`` type instead of a ``StreamEmitter``.
-
-The unary helper function allows for easily performing the following request types:
-
-- **Headers-only:** Send request headers then close the stream.
-
-  - Done by passing ``nil`` body and ``nil`` trailers.
-
-- **Close with data:** Send request headers and data, then close.
-
-  - Done by passing ``nil`` trailers.
-
-- **Close with trailers:** Send request headers and data, then close with trailers.
-
-  - Done by passing a body and trailers.
-
-The ``CancelableStream`` returned by the unary function does not expose options for sending additional data.
+Doing so returns a ``Stream`` which allows the sender to interact with the stream.
 
 **Kotlin**::
 
-  val envoy = AndroidEnvoyClientBuilder(...).build()
+  val streamClient = AndroidStreamClientBuilder()
+    ...
+    .build()
 
-  val request = RequestBuilder(...).build()
-  val responseHandler = ResponseHandler(...)
+  val requestHeaders = RequestHeadersBuilder()
+    ...
+    .build()
+  val prototype = streamClient
+    .newStreamPrototype()
+    ...
+  val stream = prototype
+    .start(Executors.newSingleThreadExecutor())
+    .sendHeaders(...)
+    .sendData(...)
 
-  // Headers-only
-  val cancelable = envoy.send(request, null, null, responseHandler)
-
-  // Close using data
-  val cancelable = envoy.send(request, body, null, responseHandler)
-
-  // Close using trailers
-  val cancelable = envoy.send(request, body, trailers, responseHandler)
-
-  // To cancel the request:
-  cancelable.cancel()
+  ...
+  stream.close(...)
 
 **Swift**::
 
-  let envoy = try EnvoyClientBuilder(...).build()
+  let streamClient = StreamClientBuilder()
+    ...
+    .build()
 
-  let request = RequestBuilder(...).build()
-  let responseHandler = ResponseHandler(...)
+  let requestHeaders = RequestHeadersBuilder()
+    ...
+    .build()
+  let prototype = streamClient
+    .newStreamPrototype()
+    ...
+  let stream = prototype
+    .start(queue: .main)
+    .sendHeaders(...)
+    .sendData(...)
+
+  ...
+  stream.close(...)
+
+--------------
+Unary requests
+--------------
+
+As mentioned above, unary requests are made using the same types that handle streams.
+
+Sending a unary request is done simply by closing the ``Stream`` after the
+set of headers/data/trailers has been written.
+
+For example:
+
+**Kotlin**::
+
+  val streamClient = AndroidStreamClientBuilder()
+    ...
+    .build()
+
+  val requestHeaders = RequestHeadersBuilder()
+    ...
+    .build()
+  val stream = streamClient
+    .newStreamPrototype()
+    .start(Executors.newSingleThreadExecutor())
 
   // Headers-only
-  let cancelable = envoy.send(request, nil, trailers: nil, handler: responseHandler)
+  stream.sendHeaders(requestHeaders, true)
 
-  // Close using data
-  let cancelable = envoy.send(request, body, trailers: nil, handler: responseHandler)
+  // Close with data
+  stream.close(ByteBuffer(...))
 
-  // Close using trailers
-  let cancelable = envoy.send(request, body, trailers: trailers, handler: responseHandler)
+  // Close with trailers
+  stream.close(RequestTrailersBuilder().build())
 
-  // To cancel the request:
-  cancelable.cancel()
+  // Cancel the stream
+  stream.cancel()
+
+**Swift**::
+
+  let streamClient = StreamClientBuilder()
+    ...
+    .build()
+
+  let requestHeaders = RequestHeadersBuilder()
+    ...
+    .build()
+  let stream = streamClient
+    .newStreamPrototype()
+    .start(queue: .main)
+
+  // Headers-only
+  stream.sendHeaders(requestHeaders, endStream: true)
+
+  // Close with data
+  stream.close(Data(...))
+
+  // Close with trailers
+  stream.close(RequestTrailersBuilder().build())
+
+  // Cancel the stream
+  stream.cancel()

--- a/docs/root/api/http.rst
+++ b/docs/root/api/http.rst
@@ -18,7 +18,7 @@ Start and interact with an HTTP stream in **Kotlin**::
 
   val streamClient = AndroidStreamClientBuilder(application).build()
 
-  val headers = RequestHeadersBuilder(RequestMethod.POST, "https", "api.envoyproxy.io", "/foo")
+  val headers = RequestHeadersBuilder(method = RequestMethod.POST, scheme = "https",  authority = "api.envoyproxy.io", path = "/foo")
     .build()
   val stream = streamClient
     .newStreamPrototype()

--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -3,37 +3,35 @@
 Starting Envoy
 ==============
 
----------------
-``EnvoyClient``
----------------
+----------------
+``StreamClient``
+----------------
 
-Starting an instance of Envoy Mobile for making requests is done by creating an ``EnvoyClient``,
-which conforms to the ``HTTPClient`` interface.
+Starting an instance of Envoy Mobile for performing requests is done by creating a ``StreamClient``.
 
-To do so, create an ``EnvoyClientBuilder`` and call ``build()`` (see below).
+To do so, create a ``StreamClientBuilder`` and call ``build()`` (see below).
 
-After the client is created, it should be stored and kept in memory in order to be used
-for issuing requests.
+After the client is created, it should be stored and used to start network requests/streams.
 
 **Kotlin example**::
 
-  val envoy = AndroidEnvoyClientBuilder(getApplication())
+  val streamClient = AndroidStreamClientBuilder(getApplication())
     .addLogLevel(LogLevel.WARN)
     ...
     .build()
 
 **Swift example**::
 
-  let envoy = try EnvoyClientBuilder()
+  let streamClient = try StreamClientBuilder()
     .addLogLevel(.warn)
     ...
     .build()
 
-----------------------
-``EnvoyClientBuilder``
-----------------------
+-----------------------
+``StreamClientBuilder``
+-----------------------
 
-This type is used to configure an instance of ``EnvoyClient`` before finally
+This type is used to configure an instance of ``StreamClient`` before finally
 creating the client using ``.build()``.
 
 Available builders are 1:1 between iOS/Android, and are documented below.
@@ -197,7 +195,7 @@ This may be done by initializing a builder with the contents of the YAML file yo
 
 **Kotlin example**::
 
-  val envoy = AndroidEnvoyClientBuilder(baseContext, Yaml(yamlFileString))
+  val streamClient = AndroidStreamClientBuilder(baseContext, Yaml(yamlFileString))
     .addLogLevel(LogLevel.WARN)
     .addStatsFlushSeconds(60)
     ...
@@ -205,12 +203,11 @@ This may be done by initializing a builder with the contents of the YAML file yo
 
 **Swift example**::
 
-  let envoy = try EnvoyClientBuilder(yaml: yamlFileString)
+  let streamClient = try StreamClientBuilder(yaml: yamlFileString)
     .addLogLevel(.warn)
     .addStatsFlushSeconds(60)
     ...
     .build()
-
 
 .. attention::
 
@@ -219,7 +216,7 @@ This may be done by initializing a builder with the contents of the YAML file yo
   options are supported by Envoy Mobile.
 
 ---------------
-Making Requests
+Making requests
 ---------------
 
 Now that you have an Envoy Mobile instance, you can start making requests:


### PR DESCRIPTION
This PR updates the docs to reflect all the recent Swift/Kotlin interface changes. It also adds "quick start" sections to the HTTP and gRPC pages.

Resolves https://github.com/lyft/envoy-mobile/issues/906.

Signed-off-by: Michael Rebello <me@michaelrebello.com>