### PR TITLE
ci: increase wait for ios simulator to start

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -48,9 +48,8 @@ jobs:
       # Run the app in the background and redirect logs.
       - name: 'Run swift app'
         run: bazel run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
-      # Wait for the app to start and get some requests/responses.
-      - name: 'Sleep'
-        run: sleep 120
+      - name: 'Wait for simulator to start & perform requests'
+        run: sleep 180
       # Print out the log in case the liveliness check fails.
       # This allows the author to decide if the failure is a flake or a real problem.
       - name: 'Cat log'
@@ -80,9 +79,8 @@ jobs:
       # Run the app in the background and redirect logs.
       - name: 'Run objective-c app'
         run: bazel run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
-      # Wait for the app to start and get some requests/responses.
-      - name: 'Sleep'
-        run: sleep 120
+      - name: 'Wait for simulator to start & perform requests'
+        run: sleep 180
       # Print out the log in case the liveliness check fails.
       # This allows the author to decide if the failure is a flake or a real problem.
       - name: 'Cat log'


### PR DESCRIPTION
It appears that 120s is not long enough to consistently allow the simulator to start up. Successful CI runs seem to take >60s, while flaky runs take longer. Bumping this timeout which should hopefully reduce these flakes.

Signed-off-by: Michael Rebello <me@michaelrebello.com>