### PR TITLE
filters: rework callbacks for shared signatures

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -146,6 +146,7 @@ static JNIEnv* get_env() {
 static void jvm_on_headers(envoy_headers headers, bool end_stream, void* context) {
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
+  pass_headers(env, headers, j_context);
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onHeaders = env->GetMethodID(jcls_JvmCallbackContext, "onHeaders", "(JZ)V");
@@ -155,7 +156,6 @@ static void jvm_on_headers(envoy_headers headers, bool end_stream, void* context
                       end_stream ? JNI_TRUE : JNI_FALSE);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
-  pass_headers(env, headers, j_context);
 }
 
 static void jvm_on_data(envoy_data data, bool end_stream, void* context) {
@@ -192,6 +192,7 @@ static void jvm_on_trailers(envoy_headers trailers, void* context) {
 
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
+  pass_headers(env, trailers, j_context);
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onTrailers = env->GetMethodID(jcls_JvmCallbackContext, "onTrailers", "(J)V");
@@ -200,7 +201,6 @@ static void jvm_on_trailers(envoy_headers trailers, void* context) {
   env->CallVoidMethod(j_context, jmid_onTrailers, (jlong)trailers.length);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
-  pass_headers(env, trailers, j_context);
 }
 
 static void jvm_on_error(envoy_error error, void* context) {

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -91,7 +91,7 @@ static void pass_headers(JNIEnv* env, envoy_headers headers, jobject j_context) 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_passHeader = env->GetMethodID(jcls_JvmCallbackContext, "passHeader", "([B[BZ)V");
   env->PushLocalFrame(headers.length * 2);
-  jboolean start_headers  = JNI_TRUE;
+  jboolean start_headers = JNI_TRUE;
 
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
     // Note this is just an initial implementation, and we will pass a more optimized structure in
@@ -152,7 +152,8 @@ static void* jvm_on_headers(envoy_headers headers, bool end_stream, void* contex
   pass_headers(env, headers, j_context);
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
-  jmethodID jmid_onHeaders = env->GetMethodID(jcls_JvmCallbackContext, "onHeaders", "(JZ)Ljava/lang/Object;");
+  jmethodID jmid_onHeaders =
+      env->GetMethodID(jcls_JvmCallbackContext, "onHeaders", "(JZ)Ljava/lang/Object;");
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
   jobject result = env->CallObjectMethod(j_context, jmid_onHeaders, (jlong)headers.length,
@@ -168,7 +169,8 @@ static void* jvm_on_data(envoy_data data, bool end_stream, void* context) {
   jobject j_context = static_cast<jobject>(context);
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
-  jmethodID jmid_onData = env->GetMethodID(jcls_JvmCallbackContext, "onData", "([BZ)Ljava/lang/Object;");
+  jmethodID jmid_onData =
+      env->GetMethodID(jcls_JvmCallbackContext, "onData", "([BZ)Ljava/lang/Object;");
 
   jbyteArray j_data = env->NewByteArray(data.length);
   // TODO: check if copied via isCopy.
@@ -202,7 +204,8 @@ static void* jvm_on_trailers(envoy_headers trailers, void* context) {
   pass_headers(env, trailers, j_context);
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
-  jmethodID jmid_onTrailers = env->GetMethodID(jcls_JvmCallbackContext, "onTrailers", "(J)Ljava/lang/Object;");
+  jmethodID jmid_onTrailers =
+      env->GetMethodID(jcls_JvmCallbackContext, "onTrailers", "(J)Ljava/lang/Object;");
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
   jobject result = env->CallObjectMethod(j_context, jmid_onTrailers, (jlong)trailers.length);
@@ -217,7 +220,8 @@ static void* jvm_on_error(envoy_error error, void* context) {
   jobject j_context = static_cast<jobject>(context);
 
   jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
-  jmethodID jmid_onError = env->GetMethodID(jcls_JvmObserverContext, "onError", "(I[BI)Ljava/lang/Object;");
+  jmethodID jmid_onError =
+      env->GetMethodID(jcls_JvmObserverContext, "onError", "(I[BI)Ljava/lang/Object;");
 
   jbyteArray j_error_message = env->NewByteArray(error.message.length);
   // TODO: check if copied via isCopy.
@@ -252,7 +256,8 @@ static void* jvm_on_cancel(void* context) {
   jobject j_context = static_cast<jobject>(context);
 
   jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
-  jmethodID jmid_onCancel = env->GetMethodID(jcls_JvmObserverContext, "onCancel", "()Ljava/lang/Object;");
+  jmethodID jmid_onCancel =
+      env->GetMethodID(jcls_JvmObserverContext, "onCancel", "()Ljava/lang/Object;");
   jobject result = env->CallObjectMethod(j_context, jmid_onCancel);
 
   // No further callbacks happen on this context. Delete the reference held by native code.

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -152,8 +152,8 @@ static void jvm_on_headers(envoy_headers headers, bool end_stream, void* context
   jmethodID jmid_onHeaders = env->GetMethodID(jcls_JvmCallbackContext, "onHeaders", "(JZ)V");
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
-  env->CallVoidMethod(j_context, jmid_onHeaders, (jlong)headers.length,
-                      end_stream ? JNI_TRUE : JNI_FALSE);
+  env->CallObjectMethod(j_context, jmid_onHeaders, (jlong)headers.length,
+                        end_stream ? JNI_TRUE : JNI_FALSE);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
 }
@@ -175,7 +175,7 @@ static void jvm_on_data(envoy_data data, bool end_stream, void* context) {
   // Here '0' (for which there is no named constant) indicates we want to commit the changes back
   // to the JVM and free the c array, where applicable.
   env->ReleasePrimitiveArrayCritical(j_data, critical_data, 0);
-  env->CallVoidMethod(j_context, jmid_onData, j_data, end_stream ? JNI_TRUE : JNI_FALSE);
+  env->CallObjectMethod(j_context, jmid_onData, j_data, end_stream ? JNI_TRUE : JNI_FALSE);
 
   data.release(data.context);
   env->DeleteLocalRef(j_data);
@@ -198,7 +198,7 @@ static void jvm_on_trailers(envoy_headers trailers, void* context) {
   jmethodID jmid_onTrailers = env->GetMethodID(jcls_JvmCallbackContext, "onTrailers", "(J)V");
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
-  env->CallVoidMethod(j_context, jmid_onTrailers, (jlong)trailers.length);
+  env->CallObjectMethod(j_context, jmid_onTrailers, (jlong)trailers.length);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
 }
@@ -221,8 +221,8 @@ static void jvm_on_error(envoy_error error, void* context) {
   // to the JVM and free the c array, where applicable.
   env->ReleasePrimitiveArrayCritical(j_error_message, critical_error_message, 0);
 
-  env->CallVoidMethod(j_context, jmid_onError, error.error_code, j_error_message,
-                      error.attempt_count);
+  env->CallObjectMethod(j_context, jmid_onError, error.error_code, j_error_message,
+                        error.attempt_count);
 
   error.message.release(error.message.context);
   // No further callbacks happen on this context. Delete the reference held by native code.
@@ -243,7 +243,7 @@ static void jvm_on_cancel(void* context) {
 
   jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
   jmethodID jmid_onCancel = env->GetMethodID(jcls_JvmObserverContext, "onCancel", "()V");
-  env->CallVoidMethod(j_context, jmid_onCancel);
+  env->CallObjectMethod(j_context, jmid_onCancel);
 
   // No further callbacks happen on this context. Delete the reference held by native code.
   env->DeleteGlobalRef(j_context);

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -176,8 +176,8 @@ static void* jvm_on_data(envoy_data data, bool end_stream, void* context) {
   // Here '0' (for which there is no named constant) indicates we want to commit the changes back
   // to the JVM and free the c array, where applicable.
   env->ReleasePrimitiveArrayCritical(j_data, critical_data, 0);
-  jobject result = env->CallObjectMethod(j_context, jmid_onData, j_data,
-                                         end_stream ? JNI_TRUE : JNI_FALSE);
+  jobject result =
+      env->CallObjectMethod(j_context, jmid_onData, j_data, end_stream ? JNI_TRUE : JNI_FALSE);
 
   data.release(data.context);
   env->DeleteLocalRef(j_data);

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -167,59 +167,66 @@ typedef struct {
 extern "C" { // function pointers
 #endif
 /**
- * Called when all headers get received on the async HTTP stream.
+ * Callback signature for headers on an HTTP stream.
  * @param headers, the headers received.
  * @param end_stream, whether the response is headers-only.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
+ * @return void*, return context (may be unused).
  */
-typedef void (*envoy_on_headers_f)(envoy_headers headers, bool end_stream, void* context);
+typedef void* (*envoy_on_headers_f)(envoy_headers headers, bool end_stream, void* context);
 /**
- * Called when a data frame gets received on the async HTTP stream.
+ * Callback signature for data on an HTTP stream.
  * This callback can be invoked multiple times if the data gets streamed.
  * @param data, the data received.
  * @param end_stream, whether the data is the last data frame.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
+ * @return void*, return context (may be unused).
  */
-typedef void (*envoy_on_data_f)(envoy_data data, bool end_stream, void* context);
+typedef void* (*envoy_on_data_f)(envoy_data data, bool end_stream, void* context);
 /**
- * Called when a metadata frame gets received on the async HTTP stream.
+ * Callback signature for metadata on an HTTP stream.
  * Note that metadata frames are prohibited from ending a stream.
  * @param metadata, the metadata received.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
+ * @return void*, return context (may be unused).
  */
-typedef void (*envoy_on_metadata_f)(envoy_headers metadata, void* context);
+typedef void* (*envoy_on_metadata_f)(envoy_headers metadata, void* context);
 /**
- * Called when all trailers get received on the async HTTP stream.
+ * Callback signature for trailers on an HTTP stream.
  * Note that end stream is implied when on_trailers is called.
  * @param trailers, the trailers received.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
+ * @return void*, return context (may be unused).
  */
-typedef void (*envoy_on_trailers_f)(envoy_headers trailers, void* context);
+typedef void* (*envoy_on_trailers_f)(envoy_headers trailers, void* context);
 /**
- * Called when the async HTTP stream has an error.
+ * Callback signature for errors with an HTTP stream.
  * @param envoy_error, the error received/caused by the async HTTP stream.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
+ * @return void*, return context (may be unused).
  */
-typedef void (*envoy_on_error_f)(envoy_error error, void* context);
+typedef void* (*envoy_on_error_f)(envoy_error error, void* context);
 
 /**
- * Called when the async HTTP stream has completed without an error bi-directionally.
+ * Callback signature for when an HTTP stream bi-directionally completes without error.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
+ * @return void*, return context (may be unused).
  */
-typedef void (*envoy_on_complete_f)(void* context);
+typedef void* (*envoy_on_complete_f)(void* context);
 
 /**
- * Called when the async HTTP stream has been cancelled by the client.
+ * Callback signature for when an HTTP stream is cancelled.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
+ * @return void*, return context (may be unused).
  */
-typedef void (*envoy_on_cancel_f)(void* context);
+typedef void* (*envoy_on_cancel_f)(void* context);
 
 /**
  * Called when the envoy engine is exiting.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
@@ -28,6 +28,7 @@ java_library(
         "EnvoyEngineImpl.java",
         "EnvoyHTTPStream.java",
         "JniLibrary.java",
+        "JvmBridgeUtility.java",
         "JvmCallbackContext.java",
     ],
     visibility = ["//visibility:public"],

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -1,0 +1,64 @@
+package io.envoyproxy.envoymobile.engine;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
+
+/**
+ * Class to assist with passing types from native code to the JNI. Currently supports
+ * HTTP headers.
+ */
+class JvmBridgeUtility {
+  // State-tracking for header accumulation
+  private Map<String, List<String>> headerAccumulator = null;
+  private int headerCount = 0;
+
+  JvmBridgeUtility() {}
+
+  /**
+   * Allows pairs of strings to be passed across the JVM, reducing overall calls
+   * (at the expense of some complexity).
+   *
+   * @param key,        the name of the HTTP header.
+   * @param value,      the value of the HTTP header.
+   * @param endHeaders, indicates this is the last header pair for this header
+   *                    block.
+   */
+  void passHeader(byte[] key, byte[] value, boolean start) {
+    if (start) {
+      assert headerAccumulator == null;
+      assert headerCount == 0;
+      headerAccumulator = new HashMap();
+    }
+
+    String headerKey;
+    String headerValue;
+
+    try {
+      headerKey = new String(key, "UTF-8");
+      headerValue = new String(value, "UTF-8");
+    } catch (java.io.UnsupportedEncodingException e) {
+      throw new Ru:wntimeException(e);
+    }
+
+    List<String> values = headerAccumulator.get(headerKey);
+    if (values == null) {
+      values = new ArrayList(1);
+      headerAccumulator.put(headerKey, values);
+    }
+    values.add(headerValue);
+    headerCounth++;
+  }
+
+  Map<String, List<String>> retrieveHeaders() {
+    Map headers = headerAccumulator;
+    headerAccumulator = null;
+    headerCount = 0;
+    return headers;
+  }
+}

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -31,7 +31,7 @@ class JvmBridgeUtility {
     if (start) {
       assert headerAccumulator == null;
       assert headerCount == 0;
-      headerAccumulator = new HashMap();
+      headerAccumulator = new HashMap<>();
     }
 
     String headerKey;

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -59,7 +59,7 @@ class JvmBridgeUtility {
    * @return Map, a map of header names to one or more values.
    */
   Map<String, List<String>> retrieveHeaders() {
-    Map headers = headerAccumulator;
+    final Map<String, List<String>> headers = headerAccumulator;
     headerAccumulator = null;
     headerCount = 0;
     return headers;

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -71,7 +71,5 @@ class JvmBridgeUtility {
    * @param headerCount, the expected number of headers.
    * @return boolean, true if the expected number matches the accumulated count.
    */
-  boolean validateCount(long headerCount) {
-    return this.headerCount == headerCount;
-  }
+  boolean validateCount(long headerCount) { return this.headerCount == headerCount; }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -24,8 +24,9 @@ class JvmCallbackContext {
    *
    * @param length,    the total number of headers included in this header block.
    * @param endStream, whether this header block is the final remote frame.
+   * @return Void,     not used for response callbacks.
    */
-  public void onHeaders(long headerCount, boolean endStream) {
+  public Void onHeaders(long headerCount, boolean endStream) {
     assert bridgeUtility.validateCount(headerCount);
     final Map headers = bridgeUtility.retrieveHeaders();
 
@@ -34,6 +35,8 @@ class JvmCallbackContext {
         callbacks.onHeaders(headers, endStream);
       }
     });
+
+    return null;
   }
 
   /**
@@ -41,8 +44,9 @@ class JvmCallbackContext {
    * to be dispatched via the callback.
    *
    * @param length, the total number of trailers included in this header block.
+   * @return Void,  not used for response callbacks.
    */
-  public void onTrailers(long trailerCount, boolean endStream) {
+  public Void onTrailers(long trailerCount, boolean endStream) {
     assert bridgeUtility.validateCount(trailerCount);
     final Map trailers = bridgeUtility.retrieveHeaders();
 
@@ -51,6 +55,8 @@ class JvmCallbackContext {
         callbacks.onTrailers(trailers);
       }
     });
+
+    return null;
   }
 
   /**
@@ -58,14 +64,17 @@ class JvmCallbackContext {
    *
    * @param data,      chunk of body data from the HTTP response.
    * @param endStream, indicates this is the last remote frame of the stream.
+   * @return Void,     not used for response callbacks.
    */
-  public void onData(byte[] data, boolean endStream) {
+  public Void onData(byte[] data, boolean endStream) {
     callbacks.getExecutor().execute(new Runnable() {
       public void run() {
         ByteBuffer dataBuffer = ByteBuffer.wrap(data);
         callbacks.onData(dataBuffer, endStream);
       }
     });
+
+    return null;
   }
 
   /**
@@ -74,25 +83,32 @@ class JvmCallbackContext {
    * @param errorCode,    the error code.
    * @param message,      the error message.
    * @param attemptCount, the number of times an operation was attempted before firing this error.
+   * @return Void,        not used for response callbacks.
    */
-  public void onError(int errorCode, byte[] message, int attemptCount) {
+  public Void onError(int errorCode, byte[] message, int attemptCount) {
     callbacks.getExecutor().execute(new Runnable() {
       public void run() {
         String errorMessage = new String(message);
         callbacks.onError(errorCode, errorMessage, attemptCount);
       }
     });
+
+    return null;
   }
 
   /**
    * Dispatches cancellation notice up to the platform
+   *
+   * @return Void, not used for response callbacks.
    */
-  public void onCancel() {
+  public Void onCancel() {
     callbacks.getExecutor().execute(new Runnable() {
       public void run() {
         // This call is atomically gated at the call-site and will only happen once.
         callbacks.onCancel();
       }
     });
+
+    return null;
   }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -31,9 +31,7 @@ class JvmCallbackContext {
     final Map headers = bridgeUtility.retrieveHeaders();
 
     callbacks.getExecutor().execute(new Runnable() {
-      public void run() {
-        callbacks.onHeaders(headers, endStream);
-      }
+      public void run() { callbacks.onHeaders(headers, endStream); }
     });
 
     return null;
@@ -51,9 +49,7 @@ class JvmCallbackContext {
     final Map trailers = bridgeUtility.retrieveHeaders();
 
     callbacks.getExecutor().execute(new Runnable() {
-      public void run() {
-        callbacks.onTrailers(trailers);
-      }
+      public void run() { callbacks.onTrailers(trailers); }
     });
 
     return null;

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -34,7 +34,7 @@ class JvmCallbackContext {
    *
    * @param length,    the total number of headers included in this header block.
    * @param endStream, whether this header block is the final remote frame.
-   * @return Object,     not used for response callbacks.
+   * @return Object,   not used for response callbacks.
    */
   public Object onHeaders(long headerCount, boolean endStream) {
     assert bridgeUtility.validateCount(headerCount);
@@ -51,7 +51,7 @@ class JvmCallbackContext {
    * Invokes onTrailers callback using trailers passed via passHeaders.
    *
    * @param length, the total number of trailers included in this header block.
-   * @return Object,  not used for response callbacks.
+   * @return Object,not used for response callbacks.
    */
   public Object onTrailers(long trailerCount, boolean endStream) {
     assert bridgeUtility.validateCount(trailerCount);
@@ -69,7 +69,7 @@ class JvmCallbackContext {
    *
    * @param data,      chunk of body data from the HTTP response.
    * @param endStream, indicates this is the last remote frame of the stream.
-   * @return Object,     not used for response callbacks.
+   * @return Object,   not used for response callbacks.
    */
   public Object onData(byte[] data, boolean endStream) {
     callbacks.getExecutor().execute(new Runnable() {
@@ -88,7 +88,7 @@ class JvmCallbackContext {
    * @param errorCode,    the error code.
    * @param message,      the error message.
    * @param attemptCount, the number of times an operation was attempted before firing this error.
-   * @return Object,        not used for response callbacks.
+   * @return Object,      not used for response callbacks.
    */
   public Object onError(int errorCode, byte[] message, int attemptCount) {
     callbacks.getExecutor().execute(new Runnable() {

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -21,7 +21,7 @@ typedef struct {
 
 #pragma mark - C callbacks
 
-static void* ios_on_headers(envoy_headers headers, bool end_stream, void *context) {
+static void *ios_on_headers(envoy_headers headers, bool end_stream, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -32,7 +32,7 @@ static void* ios_on_headers(envoy_headers headers, bool end_stream, void *contex
   return NULL;
 }
 
-static void* ios_on_data(envoy_data data, bool end_stream, void *context) {
+static void *ios_on_data(envoy_data data, bool end_stream, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -43,9 +43,9 @@ static void* ios_on_data(envoy_data data, bool end_stream, void *context) {
   return NULL;
 }
 
-static void* ios_on_metadata(envoy_headers metadata, void *context) { return NULL; }
+static void *ios_on_metadata(envoy_headers metadata, void *context) { return NULL; }
 
-static void* ios_on_trailers(envoy_headers trailers, void *context) {
+static void *ios_on_trailers(envoy_headers trailers, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -56,7 +56,7 @@ static void* ios_on_trailers(envoy_headers trailers, void *context) {
   return NULL;
 }
 
-static void* ios_on_complete(void *context) {
+static void *ios_on_complete(void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
@@ -68,7 +68,7 @@ static void* ios_on_complete(void *context) {
   return NULL;
 }
 
-static void* ios_on_cancel(void *context) {
+static void *ios_on_cancel(void *context) {
   // This call is atomically gated at the call-site and will only happen once. It may still fire
   // after a complete response or error callback, but no other callbacks for the stream will ever
   // fire AFTER the cancellation callback.
@@ -87,7 +87,7 @@ static void* ios_on_cancel(void *context) {
   return NULL;
 }
 
-static void* ios_on_error(envoy_error error, void *context) {
+static void *ios_on_error(envoy_error error, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -21,7 +21,7 @@ typedef struct {
 
 #pragma mark - C callbacks
 
-static void ios_on_headers(envoy_headers headers, bool end_stream, void *context) {
+static void* ios_on_headers(envoy_headers headers, bool end_stream, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -29,9 +29,10 @@ static void ios_on_headers(envoy_headers headers, bool end_stream, void *context
       callbacks.onHeaders(to_ios_headers(headers), end_stream);
     }
   });
+  return NULL;
 }
 
-static void ios_on_data(envoy_data data, bool end_stream, void *context) {
+static void* ios_on_data(envoy_data data, bool end_stream, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -39,11 +40,12 @@ static void ios_on_data(envoy_data data, bool end_stream, void *context) {
       callbacks.onData(to_ios_data(data), end_stream);
     }
   });
+  return NULL;
 }
 
-static void ios_on_metadata(envoy_headers metadata, void *context) {}
+static void* ios_on_metadata(envoy_headers metadata, void *context) { return NULL; }
 
-static void ios_on_trailers(envoy_headers trailers, void *context) {
+static void* ios_on_trailers(envoy_headers trailers, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -51,9 +53,10 @@ static void ios_on_trailers(envoy_headers trailers, void *context) {
       callbacks.onTrailers(to_ios_headers(trailers));
     }
   });
+  return NULL;
 }
 
-static void ios_on_complete(void *context) {
+static void* ios_on_complete(void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
@@ -62,9 +65,10 @@ static void ios_on_complete(void *context) {
     assert(stream);
     [stream cleanUp];
   });
+  return NULL;
 }
 
-static void ios_on_cancel(void *context) {
+static void* ios_on_cancel(void *context) {
   // This call is atomically gated at the call-site and will only happen once. It may still fire
   // after a complete response or error callback, but no other callbacks for the stream will ever
   // fire AFTER the cancellation callback.
@@ -80,9 +84,10 @@ static void ios_on_cancel(void *context) {
     assert(stream);
     [stream cleanUp];
   });
+  return NULL;
 }
 
-static void ios_on_error(envoy_error error, void *context) {
+static void* ios_on_error(envoy_error error, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
@@ -99,6 +104,7 @@ static void ios_on_error(envoy_error error, void *context) {
     assert(stream);
     [stream cleanUp];
   });
+  return NULL;
 }
 
 #pragma mark - EnvoyHTTPStreamImpl

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -128,14 +128,15 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   callbacks_called cc = {0, 0, 0, 0, 0, &terminal_callback};
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void {
+                                   void* context) -> void* {
     ASSERT_FALSE(end_stream);
     Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
+    return nullptr;
   };
-  bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void {
+  bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
     if (end_stream) {
       ASSERT_EQ(Http::Utility::convertToString(c_data), "");
     } else {
@@ -144,11 +145,13 @@ TEST_P(DispatcherIntegrationTest, Basic) {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
     c_data.release(c_data.context);
+    return nullptr;
   };
-  bridge_callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void* {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
     cc->terminal_callback->setReady();
+    return nullptr;
   };
 
   // Build a set of request headers.
@@ -205,22 +208,25 @@ TEST_P(DispatcherIntegrationTest, BasicNon2xx) {
   callbacks_called cc = {0, 0, 0, 0, 0, &terminal_callback};
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void {
+                                   void* context) -> void* {
     ASSERT_TRUE(end_stream);
     Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "503");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
+    return nullptr;
   };
-  bridge_callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void* {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
     cc->terminal_callback->setReady();
+    return nullptr;
   };
-  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
+  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void* {
     error.message.release(error.message.context);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
+    return nullptr;
   };
 
   // Build a set of request headers.
@@ -258,11 +264,12 @@ TEST_P(DispatcherIntegrationTest, BasicReset) {
   ConditionalInitializer terminal_callback;
   callbacks_called cc = {0, 0, 0, 0, 0, &terminal_callback};
   bridge_callbacks.context = &cc;
-  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void {
+  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void* {
     error.message.release(error.message.context);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
     cc->terminal_callback->setReady();
+    return nullptr;
   };
 
   // Build a set of request headers.
@@ -301,14 +308,15 @@ TEST_P(DispatcherIntegrationTest, RaceDoesNotCauseDoubleDeletion) {
   callbacks_called cc = {0, 0, 0, 0, 0, nullptr};
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void {
+                                   void* context) -> void* {
     ASSERT_FALSE(end_stream);
     Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_headers_calls++;
+    return nullptr;
   };
-  bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void {
+  bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
     if (end_stream) {
       ASSERT_EQ(Http::Utility::convertToString(c_data), "");
     } else {
@@ -317,14 +325,17 @@ TEST_P(DispatcherIntegrationTest, RaceDoesNotCauseDoubleDeletion) {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
     c_data.release(c_data.context);
+    return nullptr;
   };
-  bridge_callbacks.on_complete = [](void* context) -> void {
+  bridge_callbacks.on_complete = [](void* context) -> void* {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
+    return nullptr;
   };
-  bridge_callbacks.on_cancel = [](void* context) -> void {
+  bridge_callbacks.on_cancel = [](void* context) -> void* {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_cancel_calls++;
+    return nullptr;
   };
 
   // Build a set of request headers.

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -129,7 +129,7 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void* {
-    ASSERT_FALSE(end_stream);
+    EXPECT_FALSE(end_stream);
     Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -138,9 +138,9 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   };
   bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
     if (end_stream) {
-      ASSERT_EQ(Http::Utility::convertToString(c_data), "");
+      EXPECT_EQ(Http::Utility::convertToString(c_data), "");
     } else {
-      ASSERT_EQ(c_data.length, 10);
+      EXPECT_EQ(c_data.length, 10);
     }
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
@@ -209,7 +209,7 @@ TEST_P(DispatcherIntegrationTest, BasicNon2xx) {
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void* {
-    ASSERT_TRUE(end_stream);
+    EXPECT_TRUE(end_stream);
     Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "503");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -309,7 +309,7 @@ TEST_P(DispatcherIntegrationTest, RaceDoesNotCauseDoubleDeletion) {
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
                                    void* context) -> void* {
-    ASSERT_FALSE(end_stream);
+    EXPECT_FALSE(end_stream);
     Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -318,9 +318,9 @@ TEST_P(DispatcherIntegrationTest, RaceDoesNotCauseDoubleDeletion) {
   };
   bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
     if (end_stream) {
-      ASSERT_EQ(Http::Utility::convertToString(c_data), "");
+      EXPECT_EQ(Http::Utility::convertToString(c_data), "");
     } else {
-      ASSERT_EQ(c_data.length, 10);
+      EXPECT_EQ(c_data.length, 10);
     }
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;


### PR DESCRIPTION
Description: Rework callback signatures by allowing a type-erased return context similar to the context parameter that gets included in the call argument. This opens the door to filter callbacks and stream callbacks sharing streamlined bridge code, especially in the case of the JNI. Also improves upon the current header passing mechanism for the JNI.
Risk Level: Moderate
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>