### PR TITLE
ci: increase ios/mac_dist timeout

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -10,7 +10,7 @@ jobs:
   macdist:
     name: mac_dist
     runs-on: macOS-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Description: This job seems to get cancelled frequently at the 45-minute mark, which just means another 45-minute cycle to run it again. Increase to 60 to hopefully get it to complete consistently.

Signed-off-by: Mike Schore <mike.schore@gmail.com>
