### PR TITLE
compression: change decompressor window bits

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -50,6 +50,11 @@ static_resources:
                 name: basic
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.compression.gzip.decompressor.v3.Gzip
+                  # Maximum window bits to allow for any stream to be decompressed. Optimally this
+                  # would be set to 0. According to the zlib manual this would allow the decompressor
+                  # to use the window bits in the zlib header to perform the decompression.
+                  # Unfortunately, the proto field constraint makes this impossible currently.
+                  window_bits: 15
               request_direction_config:
                 common_config:
                   enabled:


### PR DESCRIPTION
Description: allow the decompressor to be flexible in decompressing all possible compressed gzip streams. The decompressor setting should be at least as big as the compressed stream. Optimally Envoy would allow us to set the value to 0, which would then derive the actual window bits value from the zlib header in the compressed stream.
Risk Level: low
Testing: local + CI

Signed-off-by: Jose Nino <jnino@lyft.com>