### PR TITLE
ci: use bazelisk

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,16 +23,16 @@ jobs:
           export CC=clang
           export CXX=clang++
           export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-          bazel build --fat_apk_cpu=x86 //:android_dist_ci
+          bazelisk build --fat_apk_cpu=x86 //:android_dist_ci
     # TODO: parallelize these two jobs
       - name: 'Build Java app'
         run: |
           export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-          bazel build --fat_apk_cpu=x86 //examples/java/hello_world:hello_envoy
+          bazelisk build --fat_apk_cpu=x86 //examples/java/hello_world:hello_envoy
       - name: 'Build kotlin app'
         run: |
           export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-          bazel build --fat_apk_cpu=x86 //examples/kotlin/hello_world:hello_envoy_kt
+          bazelisk build --fat_apk_cpu=x86 //examples/kotlin/hello_world:hello_envoy_kt
   macdist:
     name: mac_dist
     runs-on: macOS-latest
@@ -49,7 +49,7 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
       - name: 'Build envoy.aar distributable'
-        run: bazel build --fat_apk_cpu=x86 //:android_dist_ci
+        run: bazelisk build --fat_apk_cpu=x86 //:android_dist_ci
       - uses: actions/upload-artifact@v1
         with:
           name: envoy.aar
@@ -78,10 +78,10 @@ jobs:
       - name: start simulator
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   bazel mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
+      #   bazelisk mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
       # When https://github.com/lyft/envoy-mobile/issues/853 is fixed.
       - run: |
-          bazel build --fat_apk_cpu=x86 //examples/java/hello_world:hello_envoy
+          bazelisk build --fat_apk_cpu=x86 //examples/java/hello_world:hello_envoy
           adb install -r --no-incremental bazel-bin/examples/java/hello_world/hello_envoy.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoy/.MainActivity
         name: 'Start java app'
@@ -111,10 +111,10 @@ jobs:
       - name: start simulator
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   bazel mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
+      #   bazelisk mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/lyft/envoy-mobile/issues/853 is fixed.
       - run: |
-          bazel build --fat_apk_cpu=x86 //examples/kotlin/hello_world:hello_envoy_kt
+          bazelisk build --fat_apk_cpu=x86 //examples/kotlin/hello_world:hello_envoy_kt
           adb install -r --no-incremental bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
         name: 'Start kotlin app'
@@ -130,7 +130,7 @@ jobs:
           submodules: true
       - name: 'Install dependencies'
         run: ./ci/linux_ci_setup.sh
-      - run: bazel test --test_output=all --build_tests_only //library/kotlin/test/...
+      - run: bazelisk test --test_output=all --build_tests_only //library/kotlin/test/...
         name: 'Run Kotlin library tests'
   javatests:
     name: java_tests
@@ -142,5 +142,5 @@ jobs:
           submodules: true
       - name: 'Install dependencies'
         run: ./ci/linux_ci_setup.sh
-      - run: bazel test --test_output=all --build_tests_only //library/java/test/...
+      - run: bazelisk test --test_output=all --build_tests_only //library/java/test/...
         name: 'Run Java library tests'

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -25,7 +25,7 @@ jobs:
           export CXX=clang++
           export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
           current_short_commit=$(git rev-parse --short HEAD)
-          bazel build \
+          bazelisk build \
               --config=release-android \
               --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a \
               --define=pom_version=main-$current_short_commit \
@@ -45,7 +45,7 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Build Envoy.framework distributable'
-        run: bazel build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 //:ios_dist
+        run: bazelisk build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 //:ios_dist
       - name: 'Create temporary directory for artifact to produce properly named zip'
         run: mkdir -p dist/ios_artifact/Envoy.framework
       - name: 'Move artifact to directory for zipping'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Run tests'
-        run: bazel test --test_output=all //test/...
+        run: bazelisk test --test_output=all //test/...
   tsan:
     name: tsan
     runs-on: ubuntu-18.04
@@ -34,7 +34,7 @@ jobs:
           export PATH=/usr/lib/llvm-8/bin:$PATH
           export CC=clang
           export CXX=clang++
-          bazel test --config=clang-tsan --test_output=all //test/...
+          bazelisk test --config=clang-tsan --test_output=all //test/...
   asan:
     name: asan
     runs-on: ubuntu-18.04
@@ -50,4 +50,4 @@ jobs:
           export PATH=/usr/lib/llvm-8/bin:$PATH
           export CC=clang
           export CXX=clang++
-          bazel test --config=clang-asan --test_output=all //test/...
+          bazelisk test --config=clang-asan --test_output=all //test/...

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -57,9 +57,9 @@ jobs:
         run: ./ci/linux_ci_setup.sh
       - name: 'Run Kotlin Lint (Detekt)'
         run: |
-          bazel build \
+          bazelisk build \
             //library/kotlin/src/io/envoyproxy/envoymobile:envoy_lib_lint \
             //examples/kotlin/hello_world:hello_envoy_kt_lint
       - name: 'Run Kotlin Formatter (ktlint)'
         run: |
-          bazel build kotlin_format
+          bazelisk build kotlin_format

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Build Envoy.framework distributable'
-        run: bazel build --config=ios //:ios_dist
+        run: bazelisk build --config=ios //:ios_dist
       - name: 'Zip Envoy.framework.zip distributable'
         run: zip -r dist/Envoy.framework.zip dist/Envoy.framework
       - run: ls -lh dist/
@@ -44,10 +44,10 @@ jobs:
       - run: unzip dist/Envoy.framework.zip
       - run: ls -lh dist/
       - name: 'Build swift app'
-        run: bazel build --config=ios //examples/swift/hello_world:app
+        run: bazelisk build --config=ios //examples/swift/hello_world:app
       # Run the app in the background and redirect logs.
       - name: 'Run swift app'
-        run: bazel run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
+        run: bazelisk run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
       - name: 'Wait for simulator to start & perform requests'
         run: sleep 180
       # Print out the log in case the liveliness check fails.
@@ -75,10 +75,10 @@ jobs:
       - run: unzip dist/Envoy.framework.zip
       - run: ls -lh dist/
       - name: 'Build objective-c app'
-        run: bazel build --config=ios //examples/objective-c/hello_world:app
+        run: bazelisk build --config=ios //examples/objective-c/hello_world:app
       # Run the app in the background and redirect logs.
       - name: 'Run objective-c app'
-        run: bazel run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+        run: bazelisk run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
       - name: 'Wait for simulator to start & perform requests'
         run: sleep 180
       # Print out the log in case the liveliness check fails.
@@ -99,4 +99,4 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Run swift library tests'
-        run: bazel test --test_output=all --config=ios --build_tests_only //library/swift/test/...
+        run: bazelisk test --test_output=all --config=ios --build_tests_only //library/swift/test/...

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -22,7 +22,7 @@ jobs:
           export PATH=/usr/lib/llvm-8/bin:$PATH
           export CC=clang
           export CXX=clang++
-          bazel build //test/performance:test_binary_size --config=sizeopt
+          bazelisk build //test/performance:test_binary_size --config=sizeopt
       - uses: actions/upload-artifact@v1
         with:
           name: sizecurrent
@@ -43,7 +43,7 @@ jobs:
           export PATH=/usr/lib/llvm-8/bin:$PATH
           export CC=clang
           export CXX=clang++
-          bazel build //test/performance:test_binary_size --config=sizeopt
+          bazelisk build //test/performance:test_binary_size --config=sizeopt
       - uses: actions/upload-artifact@v1
         with:
           name: sizemain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
           # Build and create the artifacts
           current_release_tag=$(git describe --tags --abbrev=0 --exact-match)
-          bazel build \
+          bazelisk build \
             --config=release-android \
             --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a \
             --define=pom_version="${current_release_tag:1}" \


### PR DESCRIPTION
We should be using bazelisk on CI since that's what we advise doing locally.

Signed-off-by: Michael Rebello <me@michaelrebello.com>