### PR TITLE
filters: wire Android invocation path

### DIFF
--- a/examples/kotlin/hello_world/BUILD
+++ b/examples/kotlin/hello_world/BUILD
@@ -18,6 +18,7 @@ android_binary(
 kt_android_library(
     name = "hello_envoy_kt_lib",
     srcs = [
+        "DemoFilter.kt",
         "MainActivity.kt",
     ],
     custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",

--- a/examples/kotlin/hello_world/DemoFilter.kt
+++ b/examples/kotlin/hello_world/DemoFilter.kt
@@ -1,0 +1,41 @@
+package io.envoyproxy.envoymobile.helloenvoykotlin
+
+import android.util.Log
+import io.envoyproxy.envoymobile.EnvoyError
+import io.envoyproxy.envoymobile.FilterHeadersStatus
+import io.envoyproxy.envoymobile.FilterDataStatus
+import io.envoyproxy.envoymobile.FilterTrailersStatus
+import io.envoyproxy.envoymobile.ResponseHeaders
+import io.envoyproxy.envoymobile.ResponseFilter
+import io.envoyproxy.envoymobile.ResponseFilterCallbacks
+import io.envoyproxy.envoymobile.ResponseTrailers
+import java.nio.ByteBuffer
+
+class DemoFilter() : ResponseFilter {
+
+  override fun setResponseFilterCallbacks(callbacks: ResponseFilterCallbacks) {}
+
+  override fun onResponseHeaders(headers: ResponseHeaders, endStream: Boolean):
+    FilterHeadersStatus<ResponseHeaders> {
+      Log.d("DemoFilter", "On headers!")
+      return FilterHeadersStatus.Continue(headers)
+  }
+
+  override fun onResponseData(body: ByteBuffer, endStream: Boolean): FilterDataStatus {
+    Log.d("DemoFilter", "On data!")
+    return FilterDataStatus.Continue(body)
+  }
+
+  override fun onResponseTrailers(trailers: ResponseTrailers): FilterTrailersStatus<ResponseTrailers> {
+    Log.d("DemoFilter", "On trailers!")
+    return FilterTrailersStatus.Continue(trailers)
+  }
+
+  override fun onError(error: EnvoyError) {
+    Log.d("DemoFilter", "On error!")
+  }
+
+  override fun onCancel() {
+    Log.d("DemoFilter", "On cancel!")
+  }
+}

--- a/examples/kotlin/hello_world/DemoFilter.kt
+++ b/examples/kotlin/hello_world/DemoFilter.kt
@@ -2,12 +2,12 @@ package io.envoyproxy.envoymobile.helloenvoykotlin
 
 import android.util.Log
 import io.envoyproxy.envoymobile.EnvoyError
-import io.envoyproxy.envoymobile.FilterHeadersStatus
 import io.envoyproxy.envoymobile.FilterDataStatus
+import io.envoyproxy.envoymobile.FilterHeadersStatus
 import io.envoyproxy.envoymobile.FilterTrailersStatus
-import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseFilter
 import io.envoyproxy.envoymobile.ResponseFilterCallbacks
+import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseTrailers
 import java.nio.ByteBuffer
 
@@ -21,7 +21,7 @@ class DemoFilter : ResponseFilter {
     FilterHeadersStatus<ResponseHeaders> {
       Log.d("DemoFilter", "On headers!")
       return FilterHeadersStatus.Continue(headers)
-  }
+    }
 
   override fun onResponseData(body: ByteBuffer, endStream: Boolean): FilterDataStatus {
     Log.d("DemoFilter", "On data!")
@@ -30,9 +30,9 @@ class DemoFilter : ResponseFilter {
 
   override fun onResponseTrailers(trailers: ResponseTrailers):
     FilterTrailersStatus<ResponseTrailers> {
-    Log.d("DemoFilter", "On trailers!")
-    return FilterTrailersStatus.Continue(trailers)
-  }
+      Log.d("DemoFilter", "On trailers!")
+      return FilterTrailersStatus.Continue(trailers)
+    }
 
   override fun onError(error: EnvoyError) {
     Log.d("DemoFilter", "On error!")

--- a/examples/kotlin/hello_world/DemoFilter.kt
+++ b/examples/kotlin/hello_world/DemoFilter.kt
@@ -11,9 +11,11 @@ import io.envoyproxy.envoymobile.ResponseFilterCallbacks
 import io.envoyproxy.envoymobile.ResponseTrailers
 import java.nio.ByteBuffer
 
-class DemoFilter() : ResponseFilter {
+class DemoFilter : ResponseFilter {
 
-  override fun setResponseFilterCallbacks(callbacks: ResponseFilterCallbacks) {}
+  override fun setResponseFilterCallbacks(callbacks: ResponseFilterCallbacks) {
+    // No-op
+  }
 
   override fun onResponseHeaders(headers: ResponseHeaders, endStream: Boolean):
     FilterHeadersStatus<ResponseHeaders> {
@@ -26,7 +28,8 @@ class DemoFilter() : ResponseFilter {
     return FilterDataStatus.Continue(body)
   }
 
-  override fun onResponseTrailers(trailers: ResponseTrailers): FilterTrailersStatus<ResponseTrailers> {
+  override fun onResponseTrailers(trailers: ResponseTrailers):
+    FilterTrailersStatus<ResponseTrailers> {
     Log.d("DemoFilter", "On trailers!")
     return FilterTrailersStatus.Continue(trailers)
   }

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -13,6 +13,7 @@ import io.envoyproxy.envoymobile.Engine
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.UpstreamHttpProtocol
+import io.envoyproxy.envoymobile.helloenvoykotlin.DemoFilter
 import io.envoyproxy.envoymobile.shared.Failure
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter
 import io.envoyproxy.envoymobile.shared.Success
@@ -37,6 +38,8 @@ class MainActivity : Activity() {
     setContentView(R.layout.activity_main)
 
     engine = AndroidEngineBuilder(application).build()
+      .addFilter({ DemoFilter() })
+      .build()
 
     recyclerView = findViewById(R.id.recycler_view) as RecyclerView
     recyclerView.layoutManager = LinearLayoutManager(this)

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -37,7 +37,7 @@ class MainActivity : Activity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
 
-    engine = AndroidEngineBuilder(application).build()
+    engine = AndroidEngineBuilder(application)
       .addFilter { DemoFilter() }
       .build()
 

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity : Activity() {
     setContentView(R.layout.activity_main)
 
     engine = AndroidEngineBuilder(application).build()
-      .addFilter({ DemoFilter() })
+      .addFilter { DemoFilter() }
       .build()
 
     recyclerView = findViewById(R.id.recycler_view) as RecyclerView

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -13,7 +13,6 @@ import io.envoyproxy.envoymobile.Engine
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.UpstreamHttpProtocol
-import io.envoyproxy.envoymobile.helloenvoykotlin.DemoFilter
 import io.envoyproxy.envoymobile.shared.Failure
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter
 import io.envoyproxy.envoymobile.shared.Success

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -55,6 +55,14 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_templateString(JNIEnv* env,
   return result;
 }
 
+extern "C" JNIEXPORT jstring JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_filterTemplateString(JNIEnv* env,
+                                                                      jclass // class
+) {
+  jstring result = env->NewStringUTF(platform_filter_template);
+  return result;
+}
+
 // AndroidJniLibrary
 
 extern "C" JNIEXPORT jint JNICALL

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -4,8 +4,8 @@
 
 #include <string>
 
-#include "library/common/main_interface.h"
 #include "library/common/extensions/filters/http/platform_bridge/c_types.h"
+#include "library/common/main_interface.h"
 
 static JavaVM* static_jvm = nullptr;
 static JNIEnv* static_env = nullptr;
@@ -154,7 +154,8 @@ static JNIEnv* get_env() {
   return env;
 }
 
-static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_stream, void* context) {
+static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_stream,
+                            void* context) {
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
   pass_headers(env, headers, j_context);
@@ -175,14 +176,18 @@ static void* jvm_on_response_headers(envoy_headers headers, bool end_stream, voi
   return jvm_on_headers("onResponseHeaders", headers, end_stream, context);
 }
 
-static envoy_filter_headers_status jvm_http_filter_on_request_headers(envoy_headers headers, bool end_stream, const void* context) {
-  jobject result = static_cast<jobject>(jvm_on_headers("onRequestHeaders", headers, end_stream, const_cast<void*>(context)));
+static envoy_filter_headers_status
+jvm_http_filter_on_request_headers(envoy_headers headers, bool end_stream, const void* context) {
+  jobject result = static_cast<jobject>(
+      jvm_on_headers("onRequestHeaders", headers, end_stream, const_cast<void*>(context)));
   return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusContinue,
                                        /*headers*/ headers};
 }
 
-static envoy_filter_headers_status jvm_http_filter_on_response_headers(envoy_headers headers, bool end_stream, const void* context) {
-  jobject result = static_cast<jobject>(jvm_on_headers("onResponseHeaders", headers, end_stream, const_cast<void*>(context)));
+static envoy_filter_headers_status
+jvm_http_filter_on_response_headers(envoy_headers headers, bool end_stream, const void* context) {
+  jobject result = static_cast<jobject>(
+      jvm_on_headers("onResponseHeaders", headers, end_stream, const_cast<void*>(context)));
   return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusContinue,
                                        /*headers*/ headers};
 }
@@ -218,14 +223,18 @@ static void* jvm_on_response_data(envoy_data data, bool end_stream, void* contex
   return jvm_on_data("onResponseData", data, end_stream, context);
 }
 
-static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data, bool end_stream, const void* context) {
-  jobject result = static_cast<jobject>(jvm_on_data("onRequestData", data, end_stream, const_cast<void*>(context)));
+static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data, bool end_stream,
+                                                                const void* context) {
+  jobject result = static_cast<jobject>(
+      jvm_on_data("onRequestData", data, end_stream, const_cast<void*>(context)));
   return (envoy_filter_data_status){/*status*/ kEnvoyFilterDataStatusContinue,
                                     /*data*/ data};
 }
 
-static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data, bool end_stream, const void* context) {
-  jobject result = static_cast<jobject>(jvm_on_data("onResponseData", data, end_stream, const_cast<void*>(context)));
+static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data, bool end_stream,
+                                                                 const void* context) {
+  jobject result = static_cast<jobject>(
+      jvm_on_data("onResponseData", data, end_stream, const_cast<void*>(context)));
   return (envoy_filter_data_status){/*status*/ kEnvoyFilterDataStatusContinue,
                                     /*data*/ data};
 }
@@ -258,14 +267,18 @@ static void* jvm_on_response_trailers(envoy_headers trailers, void* context) {
   return jvm_on_trailers("onResponseTrailers", trailers, context);
 }
 
-static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_headers trailers, const void* context) {
-  jobject result = static_cast<jobject>(jvm_on_trailers("onRequestTrailers", trailers, const_cast<void*>(context)));
+static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_headers trailers,
+                                                                        const void* context) {
+  jobject result = static_cast<jobject>(
+      jvm_on_trailers("onRequestTrailers", trailers, const_cast<void*>(context)));
   return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterTrailersStatusContinue,
                                         /*trailers*/ trailers};
 }
 
-static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_headers trailers, const void* context) {
-  jobject result = static_cast<jobject>(jvm_on_trailers("onResponseTrailers", trailers, const_cast<void*>(context)));
+static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_headers trailers,
+                                                                         const void* context) {
+  jobject result = static_cast<jobject>(
+      jvm_on_trailers("onResponseTrailers", trailers, const_cast<void*>(context)));
   return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterTrailersStatusContinue,
                                         /*trailers*/ trailers};
 }
@@ -330,8 +343,8 @@ static const void* jvm_http_filter_init(const void* context) {
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
 
   jclass jcls_JvmFilterFactoryContext = env->GetObjectClass(j_context);
-  jmethodID jmid_create =
-      env->GetMethodID(jcls_JvmFilterFactoryContext, "create", "()Lio/envoyproxy/envoymobile/engine/JvmFilterContext;");
+  jmethodID jmid_create = env->GetMethodID(jcls_JvmFilterFactoryContext, "create",
+                                           "()Lio/envoyproxy/envoymobile/engine/JvmFilterContext;");
 
   jobject j_filter = env->CallObjectMethod(j_context, jmid_create);
   jobject retained_filter = env->NewGlobalRef(j_filter);
@@ -417,9 +430,14 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 
   // TODO: To be truly safe we may need stronger guarantees of operation ordering on this ref.
   jobject retained_context = env->NewGlobalRef(j_context);
-  envoy_http_callbacks native_callbacks = {jvm_on_response_headers, jvm_on_response_data, jvm_on_metadata,
-                                           jvm_on_response_trailers, jvm_on_error, jvm_on_complete,
-                                           jvm_on_cancel, retained_context};
+  envoy_http_callbacks native_callbacks = {jvm_on_response_headers,
+                                           jvm_on_response_data,
+                                           jvm_on_metadata,
+                                           jvm_on_response_trailers,
+                                           jvm_on_error,
+                                           jvm_on_complete,
+                                           jvm_on_cancel,
+                                           retained_context};
   envoy_status_t result =
       start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks);
   if (result != ENVOY_SUCCESS) {
@@ -431,14 +449,16 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 
 // EnvoyHTTPFilter
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(
-    JNIEnv* env, jclass, jstring filter_name, jobject j_context) {
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* env, jclass,
+                                                                       jstring filter_name,
+                                                                       jobject j_context) {
 
   // TODO(goaway): Everything here leaks, but it's all be tied to the life of the engine.
   // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332
   jclass jcls_JvmFilterFactoryContext = env->GetObjectClass(j_context);
   jobject retained_context = env->NewGlobalRef(j_context);
-  envoy_http_filter *api = (envoy_http_filter*)safe_malloc(sizeof(envoy_http_filter));
+  envoy_http_filter* api = (envoy_http_filter*)safe_malloc(sizeof(envoy_http_filter));
   api->init_filter = jvm_http_filter_init;
   api->on_request_headers = jvm_http_filter_on_request_headers;
   api->on_request_data = jvm_http_filter_on_request_data;

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -164,6 +164,7 @@ static JNIEnv* get_env() {
 
 static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_stream,
                             void* context) {
+  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_headers");
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
   pass_headers(env, headers, j_context);
@@ -186,18 +187,20 @@ static void* jvm_on_response_headers(envoy_headers headers, bool end_stream, voi
 
 static envoy_filter_headers_status
 jvm_http_filter_on_request_headers(envoy_headers headers, bool end_stream, const void* context) {
+  envoy_headers return_headers = copy_envoy_headers(headers);
   jobject result = static_cast<jobject>(
       jvm_on_headers("onRequestHeaders", headers, end_stream, const_cast<void*>(context)));
   return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusContinue,
-                                       /*headers*/ headers};
+                                       /*headers*/ return_headers};
 }
 
 static envoy_filter_headers_status
 jvm_http_filter_on_response_headers(envoy_headers headers, bool end_stream, const void* context) {
+  envoy_headers return_headers = copy_envoy_headers(headers);
   jobject result = static_cast<jobject>(
       jvm_on_headers("onResponseHeaders", headers, end_stream, const_cast<void*>(context)));
   return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusContinue,
-                                       /*headers*/ headers};
+                                       /*headers*/ return_headers};
 }
 
 static void* jvm_on_data(const char* method, envoy_data data, bool end_stream, void* context) {
@@ -233,18 +236,20 @@ static void* jvm_on_response_data(envoy_data data, bool end_stream, void* contex
 
 static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data, bool end_stream,
                                                                 const void* context) {
+  envoy_data return_data = copy_envoy_data(data.length, data.bytes);
   jobject result = static_cast<jobject>(
       jvm_on_data("onRequestData", data, end_stream, const_cast<void*>(context)));
   return (envoy_filter_data_status){/*status*/ kEnvoyFilterDataStatusContinue,
-                                    /*data*/ data};
+                                    /*data*/ return_data};
 }
 
 static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data, bool end_stream,
                                                                  const void* context) {
+  envoy_data return_data = copy_envoy_data(data.length, data.bytes);
   jobject result = static_cast<jobject>(
       jvm_on_data("onResponseData", data, end_stream, const_cast<void*>(context)));
   return (envoy_filter_data_status){/*status*/ kEnvoyFilterDataStatusContinue,
-                                    /*data*/ data};
+                                    /*data*/ return_data};
 }
 
 static void* jvm_on_metadata(envoy_headers metadata, void* context) {
@@ -277,18 +282,20 @@ static void* jvm_on_response_trailers(envoy_headers trailers, void* context) {
 
 static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_headers trailers,
                                                                         const void* context) {
+  envoy_headers return_trailers = copy_envoy_headers(trailers);
   jobject result = static_cast<jobject>(
       jvm_on_trailers("onRequestTrailers", trailers, const_cast<void*>(context)));
   return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterTrailersStatusContinue,
-                                        /*trailers*/ trailers};
+                                        /*trailers*/ return_trailers};
 }
 
 static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_headers trailers,
                                                                          const void* context) {
+  envoy_headers return_trailers = copy_envoy_headers(trailers);
   jobject result = static_cast<jobject>(
       jvm_on_trailers("onResponseTrailers", trailers, const_cast<void*>(context)));
   return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterTrailersStatusContinue,
-                                        /*trailers*/ trailers};
+                                        /*trailers*/ return_trailers};
 }
 
 static void* jvm_on_error(envoy_error error, void* context) {

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -349,12 +349,14 @@ static const void* jvm_http_filter_init(const void* context) {
 
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
+  __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_context: %p", j_context);
 
   jclass jcls_JvmFilterFactoryContext = env->GetObjectClass(j_context);
   jmethodID jmid_create = env->GetMethodID(jcls_JvmFilterFactoryContext, "create",
                                            "()Lio/envoyproxy/envoymobile/engine/JvmFilterContext;");
 
   jobject j_filter = env->CallObjectMethod(j_context, jmid_create);
+  __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_filter: %p", j_filter);
   jobject retained_filter = env->NewGlobalRef(j_filter);
   return retained_filter;
 }
@@ -464,8 +466,11 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* e
 
   // TODO(goaway): Everything here leaks, but it's all be tied to the life of the engine.
   // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332
+  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "registerFilterFactory");
+  __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_context: %p", j_context);
   jclass jcls_JvmFilterFactoryContext = env->GetObjectClass(j_context);
   jobject retained_context = env->NewGlobalRef(j_context);
+  __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "retained_context: %p", retained_context);
   envoy_http_filter* api = (envoy_http_filter*)safe_malloc(sizeof(envoy_http_filter));
   api->init_filter = jvm_http_filter_init;
   api->on_request_headers = jvm_http_filter_on_request_headers;

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "library/common/main_interface.h"
+#include "library/common/extensions/filters/http/platform_bridge/c_types.h"
 
 static JavaVM* static_jvm = nullptr;
 static JNIEnv* static_env = nullptr;
@@ -153,14 +154,14 @@ static JNIEnv* get_env() {
   return env;
 }
 
-static void* jvm_on_headers(envoy_headers headers, bool end_stream, void* context) {
+static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_stream, void* context) {
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
   pass_headers(env, headers, j_context);
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onHeaders =
-      env->GetMethodID(jcls_JvmCallbackContext, "onHeaders", "(JZ)Ljava/lang/Object;");
+      env->GetMethodID(jcls_JvmCallbackContext, method, "(JZ)Ljava/lang/Object;");
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
   jobject result = env->CallObjectMethod(j_context, jmid_onHeaders, (jlong)headers.length,
@@ -170,14 +171,30 @@ static void* jvm_on_headers(envoy_headers headers, bool end_stream, void* contex
   return result;
 }
 
-static void* jvm_on_data(envoy_data data, bool end_stream, void* context) {
+static void* jvm_on_response_headers(envoy_headers headers, bool end_stream, void* context) {
+  return jvm_on_headers("onResponseHeaders", headers, end_stream, context);
+}
+
+static envoy_filter_headers_status jvm_http_filter_on_request_headers(envoy_headers headers, bool end_stream, const void* context) {
+  jobject result = static_cast<jobject>(jvm_on_headers("onRequestHeaders", headers, end_stream, const_cast<void*>(context)));
+  return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusContinue,
+                                       /*headers*/ headers};
+}
+
+static envoy_filter_headers_status jvm_http_filter_on_response_headers(envoy_headers headers, bool end_stream, const void* context) {
+  jobject result = static_cast<jobject>(jvm_on_headers("onResponseHeaders", headers, end_stream, const_cast<void*>(context)));
+  return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusContinue,
+                                       /*headers*/ headers};
+}
+
+static void* jvm_on_data(const char* method, envoy_data data, bool end_stream, void* context) {
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_data");
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onData =
-      env->GetMethodID(jcls_JvmCallbackContext, "onData", "([BZ)Ljava/lang/Object;");
+      env->GetMethodID(jcls_JvmCallbackContext, method, "([BZ)Ljava/lang/Object;");
 
   jbyteArray j_data = env->NewByteArray(data.length);
   // TODO: check if copied via isCopy.
@@ -197,13 +214,29 @@ static void* jvm_on_data(envoy_data data, bool end_stream, void* context) {
   return result;
 }
 
+static void* jvm_on_response_data(envoy_data data, bool end_stream, void* context) {
+  return jvm_on_data("onResponseData", data, end_stream, context);
+}
+
+static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data, bool end_stream, const void* context) {
+  jobject result = static_cast<jobject>(jvm_on_data("onRequestData", data, end_stream, const_cast<void*>(context)));
+  return (envoy_filter_data_status){/*status*/ kEnvoyFilterDataStatusContinue,
+                                    /*data*/ data};
+}
+
+static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data, bool end_stream, const void* context) {
+  jobject result = static_cast<jobject>(jvm_on_data("onResponseData", data, end_stream, const_cast<void*>(context)));
+  return (envoy_filter_data_status){/*status*/ kEnvoyFilterDataStatusContinue,
+                                    /*data*/ data};
+}
+
 static void* jvm_on_metadata(envoy_headers metadata, void* context) {
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_metadata");
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", std::to_string(metadata.length).c_str());
   return NULL;
 }
 
-static void* jvm_on_trailers(envoy_headers trailers, void* context) {
+static void* jvm_on_trailers(const char* method, envoy_headers trailers, void* context) {
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_trailers");
 
   JNIEnv* env = get_env();
@@ -212,13 +245,29 @@ static void* jvm_on_trailers(envoy_headers trailers, void* context) {
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onTrailers =
-      env->GetMethodID(jcls_JvmCallbackContext, "onTrailers", "(J)Ljava/lang/Object;");
+      env->GetMethodID(jcls_JvmCallbackContext, method, "(J)Ljava/lang/Object;");
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
   jobject result = env->CallObjectMethod(j_context, jmid_onTrailers, (jlong)trailers.length);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
   return result;
+}
+
+static void* jvm_on_response_trailers(envoy_headers trailers, void* context) {
+  return jvm_on_trailers("onResponseTrailers", trailers, context);
+}
+
+static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_headers trailers, const void* context) {
+  jobject result = static_cast<jobject>(jvm_on_trailers("onRequestTrailers", trailers, const_cast<void*>(context)));
+  return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterTrailersStatusContinue,
+                                        /*trailers*/ trailers};
+}
+
+static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_headers trailers, const void* context) {
+  jobject result = static_cast<jobject>(jvm_on_trailers("onResponseTrailers", trailers, const_cast<void*>(context)));
+  return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterTrailersStatusContinue,
+                                        /*trailers*/ trailers};
 }
 
 static void* jvm_on_error(envoy_error error, void* context) {
@@ -270,6 +319,28 @@ static void* jvm_on_cancel(void* context) {
   // No further callbacks happen on this context. Delete the reference held by native code.
   env->DeleteGlobalRef(j_context);
   return result;
+}
+
+// JvmFilterFactoryContext
+
+static const void* jvm_http_filter_init(const void* context) {
+  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_filter_init");
+
+  JNIEnv* env = get_env();
+  jobject j_context = static_cast<jobject>(const_cast<void*>(context));
+
+  jclass jcls_JvmFilterFactoryContext = env->GetObjectClass(j_context);
+  jmethodID jmid_create =
+      env->GetMethodID(jcls_JvmFilterFactoryContext, "create", "()Lio/envoyproxy/envoymobile/engine/JvmFilterContext;");
+
+  jobject j_filter = env->CallObjectMethod(j_context, jmid_create);
+  jobject retained_filter = env->NewGlobalRef(j_filter);
+  return retained_filter;
+}
+
+static void jni_delete_global_ref(void* context);
+static void jvm_http_filter_release(const void* context) {
+  jni_delete_global_ref(const_cast<void*>(context));
 }
 
 // Utility functions
@@ -346,9 +417,9 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 
   // TODO: To be truly safe we may need stronger guarantees of operation ordering on this ref.
   jobject retained_context = env->NewGlobalRef(j_context);
-  envoy_http_callbacks native_callbacks = {jvm_on_headers,  jvm_on_data,     jvm_on_metadata,
-                                           jvm_on_trailers, jvm_on_error,    jvm_on_complete,
-                                           jvm_on_cancel,   retained_context};
+  envoy_http_callbacks native_callbacks = {jvm_on_response_headers, jvm_on_response_data, jvm_on_metadata,
+                                           jvm_on_response_trailers, jvm_on_error, jvm_on_complete,
+                                           jvm_on_cancel, retained_context};
   envoy_status_t result =
       start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks);
   if (result != ENVOY_SUCCESS) {
@@ -356,6 +427,32 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   }
   env->DeleteLocalRef(jcls_JvmCallbackContext);
   return result;
+}
+
+// EnvoyHTTPFilter
+
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(
+    JNIEnv* env, jclass, jstring filter_name, jobject j_context) {
+
+  // TODO(goaway): Everything here leaks, but it's all be tied to the life of the engine.
+  // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332
+  jclass jcls_JvmFilterFactoryContext = env->GetObjectClass(j_context);
+  jobject retained_context = env->NewGlobalRef(j_context);
+  envoy_http_filter *api = (envoy_http_filter*)safe_malloc(sizeof(envoy_http_filter));
+  api->init_filter = jvm_http_filter_init;
+  api->on_request_headers = jvm_http_filter_on_request_headers;
+  api->on_request_data = jvm_http_filter_on_request_data;
+  api->on_request_trailers = jvm_http_filter_on_request_trailers;
+  api->on_response_headers = jvm_http_filter_on_response_headers;
+  api->on_response_data = jvm_http_filter_on_response_data;
+  api->on_response_trailers = jvm_http_filter_on_response_trailers;
+  api->release_filter = jvm_http_filter_release;
+  api->static_context = retained_context;
+  api->instance_context = NULL;
+
+  register_platform_api(env->GetStringUTFChars(filter_name, nullptr), api);
+  env->DeleteLocalRef(jcls_JvmFilterFactoryContext);
+  return ENVOY_SUCCESS;
 }
 
 // Note: JLjava_nio_ByteBuffer_2Z is the mangled signature of the java method.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
@@ -30,6 +30,8 @@ java_library(
         "JniLibrary.java",
         "JvmBridgeUtility.java",
         "JvmCallbackContext.java",
+        "JvmFilterContext.java",
+        "JvmFilterFactoryContext.java",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -1,5 +1,9 @@
 package io.envoyproxy.envoymobile.engine;
 
+import java.util.List;
+
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;
+
 /* Typed configuration that may be used for starting Envoy. */
 public class EnvoyConfiguration {
   public final String statsDomain;
@@ -7,6 +11,7 @@ public class EnvoyConfiguration {
   public final Integer dnsRefreshSeconds;
   public final Integer dnsFailureRefreshSecondsBase;
   public final Integer dnsFailureRefreshSecondsMax;
+  public final List<EnvoyHTTPFilterFactory> httpFilterFactories;
   public final Integer statsFlushSeconds;
   public final String appVersion;
   public final String appId;
@@ -28,6 +33,7 @@ public class EnvoyConfiguration {
    */
   public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds, int dnsRefreshSeconds,
                             int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax,
+                            List<EnvoyHTTPFilterFactory> httpFilterFactories,
                             int statsFlushSeconds, String appVersion, String appId,
                             String virtualClusters) {
     this.statsDomain = statsDomain;
@@ -35,6 +41,7 @@ public class EnvoyConfiguration {
     this.dnsRefreshSeconds = dnsRefreshSeconds;
     this.dnsFailureRefreshSecondsBase = dnsFailureRefreshSecondsBase;
     this.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
+    this.httpFilterFactories = httpFilterFactories;
     this.statsFlushSeconds = statsFlushSeconds;
     this.appVersion = appVersion;
     this.appId = appId;
@@ -51,10 +58,17 @@ public class EnvoyConfiguration {
    *                                 resolved.
    */
   String resolveTemplate(String templateYAML) {
-    // TODO(goaway): update when Android filter chain wiring is complete.
+    final StringBuilder filterConfigBuilder = new StringBuilder();
+    final String filterTemplate = JniLibrary.filterTemplateString();
+    for (EnvoyHTTPFilterFactory filterFactory : httpFilterFactories) {
+      String filterConfig = filterTemplate.replace("{{ platform_filter_name }}", filterFactory.getFilterName());
+      filterConfigBuilder.append(filterConfig);
+    }
+    String filterConfigChain = filterConfigBuilder.toString();
+
     String resolvedConfiguration =
         templateYAML.replace("{{ stats_domain }}", statsDomain)
-            .replace("{{ platform_filter_chain }}", "")
+            .replace("{{ platform_filter_chain }}", filterConfigChain)
             .replace("{{ connect_timeout_seconds }}", String.format("%s", connectTimeoutSeconds))
             .replace("{{ dns_refresh_rate_seconds }}", String.format("%s", dnsRefreshSeconds))
             .replace("{{ dns_failure_refresh_rate_seconds_base }}",

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -33,9 +33,8 @@ public class EnvoyConfiguration {
    */
   public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds, int dnsRefreshSeconds,
                             int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax,
-                            List<EnvoyHTTPFilterFactory> httpFilterFactories,
-                            int statsFlushSeconds, String appVersion, String appId,
-                            String virtualClusters) {
+                            List<EnvoyHTTPFilterFactory> httpFilterFactories, int statsFlushSeconds,
+                            String appVersion, String appId, String virtualClusters) {
     this.statsDomain = statsDomain;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.dnsRefreshSeconds = dnsRefreshSeconds;
@@ -61,7 +60,8 @@ public class EnvoyConfiguration {
     final StringBuilder filterConfigBuilder = new StringBuilder();
     final String filterTemplate = JniLibrary.filterTemplateString();
     for (EnvoyHTTPFilterFactory filterFactory : httpFilterFactories) {
-      String filterConfig = filterTemplate.replace("{{ platform_filter_name }}", filterFactory.getFilterName());
+      String filterConfig =
+          filterTemplate.replace("{{ platform_filter_name }}", filterFactory.getFilterName());
       filterConfigBuilder.append(filterConfig);
     }
     String filterConfigChain = filterConfigBuilder.toString();

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -56,12 +56,11 @@ public class EnvoyConfiguration {
    * @throws ConfigurationException, when the template provided is not fully
    *                                 resolved.
    */
-  String resolveTemplate(String templateYAML) {
+  String resolveTemplate(final String templateYAML, final String filterTemplateYAML) {
     final StringBuilder filterConfigBuilder = new StringBuilder();
-    final String filterTemplate = JniLibrary.filterTemplateString();
     for (EnvoyHTTPFilterFactory filterFactory : httpFilterFactories) {
       String filterConfig =
-          filterTemplate.replace("{{ platform_filter_name }}", filterFactory.getFilterName());
+          filterTemplateYAML.replace("{{ platform_filter_name }}", filterFactory.getFilterName());
       filterConfigBuilder.append(filterConfig);
     }
     String filterConfigChain = filterConfigBuilder.toString();

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -56,7 +56,8 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   @Override
   public int runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
     for (EnvoyHTTPFilterFactory filterFactory : envoyConfiguration.httpFilterFactories) {
-      JniLibrary.registerFilterFactory(filterFactory.getFilterName(), new JvmFilterFactoryContext(filterFactory));
+      JniLibrary.registerFilterFactory(filterFactory.getFilterName(),
+                                       new JvmFilterFactoryContext(filterFactory));
     }
 
     return runWithConfig(envoyConfiguration.resolveTemplate(JniLibrary.templateString()), logLevel);

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -60,7 +60,9 @@ public class EnvoyEngineImpl implements EnvoyEngine {
                                        new JvmFilterFactoryContext(filterFactory));
     }
 
-    return runWithConfig(envoyConfiguration.resolveTemplate(JniLibrary.templateString(), JniLibrary.filterTemplateString()), logLevel);
+    return runWithConfig(envoyConfiguration.resolveTemplate(JniLibrary.templateString(),
+                                                            JniLibrary.filterTemplateString()),
+                         logLevel);
   }
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -1,6 +1,7 @@
 package io.envoyproxy.envoymobile.engine;
 
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;
 
 /* Concrete implementation of the `EnvoyEngine` interface. */
 public class EnvoyEngineImpl implements EnvoyEngine {
@@ -54,6 +55,10 @@ public class EnvoyEngineImpl implements EnvoyEngine {
    */
   @Override
   public int runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
+    for (EnvoyHTTPFilterFactory filterFactory : envoyConfiguration.httpFilterFactories) {
+      JniLibrary.registerFilterFactory(filterFactory.getFilterName(), new JvmFilterFactoryContext(filterFactory));
+    }
+
     return runWithConfig(envoyConfiguration.resolveTemplate(JniLibrary.templateString()), logLevel);
   }
 

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -60,7 +60,7 @@ public class EnvoyEngineImpl implements EnvoyEngine {
                                        new JvmFilterFactoryContext(filterFactory));
     }
 
-    return runWithConfig(envoyConfiguration.resolveTemplate(JniLibrary.templateString()), logLevel);
+    return runWithConfig(envoyConfiguration.resolveTemplate(JniLibrary.templateString(), JniLibrary.filterTemplateString()), logLevel);
   }
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -110,6 +110,15 @@ class JniLibrary {
    */
   protected static native int resetStream(long stream);
 
+  /**
+   * Register a factory for creating platform filter instances for each HTTP stream.
+   *
+   * @param filterName, unique name identifying this filter in the chain.
+   * @param context,    context containing logic necessary to invoke a new filter instance.
+   * @return int, the resulting status of the operation.
+   */
+  protected static native int registerFilterFactory(String filterName, JvmFilterFactoryContext context);
+
   // Native entry point
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -117,7 +117,8 @@ class JniLibrary {
    * @param context,    context containing logic necessary to invoke a new filter instance.
    * @return int, the resulting status of the operation.
    */
-  protected static native int registerFilterFactory(String filterName, JvmFilterFactoryContext context);
+  protected static native int registerFilterFactory(String filterName,
+                                                    JvmFilterFactoryContext context);
 
   // Native entry point
 

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -144,4 +144,13 @@ class JniLibrary {
    * Increment a counter.
    */
   protected static native void recordCounter(String elements, int count);
+
+  /**
+   * Provides a configuration template that may be used for building platform
+   * filter config chains.
+   *
+   * @return A template that may be used as a starting point for constructing
+   *         filter platform filter configuration.
+   */
+  public static native String filterTemplateString();
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -36,7 +36,7 @@ class JvmCallbackContext {
    * @param endStream, whether this header block is the final remote frame.
    * @return Object,   not used for response callbacks.
    */
-  public Object onHeaders(long headerCount, boolean endStream) {
+  public Object onResponseHeaders(long headerCount, boolean endStream) {
     assert bridgeUtility.validateCount(headerCount);
     final Map headers = bridgeUtility.retrieveHeaders();
 
@@ -53,7 +53,7 @@ class JvmCallbackContext {
    * @param length, the total number of trailers included in this header block.
    * @return Object,not used for response callbacks.
    */
-  public Object onTrailers(long trailerCount, boolean endStream) {
+  public Object onResponseTrailers(long trailerCount, boolean endStream) {
     assert bridgeUtility.validateCount(trailerCount);
     final Map trailers = bridgeUtility.retrieveHeaders();
 
@@ -71,7 +71,7 @@ class JvmCallbackContext {
    * @param endStream, indicates this is the last remote frame of the stream.
    * @return Object,   not used for response callbacks.
    */
-  public Object onData(byte[] data, boolean endStream) {
+  public Object onResponseData(byte[] data, boolean endStream) {
     callbacks.getExecutor().execute(new Runnable() {
       public void run() {
         ByteBuffer dataBuffer = ByteBuffer.wrap(data);

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -1,0 +1,104 @@
+package io.envoyproxy.envoymobile.engine;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilter;
+
+/**
+ * Wrapper class for EnvoyHTTPFilter for receiving JNI calls.
+ */
+class JvmFilterContext {
+  private final JvmBridgeUtility bridgeUtility;
+  private final EnvoyHTTPFilter filter;
+
+  public JvmFilterContext(EnvoyHTTPFilter filter) {
+    bridgeUtility = new JvmBridgeUtility();
+    this.filter = filter;
+  }
+
+  /**
+   * Delegates header retrieval to the bridge utility.
+   *
+   * @param key,        the name of the HTTP header.
+   * @param value,      the value of the HTTP header.
+   * @param start,      indicates this is the first header pair of the block.
+   */
+  void passHeader(byte[] key, byte[] value, boolean start) {
+    bridgeUtility.passHeader(key, value, start);
+  }
+
+  /**
+   * Invokes onHeaders callback using headers passed via passHeaders.
+   *
+   * @param length,    the total number of headers included in this header block.
+   * @param endStream, whether this header block is the final remote frame.
+   * @return Object,   not used for request filter.
+   */
+  public Object onRequestHeaders(long headerCount, boolean endStream) {
+    assert bridgeUtility.validateCount(headerCount);
+    final Map headers = bridgeUtility.retrieveHeaders();
+    return filter.onRequestHeaders(headers, endStream);
+  }
+
+  /**
+   * Dispatches data received from the JNI layer up to the platform.
+   *
+   * @param data,      chunk of body data from the HTTP request.
+   * @param endStream, indicates this is the last remote frame of the stream.
+   * @return Object,   not used for request filter.
+   */
+  public Object onRequestData(byte[] data, boolean endStream) {
+    ByteBuffer dataBuffer = ByteBuffer.wrap(data);
+    return filter.onRequestData(dataBuffer, endStream);
+  }
+
+  /**
+   * Invokes onTrailers callback using trailers passed via passHeaders.
+   *
+   * @param length, the total number of trailers included in this header block.
+   * @return Object,not used for request filter.
+   */
+  public Object onRequestTrailers(long trailerCount, boolean endStream) {
+    assert bridgeUtility.validateCount(trailerCount);
+    final Map trailers = bridgeUtility.retrieveHeaders();
+    return filter.onRequestTrailers(trailers);
+  }
+
+  /**
+   * Invokes onHeaders callback using headers passed via passHeaders.
+   *
+   * @param length,    the total number of headers included in this header block.
+   * @param endStream, whether this header block is the final remote frame.
+   * @return Object,   not used for response filter.
+   */
+  public Object onResponseHeaders(long headerCount, boolean endStream) {
+    assert bridgeUtility.validateCount(headerCount);
+    final Map headers = bridgeUtility.retrieveHeaders();
+    return filter.onResponseHeaders(headers, endStream);
+  }
+
+  /**
+   * Dispatches data received from the JNI layer up to the platform.
+   *
+   * @param data,      chunk of body data from the HTTP response.
+   * @param endStream, indicates this is the last remote frame of the stream.
+   * @return Object,   not used for response filter.
+   */
+  public Object onResponseData(byte[] data, boolean endStream) {
+    ByteBuffer dataBuffer = ByteBuffer.wrap(data);
+    return filter.onResponseData(dataBuffer, endStream);
+  }
+
+  /**
+   * Invokes onTrailers callback using trailers passed via passHeaders.
+   *
+   * @param length, the total number of trailers included in this header block.
+   * @return Object,not used for response filter.
+   */
+  public Object onResponseTrailers(long trailerCount, boolean endStream) {
+    assert bridgeUtility.validateCount(trailerCount);
+    final Map trailers = bridgeUtility.retrieveHeaders();
+    return filter.onResponseTrailers(trailers);
+  }
+}

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterFactoryContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterFactoryContext.java
@@ -13,5 +13,5 @@ class JvmFilterFactoryContext {
     this.filterFactory = filterFactory;
   }
 
-  JvmFilterContext create() { return new JvmFilterContext(filterFactory.create()); }
+  public JvmFilterContext create() { return new JvmFilterContext(filterFactory.create()); }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterFactoryContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterFactoryContext.java
@@ -13,7 +13,5 @@ class JvmFilterFactoryContext {
     this.filterFactory = filterFactory;
   }
 
-  JvmFilterContext create() {
-    return new JvmFilterContext(filterFactory.create());
-  }
+  JvmFilterContext create() { return new JvmFilterContext(filterFactory.create()); }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterFactoryContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterFactoryContext.java
@@ -1,0 +1,19 @@
+package io.envoyproxy.envoymobile.engine;
+
+import io.envoyproxy.envoymobile.engine.JvmFilterContext;
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;
+
+/**
+ * Wrapper class for EnvoyHTTPFilterFactory for receiving JNI calls.
+ */
+class JvmFilterFactoryContext {
+  private final EnvoyHTTPFilterFactory filterFactory;
+
+  public JvmFilterFactoryContext(EnvoyHTTPFilterFactory filterFactory) {
+    this.filterFactory = filterFactory;
+  }
+
+  JvmFilterContext create() {
+    return new JvmFilterContext(filterFactory.create());
+  }
+}

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -13,6 +13,8 @@ mock_template:
   dns_failure_refresh_rate:
     base_interval: {{ dns_failure_refresh_rate_seconds_base }}s
     max_interval: {{ dns_failure_refresh_rate_seconds_max }}s
+  platform_filter_chain:
+{{ platform_filter_chain }}
   stats_flush_interval: {{ stats_flush_interval_seconds }}s
   os: {{ device_os }}
   app_version: {{ app_version }}
@@ -20,13 +22,18 @@ mock_template:
   virtual_clusters: {{ virtual_clusters }}
 """
 
+private const val FILTER_CONFIG =
+  """
+    - platform_filter_name: {{ platform_filter_name }}
+"""
+
 class EnvoyConfigurationTest {
 
   @Test
   fun `resolving with default configuration resolves with values`() {
-    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567, "v1.2.3", "com.mydomain.myapp", "[test]")
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, emptyList(), 567, "v1.2.3", "com.mydomain.myapp", "[test]")
 
-    val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG)
+    val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG, FILTER_CONFIG)
     assertThat(resolvedTemplate).contains("stats_domain: stats.foo.com")
     assertThat(resolvedTemplate).contains("connect_timeout: 123s")
     assertThat(resolvedTemplate).contains("dns_refresh_rate: 234s")
@@ -41,8 +48,8 @@ class EnvoyConfigurationTest {
 
   @Test(expected = EnvoyConfiguration.ConfigurationException::class)
   fun `resolve templates with invalid templates will throw on build`() {
-    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, 567, "v1.2.3", "com.mydomain.myapp", "[test]")
+    val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, emptyList(), 567, "v1.2.3", "com.mydomain.myapp", "[test]")
 
-    envoyConfiguration.resolveTemplate("{{ }}")
+    envoyConfiguration.resolveTemplate("{{ }}", "")
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -3,6 +3,7 @@ package io.envoyproxy.envoymobile
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyEngineImpl
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory
 import java.util.UUID
 
 sealed class BaseConfiguration
@@ -24,7 +25,7 @@ open class EngineBuilder(
   private var dnsRefreshSeconds = 60
   private var dnsFailureRefreshSecondsBase = 2
   private var dnsFailureRefreshSecondsMax = 10
-  private var filterChain = mutableListOf<FilterFactory>()
+  private var filterChain = mutableListOf<EnvoyHTTPFilterFactory>()
   private var statsFlushSeconds = 60
   private var appVersion = "unspecified"
   private var appId = "unspecified"
@@ -169,7 +170,7 @@ open class EngineBuilder(
           EnvoyConfiguration(
             statsDomain, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
-            statsFlushSeconds, appVersion, appId, virtualClusters
+            filterChain, statsFlushSeconds, appVersion, appId, virtualClusters
           ),
           logLevel
         )

--- a/library/proguard.txt
+++ b/library/proguard.txt
@@ -11,6 +11,18 @@
     native <methods>;
 }
 
+-keep, includedescriptorclasses class io.envoyproxy.envoymobile.engine.JvmBridgeUtility {
+   <methods>;
+}
+
 -keep, includedescriptorclasses class io.envoyproxy.envoymobile.engine.JvmCallbackContext {
+   <methods>;
+}
+
+-keep, includedescriptorclasses class io.envoyproxy.envoymobile.engine.JvmFilterContext {
+   <methods>;
+}
+
+-keep, includedescriptorclasses class io.envoyproxy.envoymobile.engine.JvmFilterFactoryContext {
    <methods>;
 }


### PR DESCRIPTION
Description: Adds invocation path for Android platform-bridged filters, covering request/response headers, data, and trailers. This change does not provide for state modification via the return path.
Risk Level: Moderate
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
