### PR TITLE
android: only build aar for android_dist target

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
           export CC=clang
           export CXX=clang++
           export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-          bazel build --fat_apk_cpu=x86 //:android_dist
+          bazel build --fat_apk_cpu=x86 //:android_dist_ci
     # TODO: parallelize these two jobs
       - name: 'Build Java app'
         run: |
@@ -49,7 +49,7 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
       - name: 'Build envoy.aar distributable'
-        run: bazel build --fat_apk_cpu=x86 //:android_dist
+        run: bazel build --fat_apk_cpu=x86 //:android_dist_ci
       - uses: actions/upload-artifact@v1
         with:
           name: envoy.aar

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -8,8 +8,8 @@ on:
       - VERSION
 
 jobs:
-  main_android_dist:
-    name: main_android_dist
+  main_android_dist_ci:
+    name: main_android_dist_ci
     runs-on: ubuntu-18.04
     timeout-minutes: 120
     steps:
@@ -29,7 +29,7 @@ jobs:
               --config=release-android \
               --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a \
               --define=pom_version=main-$current_short_commit \
-              //:android_dist
+              //:android_dist_ci
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_android_aar_sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
             --config=release-android \
             --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a \
             --define=pom_version="${current_release_tag:1}" \
-            //:android_dist
+            //:android_dist_ci
       - name: 'Configure gpg signing'
         env:
           GPG_KEY: ${{ secrets.gpg_key }}

--- a/BUILD
+++ b/BUILD
@@ -26,12 +26,18 @@ alias(
 )
 
 genrule(
-    name = "android_zip",
+    name = "android_dist_ci",
     srcs = [
         "//library/kotlin/src/io/envoyproxy/envoymobile:android_aar",
     ],
     outs = ["envoy_mobile.zip"],
-    cmd = "$(location //bazel:zipper) fc $@ $(SRCS)",
+    cmd = """
+    for artifact in $(SRCS); do
+        chmod 755 $$artifact
+        cp $$artifact dist/
+    done
+    touch $@
+    """,
     stamp = True,
     tools = ["//bazel:zipper"],
     visibility = ["//visibility:public"],
@@ -40,14 +46,12 @@ genrule(
 genrule(
     name = "android_dist",
     srcs = [
-        "//library/kotlin/src/io/envoyproxy/envoymobile:android_aar",
+        "//library/kotlin/src/io/envoyproxy/envoymobile:android_aar_only_aar",
     ],
     outs = ["output_in_dist_directory"],
     cmd = """
-    for artifact in $(SRCS); do
-        chmod 755 $$artifact
-        cp $$artifact dist/
-    done
+    chmod 755 $<
+    cp $< dist/
     touch $@
     """,
     stamp = True,

--- a/BUILD
+++ b/BUILD
@@ -21,14 +21,14 @@ touch $@
 
 alias(
     name = "android_aar",
-    actual = "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_android",
+    actual = "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_aar",
     visibility = ["//visibility:public"],
 )
 
 genrule(
     name = "android_dist_ci",
     srcs = [
-        "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_android_artifacts",
+        "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_aar_with_artifacts",
     ],
     outs = ["envoy_mobile.zip"],
     cmd = """
@@ -46,7 +46,7 @@ genrule(
 genrule(
     name = "android_dist",
     srcs = [
-        "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_android",
+        "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_aar",
     ],
     outs = ["output_in_dist_directory"],
     cmd = """

--- a/BUILD
+++ b/BUILD
@@ -21,14 +21,14 @@ touch $@
 
 alias(
     name = "android_aar",
-    actual = "//library/kotlin/src/io/envoyproxy/envoymobile:android_aar_only_aar",
+    actual = "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_android",
     visibility = ["//visibility:public"],
 )
 
 genrule(
     name = "android_dist_ci",
     srcs = [
-        "//library/kotlin/src/io/envoyproxy/envoymobile:android_aar",
+        "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_android_artifacts",
     ],
     outs = ["envoy_mobile.zip"],
     cmd = """
@@ -46,7 +46,7 @@ genrule(
 genrule(
     name = "android_dist",
     srcs = [
-        "//library/kotlin/src/io/envoyproxy/envoymobile:android_aar_only_aar",
+        "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_android",
     ],
     outs = ["output_in_dist_directory"],
     cmd = """

--- a/bazel/android_artifacts.bzl
+++ b/bazel/android_artifacts.bzl
@@ -56,7 +56,7 @@ def android_artifacts(name, android_library, manifest, archive_name, native_deps
     _sources_name, _javadocs_name = _create_sources_javadocs(name, android_library)
     _pom_name = _create_pom_xml(name, android_library)
     native.genrule(
-        name = name + "_artifacts",
+        name = name + "_with_artifacts",
         srcs = [
             _aar_output,
             _pom_name,

--- a/bazel/android_artifacts.bzl
+++ b/bazel/android_artifacts.bzl
@@ -26,7 +26,7 @@ load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-def aar_with_jni(name, android_library, manifest, archive_name, native_deps = [], proguard_rules = "", visibility = []):
+def android_artifacts(name, android_library, manifest, archive_name, native_deps = [], proguard_rules = "", visibility = []):
     """
     NOTE: The bazel android_library's implicit aar output doesn't flatten its transitive
     dependencies. Additionally, when using the kotlin rules, the kt_android_library rule
@@ -56,7 +56,7 @@ def aar_with_jni(name, android_library, manifest, archive_name, native_deps = []
     _sources_name, _javadocs_name = _create_sources_javadocs(name, android_library)
     _pom_name = _create_pom_xml(name, android_library)
     native.genrule(
-        name = name,
+        name = name + "_artifacts",
         srcs = [
             _aar_output,
             _pom_name,
@@ -127,7 +127,7 @@ def _create_aar(name, archive_name, classes_jar, jni_archive, proguard_rules, vi
     )
 
     native.genrule(
-        name = name + "_only_aar",
+        name = name,
         outs = [_aar_output],
         srcs = [
             classes_jar,

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -6,7 +6,7 @@ load("@rules_detekt//detekt:defs.bzl", "detekt")
 licenses(["notice"])  # Apache 2
 
 android_artifacts(
-    name = "envoy_android",
+    name = "envoy_aar",
     android_library = ":envoy_lib",
     archive_name = "envoy",
     manifest = "EnvoyManifest.xml",

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -1,12 +1,12 @@
-load("@envoy_mobile//bazel:aar_with_jni.bzl", "aar_with_jni")
+load("@envoy_mobile//bazel:android_artifacts.bzl", "android_artifacts")
 load("@envoy_mobile//bazel:kotlin_lib.bzl", "envoy_mobile_kt_library")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 load("@rules_detekt//detekt:defs.bzl", "detekt")
 
 licenses(["notice"])  # Apache 2
 
-aar_with_jni(
-    name = "android_aar",
+android_artifacts(
+    name = "envoy_android",
     android_library = ":envoy_lib",
     archive_name = "envoy",
     manifest = "EnvoyManifest.xml",


### PR DESCRIPTION
Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: only build aar for android_dist target
Risk Level: low
Testing: ci
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
