### PR TITLE
android: clean up sonatype upload to support local deploy

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -47,11 +47,15 @@ genrule(
     name = "android_dist",
     srcs = [
         "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_aar",
+        "//library/kotlin/src/io/envoyproxy/envoymobile:envoy_aar_pom_xml",
     ],
     outs = ["output_in_dist_directory"],
     cmd = """
-    chmod 755 $<
-    cp $< dist/envoy.aar
+    set -- $(SRCS)
+    chmod 755 $$1
+    chmod 755 $$2
+    cp $$1 dist/envoy.aar
+    cp $$2 dist/envoy-pom.xml
     touch $@
     """,
     stamp = True,

--- a/bazel/android_artifacts.bzl
+++ b/bazel/android_artifacts.bzl
@@ -55,7 +55,7 @@ def android_artifacts(name, android_library, manifest, archive_name, native_deps
 
     # Generate other needed files for a maven publish
     _sources_name, _javadocs_name = _create_sources_javadocs(name, android_library)
-    _pom_name = _create_pom_xml(name, android_library)
+    _pom_name = _create_pom_xml(name, android_library, visibility)
     native.genrule(
         name = name + "_with_artifacts",
         srcs = [
@@ -281,19 +281,20 @@ def _create_sources_javadocs(name, android_library):
 
     return _sources_name, _javadocs_name
 
-def _create_pom_xml(name, android_library):
+def _create_pom_xml(name, android_library, visibility):
     """
     Creates a pom xml associated with the android_library target.
 
     :param name The name of the top level macro.
     :param android_library The android library to generate a pom xml for.
     """
-    _pom_name = name + "_envoy_pom_xml"
+    _pom_name = name + "_pom_xml"
 
     # This is for the pom xml. It has a public visibility since this can be accessed in the root BUILD file
     pom_file(
         name = _pom_name,
         targets = [android_library],
+        visibility = visibility,
         template_file = "@envoy_mobile//bazel:pom_template.xml",
     )
 

--- a/dist/sonatype_nexus_upload.py
+++ b/dist/sonatype_nexus_upload.py
@@ -70,6 +70,7 @@ def _install_locally(version, files):
         )
 
         shutil.copyfile(file, os.path.join(path, basename))
+        print("{file_name}\n{sha}\n".format(file_name=file, sha=_sha256(file)))
 
 
 def _urlopen_retried(request, max_retries=500, attempt=1, delay_sec=1):

--- a/dist/sonatype_nexus_upload.py
+++ b/dist/sonatype_nexus_upload.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import base64
 import hashlib
@@ -23,7 +21,9 @@ BASE64_ENCODED_CREDENTIALS = base64.b64encode("{}:{}".format(_USER_CREDS, _KEY_C
 _ARTIFACT_HOST_URL = "https://oss.sonatype.org/service/local/staging"
 _GROUP_ID = "io.envoyproxy.envoymobile"
 _ARTIFACT_ID = "envoy"
-_LOCAL_INSTALL_PATH = os.path.expanduser("~/.m2/repository/io/envoyproxy/envoymobile/{}".format(_ARTIFACT_ID))
+_LOCAL_INSTALL_PATH = os.path.expanduser("~/.m2/repository/{directory}/envoy".format(
+    directory=_GROUP_ID.replace(".", "/"),
+    artifact_id=_ARTIFACT_ID))
 
 
 def _resolve_name(file):
@@ -94,13 +94,11 @@ def _urlopen_retried(request, max_retries=500, attempt=1, delay_sec=1):
                     max_retries=max_retries,
                     delay=delay_sec,
                     code=e.code
-                ),
-                file=sys.stderr)
+                ))
             time.sleep(delay_sec)
             return _urlopen_retried(request, max_retries, attempt + 1)
         elif max_retries <= attempt:
-            print("Retry limit reached. Will not continue to retry. Received error code {}".format(e.code),
-                  file=sys.stderr)
+            print("Retry limit reached. Will not continue to retry. Received error code {}".format(e.code))
             raise e
         else:
             raise e
@@ -122,7 +120,7 @@ def _create_staging_repository(profile_id):
 
         response = json.load(_urlopen_retried(request))
         staging_id = response["data"]["stagedRepositoryId"]
-        print("staging id {} was created".format(staging_id), file=sys.stderr)
+        print("staging id {} was created".format(staging_id))
         return staging_id
     except Exception as e:
         raise e
@@ -259,7 +257,7 @@ def _sha256(file_name):
 
 def _build_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--profile_id", required=True,
+    parser.add_argument("--profile_id", required=False,
                         help="""
                         The staging profile id of the sonatype repository target.
                         This is the id in the sonatype web ui. The REST api is:
@@ -287,7 +285,7 @@ def _build_parser():
                             dist/envoy-sources.jar
                             dist/envoy-javadoc.jar
                         """)
-    parser.add_argument("--signed_files", nargs="+", required=True,
+    parser.add_argument("--signed_files", nargs="+", required=False,
                         help="""
                         Files to upload.
                         Sonatype requires uploaded artifacts to be gpg signed
@@ -337,11 +335,10 @@ if __name__ == "__main__":
         except Exception as e:
             print(e)
 
-            print("Unable to complete file upload. Will attempt to drop staging id: [{}]".format(staging_id),
-                  file=sys.stderr)
+            print("Unable to complete file upload. Will attempt to drop staging id: [{}]".format(staging_id))
             try:
                 _drop_staging_repository(staging_id, "droppng release due to error")
                 sys.exit("Dropping staging id: [{}] successful.".format(staging_id))
             except Exception as e:
-                print(e, file=sys.stderr)
+                print(e)
                 sys.exit("Dropping staging id: [{}] failed.".format(staging_id))

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -128,3 +128,24 @@ and include the following in the WORKSPACE file::
     # Relative paths are also supported.
     path = "/somewhere/on/filesystem/envoy_build_config",
   )
+
+------------------------------
+Deploying Envoy Mobile Locally
+------------------------------
+
+~~~~~~~
+Android
+~~~~~~~
+
+To deploy Envoy Mobile's aar to your local maven repository, run the following command:
+```
+
+dist/sonatype_nexus_upload.py --files dist/envoy.aar dist/envoy_pom.xml --local
+```
+
+The version deployed will be `LOCAL-SNAPSHOT`. These artifacts will be
+
+~~~
+iOS
+~~~
+TODO

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -151,4 +151,4 @@ The version deployed will be ``LOCAL-SNAPSHOT``. These artifacts will be
 ~~~
 iOS
 ~~~
-TODO
+TODO :issue:`#980 <980>`

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -137,13 +137,16 @@ Deploying Envoy Mobile Locally
 Android
 ~~~~~~~
 
-To deploy Envoy Mobile's aar to your local maven repository, run the following command:
-```
+To deploy Envoy Mobile's aar to your local maven repository, run the following commands::
 
-dist/sonatype_nexus_upload.py --files dist/envoy.aar dist/envoy_pom.xml --local
-```
+    # To build Envoy Mobile
+    bazelisk build android_dist --config=android --fat_apk_cpu=x86
 
-The version deployed will be `LOCAL-SNAPSHOT`. These artifacts will be
+    # To publish to local maven
+    dist/sonatype_nexus_upload.py --files dist/envoy.aar dist/envoy_pom.xml --local
+
+
+The version deployed will be ``LOCAL-SNAPSHOT``. These artifacts will be
 
 ~~~
 iOS

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -146,7 +146,7 @@ To deploy Envoy Mobile's aar to your local maven repository, run the following c
     dist/sonatype_nexus_upload.py --files dist/envoy.aar dist/envoy-pom.xml --local
 
 
-The version deployed will be ``LOCAL-SNAPSHOT``. These artifacts will be
+The version deployed will be ``LOCAL-SNAPSHOT``. These artifacts can be found in your local maven directory (``~/.m2/repository/io/envoyproxy/envoymobile/envoy/LOCAL-SNAPSHOT/``)
 
 ~~~
 iOS

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -139,11 +139,11 @@ Android
 
 To deploy Envoy Mobile's aar to your local maven repository, run the following commands::
 
-    # To build Envoy Mobile
+    # To build Envoy Mobile. --fat_apk_cpu takes in a list of architectures: [x86|armeabi-v7a|arm64-v8a].
     bazelisk build android_dist --config=android --fat_apk_cpu=x86
 
-    # To publish to local maven
-    dist/sonatype_nexus_upload.py --files dist/envoy.aar dist/envoy_pom.xml --local
+    # To publish to local maven.
+    dist/sonatype_nexus_upload.py --files dist/envoy.aar dist/envoy-pom.xml --local
 
 
 The version deployed will be ``LOCAL-SNAPSHOT``. These artifacts will be


### PR DESCRIPTION
Cleaning up the sonatype upload script to enable easier local deployment. The change here is just to remove some required fields in the local publish case.


Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: clean up sonatype upload to support local deploy 
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
