### PR TITLE
Revert "Swift: Workaround Swift 5.1 swiftinterface bug (#914)"

### DIFF
--- a/library/swift/src/HeadersBuilder.swift
+++ b/library/swift/src/HeadersBuilder.swift
@@ -73,13 +73,6 @@ public class HeadersBuilder: NSObject {
     return self
   }
 
-  // Only explicitly implemented to work around a swiftinterface issue in Swift 5.1. This can be
-  // removed once envoy is only built with Swift 5.2+
-  public override init() {
-    self.headers = [:]
-    super.init()
-  }
-
   /// Initialize a new builder. Subclasses should provide their own public convenience initializers.
   ///
   /// - parameter headers: The headers with which to start.

--- a/library/swift/src/RequestTrailersBuilder.swift
+++ b/library/swift/src/RequestTrailersBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 @objcMembers
 public final class RequestTrailersBuilder: HeadersBuilder {
   /// Initialize a new instance of the builder.
-  public override convenience init() {
+  public convenience init() {
     self.init(headers: [:])
   }
 

--- a/library/swift/src/ResponseHeadersBuilder.swift
+++ b/library/swift/src/ResponseHeadersBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 @objcMembers
 public final class ResponseHeadersBuilder: HeadersBuilder {
   /// Initialize a new instance of the builder.
-  public override convenience init() {
+  public convenience init() {
     self.init(headers: [:])
   }
 

--- a/library/swift/src/ResponseTrailersBuilder.swift
+++ b/library/swift/src/ResponseTrailersBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 @objcMembers
 public final class ResponseTrailersBuilder: HeadersBuilder {
   /// Initialize a new instance of the builder.
-  public override convenience init() {
+  public convenience init() {
     self.init(headers: [:])
   }
 

--- a/library/swift/src/mocks/MockStreamClient.swift
+++ b/library/swift/src/mocks/MockStreamClient.swift
@@ -9,13 +9,6 @@ public final class MockStreamClient: NSObject {
   /// Typically, this is used to capture streams on creation before sending values through them.
   public var onStartStream: ((MockStream) -> Void)?
 
-  // Only explicitly implemented to work around a swiftinterface issue in Swift 5.1. This can be
-  // removed once envoy is only built with Swift 5.2+
-  public override init() {
-    self.onStartStream = nil
-    super.init()
-  }
-
   /// Initialize a new instance of the stream client.
   ///
   /// - parameter onStartStream: Closure that may be set to observe the creation of new streams.


### PR DESCRIPTION
This reverts 139f037e2599438ae3bf3faa62ed03d7f8594c7f and 1b36d5a2c31c5b55c4d64bc3a933969cbab6ec06

These are no longer required since we now build with Swift 5.2

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>