### PR TITLE
coverage: upload report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,4 +30,4 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: coverage.tar.gz
-          path: coveverage.tar.gz
+          path: coverage.tar.gz

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - 'library/common/**'
-      - 'test/**'
+    # paths:
+    #   - 'library/common/**'
+    #   - 'test/**'
 
 jobs:
   coverage:
@@ -26,3 +26,8 @@ jobs:
           export CC=clang
           export CXX=clang++
           ./envoy/test/run_envoy_bazel_coverage.sh //test/...
+          tar -czvf coverage.tar.gz generated/coverage
+      - uses: actions/upload-artifact@v1
+        with:
+          name: coverage.tar.gz
+          path: coveverage.tar.gz

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -18,7 +18,7 @@ sudo apt-get update
 
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y wget software-properties-common make cmake git \
-  unzip bc libtool ninja-build automake zip time \
+  unzip bc libtool ninja-build automake zip time genhtml \
   apt-transport-https
 
 # clang 8.

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+function download_and_check () {
+  local to=$1
+  local url=$2
+  local sha256=$3
+
+  curl -fsSL --output "${to}" "${url}"
+  echo "${sha256}  ${to}" | sha256sum --check
+}
+
 # Set up basic requirements and install them.
 # workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
 sudo rm -rf /var/lib/apt/lists/*
@@ -18,7 +27,7 @@ sudo apt-get update
 
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y wget software-properties-common make cmake git \
-  unzip bc libtool ninja-build automake zip time genhtml \
+  unzip bc libtool ninja-build automake zip time \
   apt-transport-https
 
 # clang 8.
@@ -42,3 +51,11 @@ sudo chmod +x /usr/local/bin/buildifier
 # bazelisk
 sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v0.0.8/bazelisk-linux-amd64
 sudo chmod +x /usr/local/bin/bazel
+
+# Install lcov
+LCOV_VERSION=1.14
+download_and_check lcov-${LCOV_VERSION}.tar.gz https://github.com/linux-test-project/lcov/releases/download/v${LCOV_VERSION}/lcov-${LCOV_VERSION}.tar.gz \
+  14995699187440e0ae4da57fe3a64adc0a3c5cf14feab971f8db38fb7d8f071a
+tar zxf lcov-${LCOV_VERSION}.tar.gz
+make -C lcov-${LCOV_VERSION} install
+rm -rf "lcov-${LCOV_VERSION}" "./lcov-${LCOV_VERSION}.tar.gz"

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -2,15 +2,6 @@
 
 set -e
 
-function download_and_check () {
-  local to=$1
-  local url=$2
-  local sha256=$3
-
-  curl -fsSL --output "${to}" "${url}"
-  echo "${sha256}  ${to}" | sha256sum --check
-}
-
 # Set up basic requirements and install them.
 # workaround https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
 sudo rm -rf /var/lib/apt/lists/*
@@ -27,7 +18,7 @@ sudo apt-get update
 
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y wget software-properties-common make cmake git \
-  unzip bc libtool ninja-build automake zip time \
+  unzip bc libtool ninja-build automake zip time lcov \
   apt-transport-https
 
 # clang 8.
@@ -51,11 +42,3 @@ sudo chmod +x /usr/local/bin/buildifier
 # bazelisk
 sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v0.0.8/bazelisk-linux-amd64
 sudo chmod +x /usr/local/bin/bazel
-
-# Install lcov
-LCOV_VERSION=1.14
-download_and_check lcov-${LCOV_VERSION}.tar.gz https://github.com/linux-test-project/lcov/releases/download/v${LCOV_VERSION}/lcov-${LCOV_VERSION}.tar.gz \
-  14995699187440e0ae4da57fe3a64adc0a3c5cf14feab971f8db38fb7d8f071a
-tar zxf lcov-${LCOV_VERSION}.tar.gz
-make -C lcov-${LCOV_VERSION} install
-rm -rf "lcov-${LCOV_VERSION}" "./lcov-${LCOV_VERSION}.tar.gz"


### PR DESCRIPTION
Description: installs lcov in order to generate coverage reports once again.
Fixes https://github.com/lyft/envoy-mobile/issues/1009

Signed-off-by: Jose Nino <jnino@lyft.com>
