### PR TITLE
filters: update iOS interface to take explicit filter name

### DIFF
--- a/examples/swift/hello_world/DemoFilter.swift
+++ b/examples/swift/hello_world/DemoFilter.swift
@@ -2,7 +2,6 @@ import Envoy
 import Foundation
 
 struct DemoFilter: ResponseFilter {
-
   func onResponseHeaders(_ headers: ResponseHeaders, endStream: Bool)
     -> FilterHeadersStatus<ResponseHeaders>
   {

--- a/examples/swift/hello_world/DemoFilter.swift
+++ b/examples/swift/hello_world/DemoFilter.swift
@@ -2,8 +2,6 @@ import Envoy
 import Foundation
 
 struct DemoFilter: ResponseFilter {
-  // TODO(goaway): Update once dynamic registration is in place.
-  static let name = "PlatformStub"
 
   func onResponseHeaders(_ headers: ResponseHeaders, endStream: Bool)
     -> FilterHeadersStatus<ResponseHeaders>

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -16,7 +16,8 @@ final class ViewController: UITableViewController {
     do {
       NSLog("starting Envoy...")
       self.client = try StreamClientBuilder()
-        .addFilter(DemoFilter.init)
+        // TODO(goaway): Update once dynamic registration is in place.
+        .addFilter("PlatformStub", factory: DemoFilter.init)
         .build()
     } catch let error {
       NSLog("starting Envoy failed: \(error)")

--- a/library/swift/src/StreamClientBuilder.swift
+++ b/library/swift/src/StreamClientBuilder.swift
@@ -110,6 +110,7 @@ public final class StreamClientBuilder: NSObject {
 
   /// Add an HTTP filter factory used to construct filters for streams sent by this client.
   ///
+  /// - parameter filterName: Unique name for this filter required for registration.
   /// - parameter factory: Closure returning an instantiated filter. Called once per stream.
   ///
   /// - returns: This builder.

--- a/library/swift/src/StreamClientBuilder.swift
+++ b/library/swift/src/StreamClientBuilder.swift
@@ -114,8 +114,9 @@ public final class StreamClientBuilder: NSObject {
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addFilter<T: Filter>(_ factory: @escaping () -> T) -> StreamClientBuilder {
-    self.filterChain.append(EnvoyHTTPFilterFactory(factory: factory))
+  public func addFilter(_ filterName: String, factory: @escaping () -> Filter)
+      -> StreamClientBuilder {
+    self.filterChain.append(EnvoyHTTPFilterFactory(filterName: filterName, factory: factory))
     return self
   }
 

--- a/library/swift/src/filters/Filter.swift
+++ b/library/swift/src/filters/Filter.swift
@@ -3,14 +3,12 @@ import Foundation
 
 /// Interface representing a filter. See `RequestFilter` and `ResponseFilter` for more details.
 public protocol Filter {
-  /// A unique name for a filter implementation. Needed for extension registration.
-  static var name: String { get }
 }
 
 extension EnvoyHTTPFilterFactory {
-  convenience init<T: Filter>(factory: @escaping () -> T) {
+  convenience init(filterName: String, factory: @escaping () -> Filter) {
     self.init()
-    self.filterName = T.name
+    self.filterName = filterName
     self.create = { EnvoyHTTPFilter(filter: factory()) }
   }
 }


### PR DESCRIPTION
Description: This avoids generics and some additional complexity on the Kotlin side. Ultimately, we may move to a solution that removes the need to specify a name entirely.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
