### PR TITLE
Swift: Workaround Swift 5.2 + 5.3 swiftinterface bug

### DIFF
--- a/library/swift/src/HeadersBuilder.swift
+++ b/library/swift/src/HeadersBuilder.swift
@@ -73,6 +73,13 @@ public class HeadersBuilder: NSObject {
     return self
   }
 
+  // Only explicitly implemented to work around a swiftinterface issue in Swift 5.1. This can be
+  // removed once envoy is only built with Swift 5.2+
+  public override init() {
+    self.headers = [:]
+    super.init()
+  }
+
   /// Initialize a new builder. Subclasses should provide their own public convenience initializers.
   ///
   /// - parameter headers: The headers with which to start.

--- a/library/swift/src/RequestTrailersBuilder.swift
+++ b/library/swift/src/RequestTrailersBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 @objcMembers
 public final class RequestTrailersBuilder: HeadersBuilder {
   /// Initialize a new instance of the builder.
-  public convenience init() {
+  public override convenience init() {
     self.init(headers: [:])
   }
 

--- a/library/swift/src/ResponseHeadersBuilder.swift
+++ b/library/swift/src/ResponseHeadersBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 @objcMembers
 public final class ResponseHeadersBuilder: HeadersBuilder {
   /// Initialize a new instance of the builder.
-  public convenience init() {
+  public override convenience init() {
     self.init(headers: [:])
   }
 

--- a/library/swift/src/ResponseTrailersBuilder.swift
+++ b/library/swift/src/ResponseTrailersBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 @objcMembers
 public final class ResponseTrailersBuilder: HeadersBuilder {
   /// Initialize a new instance of the builder.
-  public convenience init() {
+  public override convenience init() {
     self.init(headers: [:])
   }
 

--- a/library/swift/src/mocks/MockStreamClient.swift
+++ b/library/swift/src/mocks/MockStreamClient.swift
@@ -9,6 +9,13 @@ public final class MockStreamClient: NSObject {
   /// Typically, this is used to capture streams on creation before sending values through them.
   public var onStartStream: ((MockStream) -> Void)?
 
+  // Only explicitly implemented to work around a swiftinterface issue in Swift 5.1. This can be
+  // removed once envoy is only built with Swift 5.2+
+  public override init() {
+    self.onStartStream = nil
+    super.init()
+  }
+
   /// Initialize a new instance of the stream client.
   ///
   /// - parameter onStartStream: Closure that may be set to observe the creation of new streams.


### PR DESCRIPTION
With envoy-mobile built from Xcode 11.5, we are unable to consume it
with Xcode 12.0 beta 3. I'm hoping this fixes it, the errors appear
related:

```
deps/cache/dependencies/Envoy/current/Envoy.framework/Modules/Envoy.swiftmodule/x86_64.swiftinterface:137:28: error: overriding declaration requires an 'override' keyword
  @objc convenience public init()
                           ^
                           override
deps/cache/dependencies/Envoy/current/Envoy.framework/Modules/Envoy.swiftmodule/x86_64.swiftinterface:38:33: note: overridden declaration is here
  @objc override dynamic public init()
                                ^
Modules/EnvoyFilters/Sources/EnvoyFilterManager.swift:1:8: error: failed to build module 'Envoy' from its module interface; the compiler that produced it, 'Apple Swift version 5.2.4 (swiftlang-1103.0.32.9 clang-1103.0.32.53)', may have used features that aren't supported by this compiler, 'Apple Swift version 5.3 (swiftlang-1200.0.22.4 clang-1200.0.25.1)'
import Envoy
       ^
```

This reverts commit 29d32d8f9215ec3420442667faad333d8794a4bf.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>