### PR TITLE
ci: bump core timeouts

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -10,7 +10,7 @@ jobs:
   unittests:
     name: unit_tests
     runs-on: macOS-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
@@ -22,7 +22,7 @@ jobs:
   tsan:
     name: tsan
     runs-on: ubuntu-18.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
@@ -38,7 +38,7 @@ jobs:
   asan:
     name: asan
     runs-on: ubuntu-18.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Jobs have been timing out for the `asan` job at 60m.

Signed-off-by: Michael Rebello <me@michaelrebello.com>