### PR TITLE
coverage: fix main after #995

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - 'library/common/**'
-      - 'test/**'
+    # paths:
+    #   - 'library/common/**'
+    #   - 'test/**'
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-18.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
         with:
@@ -26,3 +26,7 @@ jobs:
           export CC=clang
           export CXX=clang++
           ./envoy/test/run_envoy_bazel_coverage.sh //test/...
+      - name: 'Failed on test'
+        if: ${{ failure() }}
+        run: |
+          cat bazel-out/k8-fastbuild/testlogs/test/common/envoy_mobile_main_common_test/test.log


### PR DESCRIPTION
Description: try to further debug why `envoy_mobile_main_common_test` is failing on coverage after #995. As [explained in that PR](https://github.com/lyft/envoy-mobile/pull/995#discussion_r466731628) I am befuddled by why the test is failing, specially since it is not failing in my local linux env.

