### PR TITLE
stats: add scope for external stats

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -95,7 +95,7 @@ Engine::~Engine() {
 }
 
 void Engine::recordCounter(std::string elements, uint64_t count) {
-  if (server_ && scope_) {
+  if (server_ && external_scope_) {
     server_->dispatcher().post([this, elements, count]() -> void {
       absl::string_view dynamic_elements{elements};
       Stats::Utility::counterFromElements(*external_scope_, {dynamic_elements}).add(count);

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -50,7 +50,7 @@ envoy_status_t Engine::run(std::string config, std::string log_level) {
     postinit_callback_handler_ = main_common_->server()->lifecycleNotifier().registerCallback(
         Envoy::Server::ServerLifecycleNotifier::Stage::PostInit, [this]() -> void {
           server_ = TS_UNCHECKED_READ(main_common_)->server();
-          external_scope_ = server_->serverFactoryContext().scope().createScope("client.");
+          client_scope_ = server_->serverFactoryContext().scope().createScope("client.");
           auto api_listener = server_->listenerManager().apiListener()->get().http();
           ASSERT(api_listener.has_value());
           http_dispatcher_->ready(server_->dispatcher(), server_->serverFactoryContext().scope(),
@@ -95,10 +95,10 @@ Engine::~Engine() {
 }
 
 void Engine::recordCounter(std::string elements, uint64_t count) {
-  if (server_ && external_scope_) {
+  if (server_ && client_scope_) {
     server_->dispatcher().post([this, elements, count]() -> void {
       absl::string_view dynamic_elements{elements};
-      Stats::Utility::counterFromElements(*external_scope_, {dynamic_elements}).add(count);
+      Stats::Utility::counterFromElements(*client_scope_, {dynamic_elements}).add(count);
     });
   }
 }

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -50,7 +50,7 @@ envoy_status_t Engine::run(std::string config, std::string log_level) {
     postinit_callback_handler_ = main_common_->server()->lifecycleNotifier().registerCallback(
         Envoy::Server::ServerLifecycleNotifier::Stage::PostInit, [this]() -> void {
           server_ = TS_UNCHECKED_READ(main_common_)->server();
-          scope_ = server_->serverFactoryContext().scope().createScope("client.");
+          external_scope_ = server_->serverFactoryContext().scope().createScope("client.");
           auto api_listener = server_->listenerManager().apiListener()->get().http();
           ASSERT(api_listener.has_value());
           http_dispatcher_->ready(server_->dispatcher(), server_->serverFactoryContext().scope(),
@@ -98,7 +98,7 @@ void Engine::recordCounter(std::string elements, uint64_t count) {
   if (server_ && scope_) {
     server_->dispatcher().post([this, elements, count]() -> void {
       absl::string_view dynamic_elements{elements};
-      Stats::Utility::counterFromElements(*scope_, {dynamic_elements}).add(count);
+      Stats::Utility::counterFromElements(*external_scope_, {dynamic_elements}).add(count);
     });
   }
 }

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -97,7 +97,8 @@ Engine::~Engine() {
 void Engine::recordCounter(std::string elements, uint64_t count) {
   if (server_ && client_scope_) {
     server_->dispatcher().post([this, elements, count]() -> void {
-      Stats::Utility::counterFromElements(*client_scope_, {Stats::DynamicName(elements)}).add(count);
+      Stats::Utility::counterFromElements(*client_scope_, {Stats::DynamicName(elements)})
+          .add(count);
     });
   }
 }

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -94,7 +94,7 @@ Engine::~Engine() {
   main_thread_.join();
 }
 
-void Engine::recordCounter(std::string elements, uint64_t count) {
+void Engine::recordCounter(const std::string& elements, uint64_t count) {
   if (server_ && client_scope_) {
     server_->dispatcher().post([this, elements, count]() -> void {
       Stats::Utility::counterFromElements(*client_scope_, {Stats::DynamicName(elements)})

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -97,8 +97,7 @@ Engine::~Engine() {
 void Engine::recordCounter(std::string elements, uint64_t count) {
   if (server_ && client_scope_) {
     server_->dispatcher().post([this, elements, count]() -> void {
-      absl::string_view dynamic_elements{elements};
-      Stats::Utility::counterFromElements(*client_scope_, {dynamic_elements}).add(count);
+      Stats::Utility::counterFromElements(*client_scope_, {Stats::DynamicName(elements)}).add(count);
     });
   }
 }

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -50,7 +50,7 @@ public:
 private:
   envoy_status_t run(std::string config, std::string log_level);
 
-  Stats::ScopePtr scope_;
+  Stats::ScopePtr external_scope_;
   envoy_engine_callbacks callbacks_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -50,7 +50,7 @@ public:
 private:
   envoy_status_t run(std::string config, std::string log_level);
 
-  Stats::ScopePtr external_scope_;
+  Stats::ScopePtr client_scope_;
   envoy_engine_callbacks callbacks_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -38,7 +38,7 @@ public:
   /**
    * Increment a counter with a given string of elements and by the given count.
    */
-  void recordCounter(std::string elements, uint64_t count);
+  void recordCounter(const std::string& elements, uint64_t count);
 
   /**
    * Flush the stats sinks outside of a flushing interval.

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -50,6 +50,7 @@ public:
 private:
   envoy_status_t run(std::string config, std::string log_level);
 
+  Stats::ScopePtr scope_;
   envoy_engine_callbacks callbacks_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;


### PR DESCRIPTION
Description: Use a dedicated Stats::Scope for external stats.
Risk Level: Low
Testing: Local

Signed-off-by: Mike Schore <mike.schore@gmail.com>