### PR TITLE
android: fixate to API 24 and use old libevent version for upstream envoy

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,7 +37,8 @@ envoy_mobile_dependencies()
 load("@envoy_mobile//bazel:envoy_mobile_toolchains.bzl", "envoy_mobile_toolchains")
 envoy_mobile_toolchains()
 
-# Fixing to API 29 since proguard seems to be failing for 30+
-android_sdk_repository(name = "androidsdk", api_level = 29)
+# Fixing to API 24. Need to lower to API 21: https://github.com/lyft/envoy-mobile/issues/936
+# Note: proguard is failing for API 30+
+android_sdk_repository(name = "androidsdk", api_level = 24)
 
-android_ndk_repository(name = "androidndk")
+android_ndk_repository(name = "androidndk", api_level = 24)

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -38,6 +38,7 @@ def upstream_envoy_overrides():
         urls = ["https://github.com/libevent/libevent/archive/0d7d85c2083f7a4c9efe01c061486f332b576d28.tar.gz"],
         strip_prefix = "libevent-0d7d85c2083f7a4c9efe01c061486f332b576d28",
         sha256 = "549d34065eb2485dfad6c8de638caaa6616ed130eec36dd978f73b6bdd5af113",
+        build_file_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])""",
     )
 
     # Patch upstream Abseil to prevent Foundation dependency from leaking into Android builds.

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -32,6 +32,14 @@ def upstream_envoy_overrides():
         urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protobuf-all-3.10.1.tar.gz"],
     )
 
+    # Workaround old NDK version breakages https://github.com/lyft/envoy-mobile/issues/934
+    http_archive(
+        name = "com_github_libevent_libevent",
+        urls = ["https://github.com/libevent/libevent/archive/0d7d85c2083f7a4c9efe01c061486f332b576d28.tar.gz"],
+        strip_prefix = "libevent-0d7d85c2083f7a4c9efe01c061486f332b576d28",
+        sha256 = "549d34065eb2485dfad6c8de638caaa6616ed130eec36dd978f73b6bdd5af113",
+    )
+
     # Patch upstream Abseil to prevent Foundation dependency from leaking into Android builds.
     # Workaround for https://github.com/abseil/abseil-cpp/issues/326.
     # TODO: Should be removed in https://github.com/lyft/envoy-mobile/issues/136 once rules_android

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -42,7 +42,7 @@ public class MainActivity extends Activity {
 
     streamClient = new AndroidStreamClientBuilder(getApplication()).build();
 
-    recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
+    recyclerView = (RecyclerView)findViewById(R.id.recycler_view);
     recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
     viewAdapter = new ResponseRecyclerViewAdapter();

--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -42,7 +42,7 @@ public class MainActivity extends Activity {
 
     streamClient = new AndroidStreamClientBuilder(getApplication()).build();
 
-    recyclerView = findViewById(R.id.recycler_view);
+    recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
     recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
     viewAdapter = new ResponseRecyclerViewAdapter();


### PR DESCRIPTION
We're reverting the libevent version bump from upstream envoy to avoid the commit which introduced a usage of `pthread_mutexattr_setprotocol`. The libevent change is [here](https://github.com/libevent/libevent/commit/f76456b0dc14fb7c5fa55f815512b2ed07df4706). The upstream envoy change was primarily targeted for windows.


Upstream change for updating libevent: https://github.com/envoyproxy/envoy/pull/11137
Addressing missing symbol: https://github.com/lyft/envoy-mobile/issues/934
Will need to lower to 21: https://github.com/lyft/envoy-mobile/issues/936

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: fixate to API 24 and use old libevent version for upstream envoy
Risk Level: low
Testing: ci
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
