### PR TITLE
swift: fix Xcode 11.5 warnings

### DIFF
--- a/library/swift/src/grpc/GRPCStream.swift
+++ b/library/swift/src/grpc/GRPCStream.swift
@@ -53,9 +53,7 @@ public final class GRPCStream: NSObject {
 
     // Message length (4 bytes)
     var length = UInt32(messageData.count).bigEndian
-    withUnsafePointer(to: &length) { lengthValue in
-      prefixData.append(UnsafeBufferPointer(start: lengthValue, count: 1))
-    }
+    prefixData.append(Data(bytes: &length, count: MemoryLayout<UInt32>.size))
 
     // Send prefix data followed by message data
     self.underlyingStream.sendData(prefixData)

--- a/library/swift/src/grpc/GRPCStream.swift
+++ b/library/swift/src/grpc/GRPCStream.swift
@@ -53,7 +53,9 @@ public final class GRPCStream: NSObject {
 
     // Message length (4 bytes)
     var length = UInt32(messageData.count).bigEndian
-    prefixData.append(UnsafeBufferPointer(start: &length, count: 1))
+    withUnsafePointer(to: &length) { lengthValue in
+      prefixData.append(UnsafeBufferPointer(start: lengthValue, count: 1))
+    }
 
     // Send prefix data followed by message data
     self.underlyingStream.sendData(prefixData)


### PR DESCRIPTION
Fixes the following warnings when compiling with Xcode 11.5:

```
INFO: From Compiling Swift module Envoy:
library/swift/src/grpc/GRPCStream.swift:56:23: warning: initialization of 'UnsafeBufferPointer<UInt32>' results in a dangling buffer pointer
    prefixData.append(UnsafeBufferPointer(start: &length, count: 1))
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
library/swift/src/grpc/GRPCStream.swift:56:50: note: implicit argument conversion from 'UInt32' to 'UnsafePointer<UInt32>?' produces a pointer valid only for the duration of the call to 'init(start:count:)'
    prefixData.append(UnsafeBufferPointer(start: &length, count: 1))
                                                 ^~~~~~~
library/swift/src/grpc/GRPCStream.swift:56:50: note: use 'withUnsafePointer' in order to explicitly convert argument to pointer valid for a defined scope
    prefixData.append(UnsafeBufferPointer(start: &length, count: 1))
                                                 ^
```

Signed-off-by: Michael Rebello <me@michaelrebello.com>