### PR TITLE
jni: move to dedicated path

### DIFF
--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
 
 licenses(["notice"])  # Apache 2
@@ -38,19 +37,4 @@ envoy_cc_library(
         "@envoy//source/exe:envoy_common_lib",
         "@envoy//source/exe:envoy_main_common_lib",
     ],
-)
-
-cc_binary(
-    name = "libenvoy_jni.so",
-    srcs = [
-        "jni_interface.cc",
-    ],
-    copts = ["-std=c++17"],
-    linkopts = [
-        "-lm",
-        "-llog",
-        "-Wl,-s",
-    ],
-    linkshared = True,
-    deps = [":envoy_main_interface_lib"],
 )

--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 
 licenses(["notice"])  # Apache 2
 

--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -1,0 +1,21 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+cc_binary(
+    name = "libenvoy_jni.so",
+    srcs = [
+        "jni_interface.cc",
+    ],
+    copts = ["-std=c++17"],
+    linkopts = [
+        "-lm",
+        "-llog",
+        "-Wl,-s",
+    ],
+    linkshared = True,
+    deps = ["//library/common:envoy_main_interface_lib"],
+)

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -4,7 +4,7 @@
 
 #include <string>
 
-#include "main_interface.h"
+#include "library/common/main_interface.h"
 
 static JavaVM* static_jvm = nullptr;
 static JNIEnv* static_env = nullptr;

--- a/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/BUILD
@@ -11,7 +11,7 @@ android_artifacts(
     archive_name = "envoy",
     manifest = "EnvoyManifest.xml",
     native_deps = [
-        "//library/common:libenvoy_jni.so",
+        "//library/common/jni:libenvoy_jni.so",
     ],
     proguard_rules = "//library:proguard_rules",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Description: Move JNI to dedicated directory ahead of Android filter PRs.

Signed-off-by: Mike Schore <mike.schore@gmail.com>
