### PR TITLE
filters: instantiate filters on a per-stream basis

### DIFF
--- a/examples/swift/hello_world/DemoFilter.swift
+++ b/examples/swift/hello_world/DemoFilter.swift
@@ -3,7 +3,7 @@ import Foundation
 
 struct DemoFilter: ResponseFilter {
   // TODO(goaway): Update once dynamic registration is in place.
-  let name = "PlatformStub"
+  static let name = "PlatformStub"
 
   func onResponseHeaders(_ headers: ResponseHeaders, endStream: Bool)
     -> FilterHeaderStatus<ResponseHeaders>

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -15,7 +15,7 @@ final class ViewController: UITableViewController {
     super.viewDidLoad()
     do {
       NSLog("starting Envoy...")
-      self.client = try StreamClientBuilder().addFilter(DemoFilter()).build()
+      self.client = try StreamClientBuilder().addFilter(DemoFilter.self).build()
     } catch let error {
       NSLog("starting Envoy failed: \(error)")
     }

--- a/library/common/extensions/filters/http/platform_bridge/BUILD
+++ b/library/common/extensions/filters/http/platform_bridge/BUILD
@@ -25,6 +25,7 @@ envoy_cc_library(
         "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//include/envoy/http:filter_interface",
+        "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )

--- a/library/common/extensions/filters/http/platform_bridge/c_types.h
+++ b/library/common/extensions/filters/http/platform_bridge/c_types.h
@@ -58,22 +58,34 @@ extern "C" { // function pointers
 #endif
 
 /**
+ * Function signature for filter factory. Implementations must return a instance_context
+ * capable of dispatching envoy_http_filter calls (below) to a platform filter instance.
+ */
+typedef const void* (*envoy_filter_init_f)(const void *context);
+
+/**
  * Function signature for on-headers filter invocations.
  */
 typedef envoy_filter_headers_status (*envoy_filter_on_headers_f)(envoy_headers headers,
-                                                                 bool end_stream, void* context);
+                                                                 bool end_stream,
+                                                                 const void* context);
 
 /**
  * Function signature for on-data filter invocations.
  */
 typedef envoy_filter_data_status (*envoy_filter_on_data_f)(envoy_data data, bool end_stream,
-                                                           void* context);
+                                                           const void* context);
 
 /**
  * Function signature for on-trailers filter invocations.
  */
 typedef envoy_filter_trailers_status (*envoy_filter_on_trailers_f)(envoy_headers trailers,
-                                                                   void* context);
+                                                                   const void* context);
+
+/**
+ * Function signature to release a filter instance once the filter chain is finished with it.
+ */
+typedef void (*envoy_filter_release_f)(const void *context);
 
 #ifdef __cplusplus
 } // function pointers
@@ -84,11 +96,14 @@ typedef envoy_filter_trailers_status (*envoy_filter_on_trailers_f)(envoy_headers
  * PlatformBridgeFilter.
  */
 typedef struct {
+  envoy_filter_init_f init_filter;
   envoy_filter_on_headers_f on_request_headers;
   envoy_filter_on_data_f on_request_data;
   envoy_filter_on_trailers_f on_request_trailers;
   envoy_filter_on_headers_f on_response_headers;
   envoy_filter_on_data_f on_response_data;
   envoy_filter_on_trailers_f on_response_trailers;
-  void* context;
+  envoy_filter_release_f release_filter;
+  const void* static_context;
+  const void* instance_context;
 } envoy_http_filter;

--- a/library/common/extensions/filters/http/platform_bridge/c_types.h
+++ b/library/common/extensions/filters/http/platform_bridge/c_types.h
@@ -61,7 +61,7 @@ extern "C" { // function pointers
  * Function signature for filter factory. Implementations must return a instance_context
  * capable of dispatching envoy_http_filter calls (below) to a platform filter instance.
  */
-typedef const void* (*envoy_filter_init_f)(const void *context);
+typedef const void* (*envoy_filter_init_f)(const void* context);
 
 /**
  * Function signature for on-headers filter invocations.
@@ -85,7 +85,7 @@ typedef envoy_filter_trailers_status (*envoy_filter_on_trailers_f)(envoy_headers
 /**
  * Function signature to release a filter instance once the filter chain is finished with it.
  */
-typedef void (*envoy_filter_release_f)(const void *context);
+typedef void (*envoy_filter_release_f)(const void* context);
 
 #ifdef __cplusplus
 } // function pointers

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -28,7 +28,7 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
 }
 
 void PlatformBridgeFilter::onDestroy() {
-  ASSERT(platform_filter_.instance_context, "init_filter must be called initially");
+  ASSERT(platform_filter_.instance_context, "expected initialized filter context");
 
   platform_filter_.release_filter(platform_filter_.instance_context);
   platform_filter_.instance_context = nullptr;
@@ -36,7 +36,7 @@ void PlatformBridgeFilter::onDestroy() {
 
 Http::FilterHeadersStatus PlatformBridgeFilter::onHeaders(Http::HeaderMap& headers, bool end_stream,
                                                           envoy_filter_on_headers_f on_headers) {
-  ASSERT(platform_filter_.instance_context, "init_filter must be called initially");
+  ASSERT(platform_filter_.instance_context, "expected initialized filter context");
 
   // Allow nullptr to act as (optimized) no-op.
   if (on_headers == nullptr) {

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -2,6 +2,8 @@
 
 #include "envoy/http/filter.h"
 
+#include "common/common/logger.h"
+
 #include "extensions/filters/http/common/pass_through_filter.h"
 
 #include "library/common/extensions/filters/http/platform_bridge/c_types.h"
@@ -17,9 +19,11 @@ public:
   PlatformBridgeFilterConfig(
       const envoymobile::extensions::filters::http::platform_bridge::PlatformBridge& proto_config);
 
+  const std::string& filter_name() { return filter_name_; }
   const envoy_http_filter* platform_filter() const { return platform_filter_; }
 
 private:
+  const std::string filter_name_;
   const envoy_http_filter* platform_filter_;
 };
 
@@ -28,7 +32,8 @@ typedef std::shared_ptr<PlatformBridgeFilterConfig> PlatformBridgeFilterConfigSh
 /**
  * Harness to bridge Envoy filter invocations up to the platform layer.
  */
-class PlatformBridgeFilter final : public Http::PassThroughFilter {
+class PlatformBridgeFilter final : public Http::PassThroughFilter,
+                                   Logger::Loggable<Logger::Id::filter> {
 public:
   PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr config);
 
@@ -55,6 +60,7 @@ private:
                                       envoy_filter_on_headers_f on_headers);
   Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream,
                                 envoy_filter_on_data_f on_data);
+  const std::string filter_name_;
   envoy_http_filter platform_filter_;
 };
 

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -32,6 +32,9 @@ class PlatformBridgeFilter final : public Http::PassThroughFilter {
 public:
   PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr config);
 
+  // StreamFilterBase
+  void onDestroy() override;
+
   // StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
                                           bool end_stream) override;
@@ -52,7 +55,7 @@ private:
                                       envoy_filter_on_headers_f on_headers);
   Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream,
                                 envoy_filter_on_data_f on_data);
-  const envoy_http_filter* platform_filter_;
+  envoy_http_filter platform_filter_;
 };
 
 } // namespace PlatformBridge

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -13,6 +13,7 @@ objc_library(
         "EnvoyEngineImpl.m",
         "EnvoyHTTPCallbacks.m",
         "EnvoyHTTPFilter.m",
+        "EnvoyHTTPFilterFactory.m",
         "EnvoyHTTPStreamImpl.m",
         "EnvoyNetworkMonitor.m",
     ],

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -9,7 +9,7 @@
                   dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
        dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
         dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
-                        filterChain:(NSArray<EnvoyHTTPFilter *> *)httpFilters
+                        filterChain:(NSArray<EnvoyHTTPFilterFactory *> *)httpFilterFactories
                   statsFlushSeconds:(UInt32)statsFlushSeconds
                          appVersion:(NSString *)appVersion
                               appId:(NSString *)appId
@@ -24,7 +24,7 @@
   self.dnsRefreshSeconds = dnsRefreshSeconds;
   self.dnsFailureRefreshSecondsBase = dnsFailureRefreshSecondsBase;
   self.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
-  self.httpFilters = httpFilters;
+  self.httpFilterFactories = httpFilterFactories;
   self.statsFlushSeconds = statsFlushSeconds;
   self.appVersion = appVersion;
   self.appId = appId;

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -68,11 +68,19 @@ extern const int kEnvoyFilterHeadersStatusStopAllIterationAndBuffer;
 
 @interface EnvoyHTTPFilter : NSObject
 
-@property (nonatomic, strong) NSString *name;
-
 @property (nonatomic, strong) NSArray * (^onRequestHeaders)(EnvoyHeaders *headers, BOOL endStream);
 
 @property (nonatomic, strong) NSArray * (^onResponseHeaders)(EnvoyHeaders *headers, BOOL endStream);
+
+@end
+
+#pragma mark - EnvoyHTTPFilterFactory
+
+@interface EnvoyHTTPFilterFactory : NSObject
+
+@property (nonatomic, strong) NSString *filterName;
+
+@property (nonatomic, strong) EnvoyHTTPFilter * (^create)();
 
 @end
 
@@ -143,7 +151,7 @@ extern const int kEnvoyFilterHeadersStatusStopAllIterationAndBuffer;
 @property (nonatomic, assign) UInt32 dnsRefreshSeconds;
 @property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsBase;
 @property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsMax;
-@property (nonatomic, strong) NSArray<EnvoyHTTPFilter *> *httpFilters;
+@property (nonatomic, strong) NSArray<EnvoyHTTPFilterFactory *> *httpFilterFactories;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
 @property (nonatomic, strong) NSString *appVersion;
 @property (nonatomic, strong) NSString *appId;
@@ -157,7 +165,7 @@ extern const int kEnvoyFilterHeadersStatusStopAllIterationAndBuffer;
                   dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
        dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
         dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
-                        filterChain:(NSArray<EnvoyHTTPFilter *> *)httpFilters
+                        filterChain:(NSArray<EnvoyHTTPFilterFactory *> *)httpFilterFactories
                   statsFlushSeconds:(UInt32)statsFlushSeconds
                          appVersion:(NSString *)appVersion
                               appId:(NSString *)appId

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -62,7 +62,7 @@ static envoy_headers toNativeHeaders(EnvoyHeaders *headers) {
   return (envoy_headers){length, header_array};
 }
 
-static const void* ios_http_filter_init(const void *context) {
+static const void *ios_http_filter_init(const void *context) {
   EnvoyHTTPFilterFactory *filterFactory = (__bridge EnvoyHTTPFilterFactory *)context;
   EnvoyHTTPFilter *filter = filterFactory.create();
   return CFBridgingRetain(filter);

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -11,10 +11,6 @@ static void ios_on_exit() {
   NSLog(@"[Envoy] library is exiting");
 }
 
-typedef struct {
-  __unsafe_unretained EnvoyHTTPFilter *filter;
-} ios_http_filter_context;
-
 // TODO(goaway): The mapping code below contains a great deal of duplication from
 // EnvoyHTTPStreamImpl.m, however retain/release semantics are slightly different and need to be
 // reconciled before this can be factored into a generic set of utility functions.
@@ -66,11 +62,17 @@ static envoy_headers toNativeHeaders(EnvoyHeaders *headers) {
   return (envoy_headers){length, header_array};
 }
 
+static const void* ios_http_filter_init(const void *context) {
+  EnvoyHTTPFilterFactory *filterFactory = (__bridge EnvoyHTTPFilterFactory *)context;
+  EnvoyHTTPFilter *filter = filterFactory.create();
+  return CFBridgingRetain(filter);
+}
+
 static envoy_filter_headers_status
-ios_http_filter_on_request_headers(envoy_headers headers, bool end_stream, void *context) {
+ios_http_filter_on_request_headers(envoy_headers headers, bool end_stream, const void *context) {
   // TODO(goaway): optimize unmodified case
-  ios_http_filter_context *c = (ios_http_filter_context *)context;
-  if (c->filter.onRequestHeaders == nil) {
+  EnvoyHTTPFilter *filter = (__bridge EnvoyHTTPFilter *)context;
+  if (filter.onRequestHeaders == nil) {
     return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusContinue,
                                          /*headers*/ headers};
   }
@@ -78,16 +80,16 @@ ios_http_filter_on_request_headers(envoy_headers headers, bool end_stream, void 
   EnvoyHeaders *platformHeaders = to_ios_headers(headers);
   release_envoy_headers(headers);
   // TODO(goaway): consider better solution for compound return
-  NSArray *result = c->filter.onRequestHeaders(platformHeaders, end_stream);
+  NSArray *result = filter.onRequestHeaders(platformHeaders, end_stream);
   return (envoy_filter_headers_status){/*status*/ [result[0] intValue],
                                        /*headers*/ toNativeHeaders(result[1])};
 }
 
 static envoy_filter_headers_status
-ios_http_filter_on_response_headers(envoy_headers headers, bool end_stream, void *context) {
+ios_http_filter_on_response_headers(envoy_headers headers, bool end_stream, const void *context) {
   // TODO(goaway): optimize unmodified case
-  ios_http_filter_context *c = (ios_http_filter_context *)context;
-  if (c->filter.onResponseHeaders == nil) {
+  EnvoyHTTPFilter *filter = (__bridge EnvoyHTTPFilter *)context;
+  if (filter.onResponseHeaders == nil) {
     return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusContinue,
                                          /*headers*/ headers};
   }
@@ -95,9 +97,14 @@ ios_http_filter_on_response_headers(envoy_headers headers, bool end_stream, void
   EnvoyHeaders *platformHeaders = to_ios_headers(headers);
   release_envoy_headers(headers);
   // TODO(goaway): consider better solution for compound return
-  NSArray *result = c->filter.onResponseHeaders(platformHeaders, end_stream);
+  NSArray *result = filter.onResponseHeaders(platformHeaders, end_stream);
   return (envoy_filter_headers_status){/*status*/ [result[0] intValue],
                                        /*headers*/ toNativeHeaders(result[1])};
+}
+
+static void ios_http_filter_release(const void *context) {
+  CFRelease(context);
+  return;
 }
 
 @implementation EnvoyEngineImpl {
@@ -119,19 +126,20 @@ ios_http_filter_on_response_headers(envoy_headers headers, bool end_stream, void
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (int)registerFilter:(EnvoyHTTPFilter *)filter {
+- (int)registerFilterFactory:(EnvoyHTTPFilterFactory *)filterFactory {
   // TODO(goaway): Everything here leaks, but it's all be tied to the life of the engine.
   // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332
-  ios_http_filter_context *context = safe_malloc(sizeof(ios_http_filter_context));
-  CFBridgingRetain(filter);
-  context->filter = filter;
   envoy_http_filter *api = safe_malloc(sizeof(envoy_http_filter));
+  api->init_filter = ios_http_filter_init;
   api->on_request_headers = ios_http_filter_on_request_headers;
   api->on_request_data = NULL;
   api->on_response_headers = ios_http_filter_on_response_headers;
   api->on_response_data = NULL;
-  api->context = context;
-  register_platform_api(filter.name.UTF8String, api);
+  api->release_filter = ios_http_filter_release;
+  api->static_context = CFBridgingRetain(filterFactory);
+  api->instance_context = NULL;
+
+  register_platform_api(filterFactory.filterName.UTF8String, api);
   return kEnvoySuccess;
 }
 
@@ -142,8 +150,8 @@ ios_http_filter_on_response_headers(envoy_headers headers, bool end_stream, void
     return kEnvoyFailure;
   }
 
-  for (EnvoyHTTPFilter *filter in config.httpFilters) {
-    [self registerFilter:filter];
+  for (EnvoyHTTPFilterFactory *filterFactory in config.httpFilterFactories) {
+    [self registerFilterFactory:filterFactory];
   }
 
   return [self runWithConfigYAML:resolvedYAML logLevel:logLevel];

--- a/library/objective-c/EnvoyHTTPFilterFactory.m
+++ b/library/objective-c/EnvoyHTTPFilterFactory.m
@@ -1,0 +1,4 @@
+#import "library/objective-c/EnvoyEngine.h"
+
+@implementation EnvoyHTTPFilterFactory
+@end

--- a/library/swift/src/StreamClientBuilder.swift
+++ b/library/swift/src/StreamClientBuilder.swift
@@ -21,7 +21,7 @@ public final class StreamClientBuilder: NSObject {
   private var statsFlushSeconds: UInt32 = 60
   private var appVersion: String = "unspecified"
   private var appId: String = "unspecified"
-  private var filterChain: [EnvoyHTTPFilter] = []
+  private var filterChain: [EnvoyHTTPFilterFactory] = []
   private var virtualClusters: String = "[]"
 
   // MARK: - Public
@@ -117,9 +117,8 @@ public final class StreamClientBuilder: NSObject {
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addFilter(_ filter: Filter) -> StreamClientBuilder {
-    // TODO(goaway): Update types here for per-stream instances.
-    self.filterChain.append(EnvoyHTTPFilter(filter: filter))
+  public func addFilter(_ filterType: Filter.Type) -> StreamClientBuilder {
+    self.filterChain.append(EnvoyHTTPFilterFactory(filterType: filterType))
     return self
   }
 

--- a/library/swift/src/filters/Filter.swift
+++ b/library/swift/src/filters/Filter.swift
@@ -4,14 +4,33 @@ import Foundation
 /// Interface representing a filter. See `RequestFilter` and `ResponseFilter` for more details.
 public protocol Filter {
   /// A unique name for a filter implementation. Needed for extension registration.
-  var name: String { get }
+  static var name: String { get }
+
+  /// Required initializer for internal creation.
+  init()
+}
+
+extension Filter {
+  static func create() -> EnvoyHTTPFilter {
+    return EnvoyHTTPFilter(filter: Self.init())
+  }
+}
+
+extension EnvoyHTTPFilterFactory {
+  convenience init(filterType: Filter.Type) {
+    self.init()
+
+    self.filterName = filterType.name
+    self.create = {
+      return filterType.create()
+    }
+  }
 }
 
 extension EnvoyHTTPFilter {
   /// Initialize an EnvoyHTTPFilter using the instance methods of a concrete Filter implementation.
   convenience init(filter: Filter) {
     self.init()
-    self.name = filter.name
 
     if let requestFilter = filter as? RequestFilter {
       self.onRequestHeaders = { envoyHeaders, endStream in

--- a/library/swift/src/filters/Filter.swift
+++ b/library/swift/src/filters/Filter.swift
@@ -10,19 +10,13 @@ public protocol Filter {
   init()
 }
 
-extension Filter {
-  static func create() -> EnvoyHTTPFilter {
-    return EnvoyHTTPFilter(filter: Self.init())
-  }
-}
-
 extension EnvoyHTTPFilterFactory {
   convenience init(filterType: Filter.Type) {
     self.init()
 
     self.filterName = filterType.name
     self.create = {
-      return filterType.create()
+      return EnvoyHTTPFilter(filter: filterType.init())
     }
   }
 }


### PR DESCRIPTION
Description: Changes filter instantiation to be a per-stream basis, across the core, bridge, and iOS platform layers. Also improves usage of CFBridge* functions to be better in line with their intent.
Risk Level: Moderate
Testing: Local end-to-end
