### PR TITLE
swift: make filter statuses equatable

### DIFF
--- a/library/swift/src/filters/FilterDataStatus.swift
+++ b/library/swift/src/filters/FilterDataStatus.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Status returned by filters when transmitting or receiving data.
 @frozen
-public enum FilterDataStatus {
+public enum FilterDataStatus: Equatable {
   /// Continue filter chain iteration. If headers have not yet been sent to the next filter, they
   /// will be sent first via `onRequestHeaders()`/`onResponseHeaders()`.
   ///

--- a/library/swift/src/filters/FilterHeaderStatus.swift
+++ b/library/swift/src/filters/FilterHeaderStatus.swift
@@ -1,6 +1,6 @@
 /// Status returned by filters when transmitting or receiving headers.
 @frozen
-public enum FilterHeaderStatus<T: Headers> {
+public enum FilterHeaderStatus<T: Headers>: Equatable {
   /// Continue filter chain iteration, passing the provided headers through.
   case `continue`(T)
 

--- a/library/swift/src/filters/FilterTrailerStatus.swift
+++ b/library/swift/src/filters/FilterTrailerStatus.swift
@@ -1,6 +1,6 @@
 /// Status returned by filters when transmitting or receiving trailers.
 @frozen
-public enum FilterTrailerStatus<T: Headers> {
+public enum FilterTrailerStatus<T: Headers>: Equatable {
   /// Continue filter chain iteration, passing the provided trailers through.
   case `continue`(T)
 


### PR DESCRIPTION
This will allow for easier testing/validation of filters for consumers.

Signed-off-by: Michael Rebello <me@michaelrebello.com>