### PR TITLE
filters: add bridge support for data invocations

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/c_types.cc
+++ b/library/common/extensions/filters/http/platform_bridge/c_types.cc
@@ -13,3 +13,11 @@ const envoy_filter_headers_status_t kEnvoyFilterHeadersStatusContinueAndEndStrea
 const envoy_filter_headers_status_t kEnvoyFilterHeadersStatusStopAllIterationAndBuffer =
     static_cast<envoy_filter_headers_status_t>(
         Envoy::Http::FilterHeadersStatus::StopAllIterationAndBuffer);
+
+const envoy_filter_data_status_t kEnvoyFilterDataStatusContinue =
+    static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatusContinue);
+const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationAndBuffer =
+    static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatusStopIterationAndBuffer);
+const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationNoBuffer =
+    static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatusStopIterationNoBuffer);
+

--- a/library/common/extensions/filters/http/platform_bridge/c_types.cc
+++ b/library/common/extensions/filters/http/platform_bridge/c_types.cc
@@ -15,8 +15,8 @@ const envoy_filter_headers_status_t kEnvoyFilterHeadersStatusStopAllIterationAnd
         Envoy::Http::FilterHeadersStatus::StopAllIterationAndBuffer);
 
 const envoy_filter_data_status_t kEnvoyFilterDataStatusContinue =
-    static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatusContinue);
+    static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatus::Continue);
 const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationAndBuffer =
-    static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatusStopIterationAndBuffer);
+    static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatus::StopIterationAndBuffer);
 const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationNoBuffer =
-    static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatusStopIterationNoBuffer);
+    static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatus::StopIterationNoBuffer);

--- a/library/common/extensions/filters/http/platform_bridge/c_types.cc
+++ b/library/common/extensions/filters/http/platform_bridge/c_types.cc
@@ -20,4 +20,3 @@ const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationAndBuffer =
     static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatusStopIterationAndBuffer);
 const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationNoBuffer =
     static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatusStopIterationNoBuffer);
-

--- a/library/common/extensions/filters/http/platform_bridge/c_types.h
+++ b/library/common/extensions/filters/http/platform_bridge/c_types.h
@@ -24,11 +24,10 @@ typedef struct {
 /**
  * Return codes for on-data filter invocations. @see envoy/http/filter.h
  */
-typedef enum {
-  ENVOY_FILTER_DATA_STATUS_CONTINUE = 0,
-  ENVOY_FILTER_DATA_STATUS_STOP_ITERATION_AND_BUFFER,
-  ENVOY_FILTER_DATA_STATUS_STOP_ITERATION_NO_BUFFER,
-} envoy_filter_data_status_t;
+typedef int envoy_filter_data_status_t;
+extern const envoy_filter_data_status_t kEnvoyFilterDataStatusContinue;
+extern const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationAndBuffer;
+extern const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationNoBuffer;
 
 /**
  * Compound return type for on-data filter invocations.

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -70,8 +70,7 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
   }
 
   envoy_data in_data = Buffer::Utility::toBridgeData(data);
-  envoy_filter_data_status result =
-      on_data(in_data, end_stream, platform_filter_->context);
+  envoy_filter_data_status result = on_data(in_data, end_stream, platform_filter_->context);
   Http::FilterDataStatus status = mapStatus(result.status);
   // Current platform implementations expose immutable data, thus any modification necessitates a
   // full copy. If the returned buffer is identical, we assume no modification was made and elide
@@ -91,8 +90,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::decodeHeaders(Http::RequestHeade
   return onHeaders(headers, end_stream, platform_filter_->on_request_headers);
 }
 
-Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data,
-                                                        bool end_stream) {
+Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, bool end_stream) {
   // Delegate to shared implementation for request and response path.
   return onData(data, end_stream, platform_filter_->on_request_data);
 }
@@ -117,8 +115,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
   return onHeaders(headers, end_stream, platform_filter_->on_response_headers);
 }
 
-Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data,
-                                                        bool end_stream) {
+Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, bool end_stream) {
   // Delegate to shared implementation for request and response path.
   return onData(data, end_stream, platform_filter_->on_response_data);
 }

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -15,20 +15,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace PlatformBridge {
 
-Http::FilterDataStatus mapStatus(envoy_filter_data_status_t status) {
-  switch (status) {
-  case ENVOY_FILTER_DATA_STATUS_CONTINUE:
-    return Http::FilterDataStatus::Continue;
-  case ENVOY_FILTER_DATA_STATUS_STOP_ITERATION_AND_BUFFER:
-    return Http::FilterDataStatus::StopIterationAndBuffer;
-  case ENVOY_FILTER_DATA_STATUS_STOP_ITERATION_NO_BUFFER:
-    return Http::FilterDataStatus::StopIterationNoBuffer;
-  default:
-    ASSERT(false, fmt::format("urecognized filter status from platform: {}", status));
-    return Http::FilterDataStatus::Continue;
-  }
-}
-
 PlatformBridgeFilterConfig::PlatformBridgeFilterConfig(
     const envoymobile::extensions::filters::http::platform_bridge::PlatformBridge& proto_config)
     : platform_filter_(static_cast<envoy_http_filter*>(
@@ -71,7 +57,7 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
 
   envoy_data in_data = Buffer::Utility::toBridgeData(data);
   envoy_filter_data_status result = on_data(in_data, end_stream, platform_filter_->context);
-  Http::FilterDataStatus status = mapStatus(result.status);
+  Http::FilterDataStatus status = static_cast<Http::FilterDataStatus>(result.status);
   // Current platform implementations expose immutable data, thus any modification necessitates a
   // full copy. If the returned buffer is identical, we assume no modification was made and elide
   // the copy here. See also https://github.com/lyft/envoy-mobile/issues/949 for potential future

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -6,6 +6,7 @@
 #include "common/common/utility.h"
 
 #include "library/common/api/external.h"
+#include "library/common/buffer/bridge_fragment.h"
 #include "library/common/buffer/utility.h"
 #include "library/common/http/header_utility.h"
 
@@ -13,6 +14,20 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace PlatformBridge {
+
+Http::FilterDataStatus mapStatus(envoy_filter_data_status_t status) {
+  switch (status) {
+  case ENVOY_FILTER_DATA_STATUS_CONTINUE:
+    return Http::FilterDataStatus::Continue;
+  case ENVOY_FILTER_DATA_STATUS_STOP_ITERATION_AND_BUFFER:
+    return Http::FilterDataStatus::StopIterationAndBuffer;
+  case ENVOY_FILTER_DATA_STATUS_STOP_ITERATION_NO_BUFFER:
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  default:
+    ASSERT(false, fmt::format("urecognized filter status from platform: {}", status));
+    return Http::FilterDataStatus::Continue;
+  }
+}
 
 PlatformBridgeFilterConfig::PlatformBridgeFilterConfig(
     const envoymobile::extensions::filters::http::platform_bridge::PlatformBridge& proto_config)
@@ -47,15 +62,39 @@ Http::FilterHeadersStatus PlatformBridgeFilter::onHeaders(Http::HeaderMap& heade
   return status;
 }
 
+Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool end_stream,
+                                                    envoy_filter_on_data_f on_data) {
+  // Allow nullptr to act as (optimized) no-op.
+  if (on_data == nullptr) {
+    return Http::FilterDataStatus::Continue;
+  }
+
+  envoy_data in_data = Buffer::Utility::toBridgeData(data);
+  envoy_filter_data_status result =
+      on_data(in_data, end_stream, platform_filter_->context);
+  Http::FilterDataStatus status = mapStatus(result.status);
+  // Current platform implementations expose immutable data, thus any modification necessitates a
+  // full copy. If the returned buffer is identical, we assume no modification was made and elide
+  // the copy here. See also https://github.com/lyft/envoy-mobile/issues/949 for potential future
+  // optimization.
+  if (in_data.bytes != result.data.bytes) {
+    data.drain(data.length());
+    data.addBufferFragment(*Buffer::BridgeFragment::createBridgeFragment(result.data));
+  }
+
+  return status;
+}
+
 Http::FilterHeadersStatus PlatformBridgeFilter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                               bool end_stream) {
   // Delegate to shared implementation for request and response path.
   return onHeaders(headers, end_stream, platform_filter_->on_request_headers);
 }
 
-Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& /*data*/,
-                                                        bool /*end_stream*/) {
-  return Http::FilterDataStatus::Continue;
+Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data,
+                                                        bool end_stream) {
+  // Delegate to shared implementation for request and response path.
+  return onData(data, end_stream, platform_filter_->on_request_data);
 }
 
 Http::FilterTrailersStatus
@@ -78,9 +117,10 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
   return onHeaders(headers, end_stream, platform_filter_->on_response_headers);
 }
 
-Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& /*data*/,
-                                                        bool /*end_stream*/) {
-  return Http::FilterDataStatus::Continue;
+Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data,
+                                                        bool end_stream) {
+  // Delegate to shared implementation for request and response path.
+  return onData(data, end_stream, platform_filter_->on_response_data);
 }
 
 Http::FilterTrailersStatus

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -50,6 +50,8 @@ public:
 private:
   Http::FilterHeadersStatus onHeaders(Http::HeaderMap& headers, bool end_stream,
                                       envoy_filter_on_headers_f on_headers);
+  Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream,
+                                envoy_filter_on_data_f on_data);
   const envoy_http_filter* platform_filter_;
 };
 


### PR DESCRIPTION
Description: Add initial support for HTTP body data chunks to be bridged to platform filter invocations.
Risk Level: Moderate
Testing: Local

Signed-off-by: Mike Schore <mike.schore@gmail.com>
