### PR TITLE
bazel: android aar bazel rule fix to output envoy.aar

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -51,7 +51,7 @@ genrule(
     outs = ["output_in_dist_directory"],
     cmd = """
     chmod 755 $<
-    cp $< dist/
+    cp $< dist/envoy.aar
     touch $@
     """,
     stamp = True,


### PR DESCRIPTION
We previously outputted `dist/envoy_local.aar` for `bazelisk build android_dist`. This change it is to appropriately name the output to `dist/envoy.aar`

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: bazel: android aar bazel rule fix to output envoy.aar
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
