### PR TITLE
ci: fix liveliness flakiness

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -85,7 +85,7 @@ jobs:
           adb install -r --no-incremental bazel-bin/examples/java/hello_world/hello_envoy.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoy/.MainActivity
         name: 'Start java app'
-      - run: 'adb logcat -e "successful response" -m 1'
+      - run: 'adb logcat -e "received headers with status 200" -m 1'
         name: 'Check liveliness'
   mackotlin:
     name: mac_kotlin_helloworld
@@ -118,7 +118,7 @@ jobs:
           adb install -r --no-incremental bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
         name: 'Start kotlin app'
-      - run: 'adb logcat -e "successful response" -m 1'
+      - run: 'adb logcat -e "received headers with status 200" -m 1'
         name: 'Check liveliness'
   kotlintests:
     name: kotlin_tests

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -57,7 +57,7 @@ jobs:
         run: 'cat /tmp/envoy.log'
       # Check for the sentinel value that shows the app is alive and well.
       - name: 'Check liveliness'
-        run: 'cat /tmp/envoy.log | grep "Response status (1): 200"'
+        run: 'cat /tmp/envoy.log | grep "received headers with status 200"'
   macobjc:
     name: mac_objc_helloworld
     needs: macdist
@@ -89,7 +89,7 @@ jobs:
         run: 'cat /tmp/envoy.log'
       # Check for the sentinel value that shows the app is alive and well.
       - name: 'Check liveliness'
-        run: 'cat /tmp/envoy.log | grep "Response status (1): 200"'
+        run: 'cat /tmp/envoy.log | grep "received headers with status 200"'
   swifttests:
     name: swift_tests
     runs-on: macOS-latest

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -21,7 +21,6 @@ import kotlin.Unit;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class MainActivity extends Activity {
   private static final String REQUEST_HANDLER_THREAD_NAME = "hello_envoy_java";
@@ -77,29 +76,24 @@ public class MainActivity extends Activity {
     RequestHeaders requestHeaders = new RequestHeadersBuilder(RequestMethod.GET, REQUEST_SCHEME,
                                                               REQUEST_AUTHORITY, REQUEST_PATH)
                                         .build();
-    AtomicReference<ResponseHeaders> responseHeaders = new AtomicReference<ResponseHeaders>();
     streamClient.newStreamPrototype()
-        .setOnResponseHeaders((headers, endStream) -> {
-          responseHeaders.set(headers);
-          Log.d("MainActivity", "successful response!");
-          return Unit.INSTANCE;
-        })
-        .setOnResponseData((buffer, endStream) -> {
+        .setOnResponseHeaders((responseHeaders, endStream) -> {
           Integer status = responseHeaders.get().getHttpStatus();
-          if (status == 200 && buffer.hasArray()) {
+          String message = "received headers with status " + status;
+          Log.d("MainActivity", message);
+          if (status == 200) {
             String serverHeaderField = responseHeaders.get().value(ENVOY_SERVER_HEADER).get(0);
-            String body = new String(buffer.array());
-            recyclerView.post(() -> viewAdapter.add(new Success(body, serverHeaderField)));
+            recyclerView.post(() -> viewAdapter.add(new Success(message, serverHeaderField)));
           } else {
-            recyclerView.post(() -> viewAdapter.add(new Failure("failed with status " + status)));
+            recyclerView.post(() -> viewAdapter.add(new Failure(message)));
           }
           return Unit.INSTANCE;
         })
         .setOnError((error) -> {
-          String msg = "failed with error after " + error.getAttemptCount() +
-                       " attempts: " + error.getMessage();
-          Log.d("MainActivity", msg);
-          recyclerView.post(() -> viewAdapter.add(new Failure(msg)));
+          String message = "failed with error after " + error.getAttemptCount() +
+                           " attempts: " + error.getMessage();
+          Log.d("MainActivity", message);
+          recyclerView.post(() -> viewAdapter.add(new Failure(message)));
           return Unit.INSTANCE;
         })
         .start(Executors.newSingleThreadExecutor())

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -78,11 +78,11 @@ public class MainActivity extends Activity {
                                         .build();
     streamClient.newStreamPrototype()
         .setOnResponseHeaders((responseHeaders, endStream) -> {
-          Integer status = responseHeaders.get().getHttpStatus();
+          Integer status = responseHeaders.getHttpStatus();
           String message = "received headers with status " + status;
           Log.d("MainActivity", message);
           if (status == 200) {
-            String serverHeaderField = responseHeaders.get().value(ENVOY_SERVER_HEADER).get(0);
+            String serverHeaderField = responseHeaders.value(ENVOY_SERVER_HEADER).get(0);
             recyclerView.post(() -> viewAdapter.add(new Success(message, serverHeaderField)));
           } else {
             recyclerView.post(() -> viewAdapter.add(new Failure(message)));

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -11,7 +11,6 @@ import android.util.Log
 import io.envoyproxy.envoymobile.AndroidStreamClientBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
-import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.StreamClient
 import io.envoyproxy.envoymobile.UpstreamHttpProtocol
 import io.envoyproxy.envoymobile.shared.Failure
@@ -97,7 +96,8 @@ class MainActivity : Activity() {
         }
       }
       .setOnError { error ->
-        val message = "failed with error after ${error.attemptCount ?: -1} attempts: ${error.message}"
+        val attemptCount = error.attemptCount ?: -1
+        val message = "failed with error after $attemptCount attempts: ${error.message}"
         Log.d("MainActivity", message)
         recyclerView.post { viewAdapter.add(Failure(message)) }
       }

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -88,7 +88,7 @@ class MainActivity : Activity() {
         val status = responseHeaders.httpStatus ?: 0L
         val message = "received headers with status $status"
         Log.d("MainActivity", message)
-        if (status == 200 && buffer.hasArray()) {
+        if (status == 200) {
           val serverHeaderField = responseHeaders?.value(ENVOY_SERVER_HEADER)?.first() ?: ""
           recyclerView.post { viewAdapter.add(Success(message, serverHeaderField)) }
         } else {

--- a/examples/objective-c/hello_world/Result.h
+++ b/examples/objective-c/hello_world/Result.h
@@ -2,8 +2,7 @@
 
 /// Represents a response from the server or an error.
 @interface Result : NSObject
-@property (nonatomic, assign) int identifier;
-@property (nonatomic, strong) NSString *body;
+@property (nonatomic, strong) NSString *message;
 @property (nonatomic, strong) NSString *serverHeader;
 @property (nonatomic, strong) NSString *error;
 @end

--- a/examples/swift/hello_world/ResponseModels.swift
+++ b/examples/swift/hello_world/ResponseModels.swift
@@ -1,12 +1,10 @@
 /// Represents a response from the server.
 struct Response {
-  let id: Int
-  let body: String
+  let message: String
   let serverHeader: String
 }
 
 /// Error that was encountered when executing a request.
 struct RequestError: Error {
-  let id: Int
   let message: String
 }


### PR DESCRIPTION
We've seen some flakiness on the iOS liveliness CI jobs which appear to be caused by the fact that the first response log from the hello world projects is not showing up when the script greps for `Response status (1): 200`. This PR aims to:

- Fix these flakes by grepping for any 200 response in the logs (rather than specifically the first one)
- Unify the logging and CI behavior for all 4 languages
- Fix error messages not being displayed in the Objective-C hello world app

Signed-off-by: Michael Rebello <me@michaelrebello.com>