### PR TITLE
dynamic forward proxy: restrict to ipv4

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -49,6 +49,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
               dns_cache_config: &dns_cache_config
                 name: dynamic_forward_proxy_cache_config
+                # TODO: Support IPV6 https://github.com/lyft/envoy-mobile/issues/1022
                 dns_lookup_family: V4_ONLY
                 dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
                 dns_failure_refresh_rate:

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -49,7 +49,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
               dns_cache_config: &dns_cache_config
                 name: dynamic_forward_proxy_cache_config
-                dns_lookup_family: AUTO
+                dns_lookup_family: V4_ONLY
                 dns_refresh_rate: {{ dns_refresh_rate_seconds }}s
                 dns_failure_refresh_rate:
                   base_interval: {{ dns_failure_refresh_rate_seconds_base }}s


### PR DESCRIPTION
Envoy Mobile currently does not handle IPV6 connections, and they fail with local 503s. This PR forces IPV4 for now until we add support in https://github.com/lyft/envoy-mobile/issues/1022.

Signed-off-by: Michael Rebello <me@michaelrebello.com>