### PR TITLE
android: switch API level to 21

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,6 +39,4 @@ envoy_mobile_toolchains()
 
 # Note: proguard is failing for API 30+
 android_sdk_repository(name = "androidsdk", api_level = 29)
-
-# Fixing to API 24. Need to lower to API 21: https://github.com/lyft/envoy-mobile/issues/936
-android_ndk_repository(name = "androidndk", api_level = 24)
+android_ndk_repository(name = "androidndk", api_level = 21)


### PR DESCRIPTION
We can do this now that https://github.com/envoyproxy/envoy/pull/11863 has landed and upstream has been bumped.

Resolves https://github.com/lyft/envoy-mobile/issues/936.

Signed-off-by: Michael Rebello <me@michaelrebello.com>
