### PR TITLE
crash fix: ensure main thread is destructed before Http::Dispatcher

### DIFF
--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -48,12 +48,12 @@ private:
   envoy_engine_callbacks callbacks_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;
-  std::thread main_thread_;
   std::unique_ptr<Http::Dispatcher> http_dispatcher_;
   std::unique_ptr<MobileMainCommon> main_common_ GUARDED_BY(mutex_);
   Server::Instance* server_{};
   Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
   Event::Dispatcher* event_dispatcher_;
+  std::thread main_thread_;
 };
 
 } // namespace Envoy

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -53,6 +53,8 @@ private:
   Server::Instance* server_{};
   Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
   Event::Dispatcher* event_dispatcher_;
+  // main_thread_ should be destroyed first, hence it is the last member variable. Objects that
+  // instructions scheduled on the main_thread_ need to have a longer lifetime.
   std::thread main_thread_;
 };
 

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -442,6 +442,7 @@ envoy_status_t Dispatcher::resetStream(envoy_stream_t stream) {
       // that another terminal callback has already happened. All terminal callbacks clean up stream
       // state, so there is no need to dispatch here.
       post([this, stream]() -> void {
+        RELEASE_ASSERT(this, "callback executed after Http::Dispatcher was deleted");
         Dispatcher::DirectStreamSharedPtr direct_stream = getStream(stream);
         if (direct_stream) {
           // This interaction is important. The runResetCallbacks call synchronously causes Envoy to


### PR DESCRIPTION
Description: Due to inverse destruction order, it was previously theoretically possible that the main thread could still be running and executing the event loop when the Http::Dispatcher had already been destroyed. This ensures that the normal destruction order of the Engine should ensure the main thread has been destructed (and terminated) before the dispatcher. Our presumption that the crash is called by `this` being null in the callback is covered by a new `RELEASE_ASSERT`, so that we can detect if further protection (e.g. capturing the dispatcher via a shared pointer in the callback) is needed.
Risk Level: Low
Testing: CI

Co-authored-by: Jose Nino <jnino@lyft.com>
Signed-off-by: Mike Schore <mike.schore@gmail.com>
