### PR TITLE
swift: add some missing ResponseFilter functions

### DIFF
--- a/examples/swift/hello_world/DemoFilter.swift
+++ b/examples/swift/hello_world/DemoFilter.swift
@@ -22,4 +22,8 @@ struct DemoFilter: ResponseFilter {
   func onResponseTrailers(_ trailers: ResponseTrailers) -> FilterTrailersStatus<ResponseTrailers> {
     return .continue(trailers)
   }
+
+  func onError(_ error: EnvoyError) {}
+
+  func onCancel() {}
 }

--- a/library/swift/src/filters/ResponseFilter.swift
+++ b/library/swift/src/filters/ResponseFilter.swift
@@ -29,6 +29,15 @@ public protocol ResponseFilter: Filter {
   /// - returns: The data status containing body with which to continue or buffer.
   func onResponseData(_ body: Data, endStream: Bool) -> FilterDataStatus
 
+  /// Called at most once when the response is closed from the server with trailers.
+  ///
+  /// Filters may mutate or delay the trailers.
+  ///
+  /// - parameter trailers: The outbound trailers.
+  ///
+  /// - returns: The trailer status containing body with which to continue or buffer.
+  func onResponseTrailers(_ trailers: ResponseTrailers) -> FilterTrailersStatus<ResponseTrailers>
+
   /// Called at most once when an error within Envoy occurs.
   ///
   /// This should be considered a terminal state, and invalidates any previous attempts to

--- a/library/swift/src/filters/ResponseFilter.swift
+++ b/library/swift/src/filters/ResponseFilter.swift
@@ -29,12 +29,17 @@ public protocol ResponseFilter: Filter {
   /// - returns: The data status containing body with which to continue or buffer.
   func onResponseData(_ body: Data, endStream: Bool) -> FilterDataStatus
 
-  /// Called at most once when the response is closed from the server with trailers.
+  /// Called at most once when an error within Envoy occurs.
   ///
-  /// Filters may mutate or delay the trailers.
+  /// This should be considered a terminal state, and invalidates any previous attempts to
+  /// `stopIteration{...}`.
   ///
-  /// - parameter trailers: The outbound trailers.
+  /// - parameter error: The error that occurred within Envoy.
+  func onError(_ error: EnvoyError)
+
+  /// Called at most once when the client cancels the stream.
   ///
-  /// - returns: The trailer status containing body with which to continue or buffer.
-  func onResponseTrailers(_ trailers: ResponseTrailers) -> FilterTrailersStatus<ResponseTrailers>
+  /// This should be considered a terminal state, and invalidates any previous attempts to
+  /// `stopIteration{...}`.
+  func onCancel()
 }


### PR DESCRIPTION
These are specified in the Kotlin interface, but not in Swift. They'll be wired up separately.

Signed-off-by: Michael Rebello <me@michaelrebello.com>