### PR TITLE
docs: update CONTRIBUTING.md with inclusive language policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,23 @@ maximize the chances of your PR being merged.
 
 * See [STYLE.md](STYLE.md)
 
+# Inclusive language policy
+
+The Envoy community has an explicit goal to be inclusive to all. As such, all PRs must adhere to the
+following guidelines for all code, APIs, and documentation:
+
+* The following words and phrases are not allowed:
+  * *Whitelist*: use allowlist instead.
+  * *Blacklist*: use denylist or blocklist instead.
+  * *Master*: use primary instead.
+  * *Slave*: use secondary or replica instead.
+* Documentation should be written in an inclusive style. The [Google developer
+  documentation](https://developers.google.com/style/inclusive-documentation) contains an excellent
+  reference on this topic.
+* The above policy is not considered definitive and may be amended in the future as industry best
+  practices evolve. Additional comments on this topic may be provided by maintainers during code
+  review.
+
 # Submitting a PR
 
 * Fork the repo.


### PR DESCRIPTION
This is snapshotted from upstream Envoy.

Signed-off-by: Michael Rebello <me@michaelrebello.com>