### PR TITLE
envoy: update upstream for multiple fixes

### DIFF
--- a/envoy_build_config/BUILD
+++ b/envoy_build_config/BUILD
@@ -22,5 +22,6 @@ envoy_cc_library(
         "@envoy//source/extensions/filters/network/http_connection_manager:config",
         "@envoy//source/extensions/stat_sinks/metrics_service:config",
         "@envoy//source/extensions/transport_sockets/tls:config",
+        "@envoy//source/extensions/upstreams/http/generic:config",
     ],
 )

--- a/envoy_build_config/extension_registry.cc
+++ b/envoy_build_config/extension_registry.cc
@@ -15,6 +15,7 @@ void ExtensionRegistry::registerFactories() {
       forceRegisterHttpConnectionManagerFilterConfigFactory();
   Envoy::Extensions::StatSinks::MetricsService::forceRegisterMetricsServiceSinkFactory();
   Envoy::Extensions::TransportSockets::Tls::forceRegisterUpstreamSslSocketFactory();
+  Envoy::Extensions::Upstreams::Http::Generic::forceRegisterGenericGenericConnPoolFactory();
   Envoy::Upstream::forceRegisterLogicalDnsClusterFactory();
 
   // TODO: add a "force initialize" function to the upstream code, or clean up the upstream code

--- a/envoy_build_config/extension_registry.h
+++ b/envoy_build_config/extension_registry.h
@@ -10,6 +10,7 @@
 #include "extensions/filters/network/http_connection_manager/config.h"
 #include "extensions/stat_sinks/metrics_service/config.h"
 #include "extensions/transport_sockets/tls/config.h"
+#include "extensions/upstreams/http/generic/config.h"
 
 namespace Envoy {
 class ExtensionRegistry {

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -1,9 +1,10 @@
 EXTENSIONS = {
-    "envoy.clusters.dynamic_forward_proxy":             "//source/extensions/clusters/dynamic_forward_proxy:cluster",
-    "envoy.filters.http.dynamic_forward_proxy":         "//source/extensions/filters/http/dynamic_forward_proxy:config",
-    "envoy.filters.http.router":                        "//source/extensions/filters/http/router:config",
-    "envoy.filters.network.http_connection_manager":    "//source/extensions/filters/network/http_connection_manager:config",
-    "envoy.stat_sinks.metrics_service":                 "//source/extensions/stat_sinks/metrics_service:config",
-    "envoy.transport_sockets.tls":                      "//source/extensions/transport_sockets/tls:config",
+    "envoy.clusters.dynamic_forward_proxy":           "//source/extensions/clusters/dynamic_forward_proxy:cluster",
+    "envoy.filters.connection_pools.http.generic":    "//source/extensions/upstreams/http/generic:config",
+    "envoy.filters.http.dynamic_forward_proxy":       "//source/extensions/filters/http/dynamic_forward_proxy:config",
+    "envoy.filters.http.router":                      "//source/extensions/filters/http/router:config",
+    "envoy.filters.network.http_connection_manager":  "//source/extensions/filters/network/http_connection_manager:config",
+    "envoy.stat_sinks.metrics_service":               "//source/extensions/stat_sinks/metrics_service:config",
+    "envoy.transport_sockets.tls":                    "//source/extensions/transport_sockets/tls:config",
 }
 WINDOWS_EXTENSIONS = {}

--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -33,6 +33,7 @@ envoy_cc_library(
     hdrs = ["envoy_mobile_main_common.h"],
     repository = "@envoy",
     deps = [
+        "@envoy//source/common/common:random_generator_lib",
         "@envoy//source/common/runtime:runtime_lib",
         "@envoy//source/exe:envoy_common_lib",
         "@envoy//source/exe:envoy_main_common_lib",

--- a/library/common/envoy_mobile_main_common.cc
+++ b/library/common/envoy_mobile_main_common.cc
@@ -1,5 +1,6 @@
 #include "library/common/envoy_mobile_main_common.h"
 
+#include "common/common/random_generator.h"
 #include "common/runtime/runtime_impl.h"
 
 namespace Envoy {
@@ -7,7 +8,7 @@ namespace Envoy {
 MobileMainCommon::MobileMainCommon(int argc, const char* const* argv)
     : options_(argc, argv, &MainCommon::hotRestartVersion, spdlog::level::info),
       base_(options_, real_time_system_, default_listener_hooks_, prod_component_factory_,
-            std::make_unique<Runtime::RandomGeneratorImpl>(), platform_impl_.threadFactory(),
+            std::make_unique<Random::RandomGeneratorImpl>(), platform_impl_.threadFactory(),
             platform_impl_.fileSystem(), nullptr) {
   // Disabling signal handling in the options makes it so that the server's event dispatcher _does
   // not_ listen for termination signals such as SIGTERM, SIGINT, etc

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -169,7 +169,7 @@ private:
     void readDisable(bool /*disable*/) override {}
     uint32_t bufferLimit() override { return 65000; }
     // Not applicable
-    void setFlushTimeout(std::chrono::milliseconds) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+    void setFlushTimeout(std::chrono::milliseconds) override {}
 
     void closeLocal(bool end_stream);
 

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -168,6 +168,8 @@ private:
     // TODO: https://github.com/lyft/envoy-mobile/issues/825
     void readDisable(bool /*disable*/) override {}
     uint32_t bufferLimit() override { return 65000; }
+    // Not applicable
+    void setFlushTimeout(std::chrono::milliseconds) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
     void closeLocal(bool end_stream);
 

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -11,7 +11,7 @@ std::string convertToString(envoy_data s) {
 }
 
 RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
-  RequestHeaderMapPtr transformed_headers = std::make_unique<RequestHeaderMapImpl>();
+  RequestHeaderMapPtr transformed_headers = RequestHeaderMapImpl::create();
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(LowerCaseString(convertToString(headers.headers[i].key)),
                                  convertToString(headers.headers[i].value));
@@ -22,7 +22,7 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
 }
 
 RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
-  RequestTrailerMapPtr transformed_trailers = std::make_unique<RequestTrailerMapImpl>();
+  RequestTrailerMapPtr transformed_trailers = RequestTrailerMapImpl::create();
   for (envoy_header_size_t i = 0; i < trailers.length; i++) {
     transformed_trailers->addCopy(LowerCaseString(convertToString(trailers.headers[i].key)),
                                   convertToString(trailers.headers[i].value));

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -31,7 +31,7 @@ namespace Http {
 
 // Based on Http::Utility::toRequestHeaders() but only used for these tests.
 ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
-  ResponseHeaderMapPtr transformed_headers = std::make_unique<ResponseHeaderMapImpl>();
+  ResponseHeaderMapPtr transformed_headers = ResponseHeaderMapImpl::create();
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(LowerCaseString(Utility::convertToString(headers.headers[i].key)),
                                  Utility::convertToString(headers.headers[i].value));

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -117,31 +117,31 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
 }
 
 TEST(HeaderDataConstructorTest, FromCppToCEmpty) {
-  HeaderMapImpl empty_headers;
-  envoy_headers c_headers = Utility::toBridgeHeaders(std::move(empty_headers));
+  RequestHeaderMapPtr empty_headers = RequestHeaderMapImpl::create();
+  envoy_headers c_headers = Utility::toBridgeHeaders(*empty_headers);
   ASSERT_EQ(0, c_headers.length);
   release_envoy_headers(c_headers);
 }
 
 TEST(HeaderDataConstructorTest, FromCppToC) {
-  HeaderMapImpl cpp_headers;
-  cpp_headers.addCopy(LowerCaseString(std::string(":method")), std::string("GET"));
-  cpp_headers.addCopy(LowerCaseString(std::string(":scheme")), std::string("https"));
-  cpp_headers.addCopy(LowerCaseString(std::string(":authority")), std::string("api.lyft.com"));
-  cpp_headers.addCopy(LowerCaseString(std::string(":path")), std::string("/ping"));
+  RequestHeaderMapPtr cpp_headers = RequestHeaderMapImpl::create();
+  cpp_headers->addCopy(LowerCaseString(std::string(":method")), std::string("GET"));
+  cpp_headers->addCopy(LowerCaseString(std::string(":scheme")), std::string("https"));
+  cpp_headers->addCopy(LowerCaseString(std::string(":authority")), std::string("api.lyft.com"));
+  cpp_headers->addCopy(LowerCaseString(std::string(":path")), std::string("/ping"));
 
-  envoy_headers c_headers = Utility::toBridgeHeaders(std::move(cpp_headers));
+  envoy_headers c_headers = Utility::toBridgeHeaders(*cpp_headers);
 
-  ASSERT_EQ(c_headers.length, static_cast<envoy_header_size_t>(cpp_headers.size()));
+  ASSERT_EQ(c_headers.length, static_cast<envoy_header_size_t>(cpp_headers->size()));
 
   for (envoy_header_size_t i = 0; i < c_headers.length; i++) {
     auto actual_key = LowerCaseString(Utility::convertToString(c_headers.headers[i].key));
     auto actual_value = Utility::convertToString(c_headers.headers[i].value);
 
     // Key is present.
-    EXPECT_NE(cpp_headers.get(actual_key), nullptr);
+    EXPECT_NE(cpp_headers->get(actual_key), nullptr);
     // Value for the key is the same.
-    EXPECT_EQ(actual_value, cpp_headers.get(actual_key)->value().getStringView());
+    EXPECT_EQ(actual_value, cpp_headers->get(actual_key)->value().getStringView());
   }
 
   release_envoy_headers(c_headers);

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -19,7 +19,7 @@ namespace {
 
 // Based on Http::Utility::toRequestHeaders() but only used for these tests.
 Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
-  Http::ResponseHeaderMapPtr transformed_headers = std::make_unique<Http::ResponseHeaderMapImpl>();
+  Http::ResponseHeaderMapPtr transformed_headers = Http::ResponseHeaderMapImpl::create();
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
         Http::LowerCaseString(Http::Utility::convertToString(headers.headers[i].key)),
@@ -195,7 +195,7 @@ TEST_P(DispatcherIntegrationTest, BasicNon2xx) {
   // Set response header status to be non-2xx to test that the correct stats get charged.
   reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())
       ->setResponseHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(
-          Http::TestHeaderMapImpl({{":status", "503"}, {"content-length", "0"}})));
+          Http::TestResponseHeaderMapImpl({{":status", "503"}, {"content-length", "0"}})));
 
   envoy_stream_t stream = 1;
   // Setup bridge_callbacks to handle the response.


### PR DESCRIPTION
Description: Pulls in multiple fixes committed to upstream Envoy.

- Update for resolution to TLSContext crash: https://github.com/envoyproxy/envoy/issues/10030
- Fixes for 32 bit archs: https://github.com/envoyproxy/envoy/pull/11726
- Fix for missing posix call on Android: https://github.com/envoyproxy/envoy/pull/12081
- Additional zlib stats: https://github.com/envoyproxy/envoy/pull/11782

Signed-off-by: Mike Schore <mike.schore@gmail.com>