### PR TITLE
android: docs update NDK to be 21 rather than 19

### DIFF
--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -32,7 +32,7 @@ Android requirements
 --------------------
 
 - Android SDK Platform 29
-- Android NDK 19.2.5345600
+- Android NDK 21
 
 ----------------
 iOS requirements


### PR DESCRIPTION

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: docs update NDK to be 21 rather than 19
Risk Level: low
Testing: n/a
Docs Changes: buidling docs for android
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
