### PR TITLE
swift: update stream client to use factory closures for filters

### DIFF
--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -15,7 +15,9 @@ final class ViewController: UITableViewController {
     super.viewDidLoad()
     do {
       NSLog("starting Envoy...")
-      self.client = try StreamClientBuilder().addFilter(DemoFilter.self).build()
+      self.client = try StreamClientBuilder()
+        .addFilter(DemoFilter.init)
+        .build()
     } catch let error {
       NSLog("starting Envoy failed: \(error)")
     }

--- a/library/swift/src/StreamClientBuilder.swift
+++ b/library/swift/src/StreamClientBuilder.swift
@@ -108,17 +108,14 @@ public final class StreamClientBuilder: NSObject {
     return self
   }
 
-  /// Add HTTP filter for requests sent by this client. Note the current implementation
-  /// uses a single filter instance for all streams on an engine; in other words,
-  /// filters must be effectively stateless. An upcoming change will switch to
-  /// per-stream filter instances (which can then maintain their own state).
+  /// Add an HTTP filter factory used to construct filters for streams sent by this client.
   ///
-  /// - parameter filter: HTTP Filter to be invoked for streams.
+  /// - parameter factory: Closure returning an instantiated filter. Called once per stream.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addFilter(_ filterType: Filter.Type) -> StreamClientBuilder {
-    self.filterChain.append(EnvoyHTTPFilterFactory(filterType: filterType))
+  public func addFilter<T: Filter>(_ factory: @escaping () -> T) -> StreamClientBuilder {
+    self.filterChain.append(EnvoyHTTPFilterFactory(factory: factory))
     return self
   }
 

--- a/library/swift/src/filters/Filter.swift
+++ b/library/swift/src/filters/Filter.swift
@@ -5,19 +5,13 @@ import Foundation
 public protocol Filter {
   /// A unique name for a filter implementation. Needed for extension registration.
   static var name: String { get }
-
-  /// Required initializer for internal creation.
-  init()
 }
 
 extension EnvoyHTTPFilterFactory {
-  convenience init(filterType: Filter.Type) {
+  convenience init<T: Filter>(factory: @escaping () -> T) {
     self.init()
-
-    self.filterName = filterType.name
-    self.create = {
-      return EnvoyHTTPFilter(filter: filterType.init())
-    }
+    self.filterName = T.name
+    self.create = { EnvoyHTTPFilter(filter: factory()) }
   }
 }
 


### PR DESCRIPTION
Updates the stream client builder to accept a closure returning a `Filter` rather than requiring `Filter` to have an `init()` in its protocol conformance. This allows consumers to provide more flexible implementations of "factories" (closures) that can be used with custom initializers or alongside additional logic.

Note: Generics are required here since `Filter.name` is needed.

As part of this change, I also fixed some outdated documentation of this function.

Signed-off-by: Michael Rebello <me@michaelrebello.com>

Testing: Local/CI
Docs Changes: No