### PR TITLE
platform: automatically assign filter names

### DIFF
--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -16,8 +16,7 @@ final class ViewController: UITableViewController {
     do {
       NSLog("starting Envoy...")
       self.client = try StreamClientBuilder()
-        // TODO(goaway): Update once dynamic registration is in place.
-        .addFilter("DemoFilter", factory: DemoFilter.init)
+        .addFilter(factory: DemoFilter.init)
         .build()
     } catch let error {
       NSLog("starting Envoy failed: \(error)")

--- a/library/kotlin/src/io/envoyproxy/envoymobile/StreamClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/StreamClientBuilder.kt
@@ -4,6 +4,8 @@ import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyEngineImpl
 
+import java.util.UUID;
+
 sealed class BaseConfiguration
 
 class Standard : BaseConfiguration()

--- a/library/kotlin/src/io/envoyproxy/envoymobile/StreamClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/StreamClientBuilder.kt
@@ -106,12 +106,12 @@ open class StreamClientBuilder(
   /**
    * Add an HTTP filter factory used to create filters for streams sent by this client.
    *
-   * @param filterName: unique name identifying this filter in the chain.
    * @param factory closure returning an instantiated filter.
    *
    * @return this builder.
    */
-  fun addFilter(filterName: String, factory: () -> Filter): StreamClientBuilder {
+  fun addFilter(factory: () -> Filter): StreamClientBuilder {
+    val filterName = UUID.randomUUID().toString()
     this.filterChain.add(FilterFactory(filterName, factory))
     return this
   }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/StreamClientBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/StreamClientBuilder.kt
@@ -3,8 +3,7 @@ package io.envoyproxy.envoymobile
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyEngineImpl
-
-import java.util.UUID;
+import java.util.UUID
 
 sealed class BaseConfiguration
 

--- a/library/swift/src/StreamClientBuilder.swift
+++ b/library/swift/src/StreamClientBuilder.swift
@@ -110,13 +110,12 @@ public final class StreamClientBuilder: NSObject {
 
   /// Add an HTTP filter factory used to construct filters for streams sent by this client.
   ///
-  /// - parameter filterName: Unique name for this filter required for registration.
   /// - parameter factory: Closure returning an instantiated filter. Called once per stream.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addFilter(_ filterName: String, factory: @escaping () -> Filter)
-      -> StreamClientBuilder {
+  public func addFilter(factory: @escaping () -> Filter) -> StreamClientBuilder {
+    let filterName = UUID().uuidString
     self.filterChain.append(EnvoyHTTPFilterFactory(filterName: filterName, factory: factory))
     return self
   }

--- a/library/swift/test/StreamClientBuilderTests.swift
+++ b/library/swift/test/StreamClientBuilderTests.swift
@@ -102,13 +102,12 @@ final class StreamClientBuilderTests: XCTestCase {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
       XCTAssertEqual(1, config.httpFilterFactories.count)
-      XCTAssertEqual("TestFilter", config.httpFilterFactories[0].filterName)
       expectation.fulfill()
     }
 
     _ = try StreamClientBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addFilter("TestFilter", factory: TestFilter.init)
+      .addFilter(factory: TestFilter.init)
       .build()
     self.waitForExpectations(timeout: 0.01)
   }


### PR DESCRIPTION
Since we essentially just want to enforce that each filter has a unique name in the registry, we can move this burden into the library and avoid making consumers specify filter names directly.

Signed-off-by: Michael Rebello <me@michaelrebello.com>