### PR TITLE
swift: add `@frozen` annotation to filter statuses

### DIFF
--- a/library/swift/src/filters/FilterDataStatus.swift
+++ b/library/swift/src/filters/FilterDataStatus.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Status returned by filters when transmitting or receiving data.
+@frozen
 public enum FilterDataStatus {
   /// Continue filter chain iteration. If headers have not yet been sent to the next filter, they
   /// will be sent first via `onRequestHeaders()`/`onResponseHeaders()`.

--- a/library/swift/src/filters/FilterHeaderStatus.swift
+++ b/library/swift/src/filters/FilterHeaderStatus.swift
@@ -1,4 +1,5 @@
 /// Status returned by filters when transmitting or receiving headers.
+@frozen
 public enum FilterHeaderStatus<T: Headers> {
   /// Continue filter chain iteration, passing the provided headers through.
   case `continue`(T)

--- a/library/swift/src/filters/FilterTrailerStatus.swift
+++ b/library/swift/src/filters/FilterTrailerStatus.swift
@@ -1,4 +1,5 @@
 /// Status returned by filters when transmitting or receiving trailers.
+@frozen
 public enum FilterTrailerStatus<T: Headers> {
   /// Continue filter chain iteration, passing the provided trailers through.
   case `continue`(T)


### PR DESCRIPTION
This suppresses the following warning when `switch`ing over filter return values:

> Switch covers known cases, but 'FilterHeaderStatus<RequestHeaders>' may have additional unknown values

Note that while we are not guaranteeing ABI stability, we will use semantic versioning going forward.

Signed-off-by: Michael Rebello <me@michaelrebello.com>
