### PR TITLE
ci: increase soft binary size limit

### DIFF
--- a/ci/test_size_regression.sh
+++ b/ci/test_size_regression.sh
@@ -2,7 +2,7 @@
 
 # Checks the absolute size and the relative size increase of a file.
 
-MAX_SIZE=5500000 # 5.5MB
+MAX_SIZE=5600000 # 5.6MB
 MAX_PERC=1
 
 if [ `uname` == "Darwin" ]


### PR DESCRIPTION
Description: Increases the soft limit for binary size to 5.6MB due to upstream Envoy update. Size prior to update was 5298092 (5.3MB).

Signed-off-by: Mike Schore <mike.schore@gmail.com>