### PR TITLE
filters: wire trailers at core layer

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/c_types.cc
+++ b/library/common/extensions/filters/http/platform_bridge/c_types.cc
@@ -20,3 +20,8 @@ const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationAndBuffer =
     static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatus::StopIterationAndBuffer);
 const envoy_filter_data_status_t kEnvoyFilterDataStatusStopIterationNoBuffer =
     static_cast<envoy_filter_data_status_t>(Envoy::Http::FilterDataStatus::StopIterationNoBuffer);
+
+const envoy_filter_trailers_status_t kEnvoyFilterTrailersStatusContinue =
+    static_cast<envoy_filter_trailers_status_t>(Envoy::Http::FilterTrailersStatus::Continue);
+const envoy_filter_trailers_status_t kEnvoyFilterTrailersStatusStopIteration =
+    static_cast<envoy_filter_trailers_status_t>(Envoy::Http::FilterTrailersStatus::StopIteration);

--- a/library/common/extensions/filters/http/platform_bridge/c_types.h
+++ b/library/common/extensions/filters/http/platform_bridge/c_types.h
@@ -40,10 +40,9 @@ typedef struct {
 /**
  * Return codes for on-trailers filter invocations. @see envoy/http/filter.h
  */
-typedef enum {
-  ENVOY_FILTER_TRAILERS_STATUS_CONTINUE = 0,
-  ENVOY_FILTER_TRAILERS_STATUS_STOP_ITERATION,
-} envoy_filter_trailers_status_t;
+typedef int envoy_filter_trailers_status_t;
+extern const envoy_filter_trailers_status_t kEnvoyFilterTrailersStatusContinue;
+extern const envoy_filter_trailers_status_t kEnvoyFilterTrailersStatusStopIteration;
 
 /**
  * Compound return type for on-trailers filter invocations.

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -99,16 +99,16 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
   return status;
 }
 
-Http::FilterTrailersStatus PlatformBridgeFilter::onTrailers(Http::HeaderMap& trailers,
-                                                          envoy_filter_on_trailers_f on_trailers) {
+Http::FilterTrailersStatus
+PlatformBridgeFilter::onTrailers(Http::HeaderMap& trailers,
+                                 envoy_filter_on_trailers_f on_trailers) {
   // Allow nullptr to act as no-op.
   if (on_trailers == nullptr) {
     return Http::FilterTrailersStatus::Continue;
   }
 
   envoy_headers in_trailers = Http::Utility::toBridgeHeaders(trailers);
-  envoy_filter_trailers_status result =
-      on_trailers(in_trailers, platform_filter_.instance_context);
+  envoy_filter_trailers_status result = on_trailers(in_trailers, platform_filter_.instance_context);
   Http::FilterTrailersStatus status = static_cast<Http::FilterTrailersStatus>(result.status);
   // TODO(goaway): Current platform implementations expose immutable trailers, thus any modification
   // necessitates a full copy. Add 'modified' bit to determine when we can elide the copy. See also
@@ -135,8 +135,7 @@ Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, 
   return onData(data, end_stream, platform_filter_.on_request_data);
 }
 
-Http::FilterTrailersStatus
-PlatformBridgeFilter::decodeTrailers(Http::RequestTrailerMap& trailers) {
+Http::FilterTrailersStatus PlatformBridgeFilter::decodeTrailers(Http::RequestTrailerMap& trailers) {
   // Delegate to shared implementation for request and response path.
   return onTrailers(trailers, platform_filter_.on_request_trailers);
 }

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -99,6 +99,31 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
   return status;
 }
 
+Http::FilterTrailersStatus PlatformBridgeFilter::onTrailers(Http::HeaderMap& trailers,
+                                                          envoy_filter_on_trailers_f on_trailers) {
+  // Allow nullptr to act as no-op.
+  if (on_trailers == nullptr) {
+    return Http::FilterTrailersStatus::Continue;
+  }
+
+  envoy_headers in_trailers = Http::Utility::toBridgeHeaders(trailers);
+  envoy_filter_trailers_status result =
+      on_trailers(in_trailers, platform_filter_.instance_context);
+  Http::FilterTrailersStatus status = static_cast<Http::FilterTrailersStatus>(result.status);
+  // TODO(goaway): Current platform implementations expose immutable trailers, thus any modification
+  // necessitates a full copy. Add 'modified' bit to determine when we can elide the copy. See also
+  // https://github.com/lyft/envoy-mobile/issues/949 for potential future optimization.
+  trailers.clear();
+  for (envoy_header_size_t i = 0; i < result.trailers.length; i++) {
+    trailers.addCopy(
+        Http::LowerCaseString(Http::Utility::convertToString(result.trailers.headers[i].key)),
+        Http::Utility::convertToString(result.trailers.headers[i].value));
+  }
+  // The C envoy_trailers struct can be released now because the trailers have been copied.
+  release_envoy_headers(result.trailers);
+  return status;
+}
+
 Http::FilterHeadersStatus PlatformBridgeFilter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                               bool end_stream) {
   // Delegate to shared implementation for request and response path.
@@ -111,8 +136,9 @@ Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, 
 }
 
 Http::FilterTrailersStatus
-PlatformBridgeFilter::decodeTrailers(Http::RequestTrailerMap& /*trailers*/) {
-  return Http::FilterTrailersStatus::Continue;
+PlatformBridgeFilter::decodeTrailers(Http::RequestTrailerMap& trailers) {
+  // Delegate to shared implementation for request and response path.
+  return onTrailers(trailers, platform_filter_.on_request_trailers);
 }
 
 Http::FilterMetadataStatus PlatformBridgeFilter::decodeMetadata(Http::MetadataMap& /*metadata*/) {
@@ -136,8 +162,9 @@ Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, 
 }
 
 Http::FilterTrailersStatus
-PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& /*trailers*/) {
-  return Http::FilterTrailersStatus::Continue;
+PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
+  // Delegate to shared implementation for request and response path.
+  return onTrailers(trailers, platform_filter_.on_response_trailers);
 }
 
 Http::FilterMetadataStatus PlatformBridgeFilter::encodeMetadata(Http::MetadataMap& /*metadata*/) {

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -60,6 +60,8 @@ private:
                                       envoy_filter_on_headers_f on_headers);
   Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream,
                                 envoy_filter_on_data_f on_data);
+  Http::FilterTrailersStatus onTrailers(Http::HeaderMap& trailers,
+                                        envoy_filter_on_trailers_f on_trailers);
   const std::string filter_name_;
   envoy_http_filter platform_filter_;
 };


### PR DESCRIPTION
Description: Adds remaining wiring in the PlatformBridgeFilter necessary for trailers invocations.
Risk: Moderate
Testing: Local

Signed-off-by: Mike Schore <mike.schore@gmail.com>