### PR TITLE
platform: remove some interfaces

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/RequestFilterCallbacks.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/RequestFilterCallbacks.kt
@@ -1,7 +1,5 @@
 package io.envoyproxy.envoymobile
 
-import java.nio.ByteBuffer
-
 interface RequestFilterCallbacks {
   /**
    * Continue iterating through the filter chain with buffered headers and body data.
@@ -15,18 +13,4 @@ interface RequestFilterCallbacks {
    * calls.
    */
   fun continueRequest()
-
-  /**
-   * @return ByteBuffer, The currently buffered data as buffered by the filter or previous ones in
-   *                     the filter chain. Nil if nothing has been buffered yet.
-   */
-  fun requestBuffer(): ByteBuffer?
-
-  /**
-   * Adds request trailers. May only be called in `onHeaders()`/`onData()` when
-   * `endStream = true` in order to guarantee that the client will not send its own trailers.
-   *
-   * @param trailers: The trailers to add and pass to subsequent filters.
-   */
-  fun addRequestTrailers(trailers: RequestTrailers)
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/ResponseFilterCallbacks.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/ResponseFilterCallbacks.kt
@@ -1,7 +1,5 @@
 package io.envoyproxy.envoymobile
 
-import java.nio.ByteBuffer
-
 interface ResponseFilterCallbacks {
   /**
    * Continue iterating through the filter chain with buffered headers and body data.
@@ -15,18 +13,4 @@ interface ResponseFilterCallbacks {
    * calls.
    */
   fun continueResponse()
-
-  /**
-   * @return ByteBuffer?: The currently buffered data as buffered by the filter or previous ones in
-   *                      the filter chain. Nil if nothing has been buffered yet.
-   */
-  fun responseBuffer(): ByteBuffer?
-
-  /**
-   * Adds response trailers. May only be called in `onHeaders()`/`onData()` when
-   * `endStream = true` in order to guarantee that the client will not send its own trailers.
-   *
-   * @param trailers: The trailers to add and pass to subsequent filters.
-   */
-  fun addResponseTrailers(trailers: ResponseTrailers)
 }

--- a/library/swift/src/filters/RequestFilterCallbacks.swift
+++ b/library/swift/src/filters/RequestFilterCallbacks.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public protocol RequestFilterCallbacks {
   /// Continue iterating through the filter chain with buffered headers and body data.
   ///

--- a/library/swift/src/filters/RequestFilterCallbacks.swift
+++ b/library/swift/src/filters/RequestFilterCallbacks.swift
@@ -11,14 +11,4 @@ public protocol RequestFilterCallbacks {
   /// If the request is not complete, the filter will still receive `onData()`/`onTrailers()`
   /// calls.
   func continueRequest()
-
-  /// - returns: The currently buffered data as buffered by the filter or previous ones in the
-  ///            filter chain. Nil if nothing has been buffered yet.
-  func requestBuffer() -> Data?
-
-  /// Adds request trailers. May only be called in `onHeaders()`/`onData()` when
-  /// `endStream = true` in order to guarantee that the client will not send its own trailers.
-  ///
-  /// - parameter trailers: The trailers to add and pass to subsequent filters.
-  func addRequestTrailers(_ trailers: RequestTrailers)
 }

--- a/library/swift/src/filters/ResponseFilterCallbacks.swift
+++ b/library/swift/src/filters/ResponseFilterCallbacks.swift
@@ -11,14 +11,4 @@ public protocol ResponseFilterCallbacks {
   /// If the response is not complete, the filter will still receive `onData()`/`onTrailers()`
   /// calls.
   func continueResponse()
-
-  /// - returns: The currently buffered data as buffered by the filter or previous ones in the
-  ///            filter chain. Nil if nothing has been buffered yet.
-  func responseBuffer() -> Data?
-
-  /// Adds response trailers. May only be called in `onHeaders()`/`onData()` when
-  /// `endStream = true` in order to guarantee that the client will not send its own trailers.
-  ///
-  /// - parameter trailers: The trailers to add and pass to subsequent filters.
-  func addResponseTrailers(_ trailers: ResponseTrailers)
 }

--- a/library/swift/src/filters/ResponseFilterCallbacks.swift
+++ b/library/swift/src/filters/ResponseFilterCallbacks.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public protocol ResponseFilterCallbacks {
   /// Continue iterating through the filter chain with buffered headers and body data.
   ///


### PR DESCRIPTION
At the moment, `continueRequest()` and `continueResponse()` are not yet wired up. While we plan to implement that in the very near future (next week or so), we do not have plans to add these other "async" operations at the moment. Removing them from the public interface until we're ready to implement them.

Signed-off-by: Michael Rebello <me@michaelrebello.com>
