### PR TITLE
filters: fix trailers callback signatures

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -32,9 +32,9 @@ class JvmCallbackContext {
   /**
    * Invokes onHeaders callback using headers passed via passHeaders.
    *
-   * @param length,    the total number of headers included in this header block.
-   * @param endStream, whether this header block is the final remote frame.
-   * @return Object,   not used for response callbacks.
+   * @param headerCount, the total number of headers included in this header block.
+   * @param endStream,   whether this header block is the final remote frame.
+   * @return Object,     not used for response callbacks.
    */
   public Object onResponseHeaders(long headerCount, boolean endStream) {
     assert bridgeUtility.validateCount(headerCount);
@@ -50,10 +50,10 @@ class JvmCallbackContext {
   /**
    * Invokes onTrailers callback using trailers passed via passHeaders.
    *
-   * @param length, the total number of trailers included in this header block.
-   * @return Object,not used for response callbacks.
+   * @param trailerCount, the total number of trailers included in this header block.
+   * @return Object,      not used for response callbacks.
    */
-  public Object onResponseTrailers(long trailerCount, boolean endStream) {
+  public Object onResponseTrailers(long trailerCount) {
     assert bridgeUtility.validateCount(trailerCount);
     final Map trailers = bridgeUtility.retrieveHeaders();
 

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -31,9 +31,9 @@ class JvmFilterContext {
   /**
    * Invokes onHeaders callback using headers passed via passHeaders.
    *
-   * @param length,    the total number of headers included in this header block.
-   * @param endStream, whether this header block is the final remote frame.
-   * @return Object,   not used for request filter.
+   * @param headerCount, the total number of headers included in this header block.
+   * @param endStream,   whether this header block is the final remote frame.
+   * @return Object,     not used for request filter.
    */
   public Object onRequestHeaders(long headerCount, boolean endStream) {
     assert bridgeUtility.validateCount(headerCount);
@@ -56,10 +56,10 @@ class JvmFilterContext {
   /**
    * Invokes onTrailers callback using trailers passed via passHeaders.
    *
-   * @param length, the total number of trailers included in this header block.
-   * @return Object,not used for request filter.
+   * @param trailerCount, the total number of trailers included in this header block.
+   * @return Object,      not used for request filter.
    */
-  public Object onRequestTrailers(long trailerCount, boolean endStream) {
+  public Object onRequestTrailers(long trailerCount) {
     assert bridgeUtility.validateCount(trailerCount);
     final Map trailers = bridgeUtility.retrieveHeaders();
     return filter.onRequestTrailers(trailers);
@@ -68,9 +68,9 @@ class JvmFilterContext {
   /**
    * Invokes onHeaders callback using headers passed via passHeaders.
    *
-   * @param length,    the total number of headers included in this header block.
-   * @param endStream, whether this header block is the final remote frame.
-   * @return Object,   not used for response filter.
+   * @param headerCount, the total number of headers included in this header block.
+   * @param endStream,   whether this header block is the final remote frame.
+   * @return Object,     not used for response filter.
    */
   public Object onResponseHeaders(long headerCount, boolean endStream) {
     assert bridgeUtility.validateCount(headerCount);
@@ -93,10 +93,10 @@ class JvmFilterContext {
   /**
    * Invokes onTrailers callback using trailers passed via passHeaders.
    *
-   * @param length, the total number of trailers included in this header block.
-   * @return Object,not used for response filter.
+   * @param trailerCount, the total number of trailers included in this header block.
+   * @return Object,      not used for response filter.
    */
-  public Object onResponseTrailers(long trailerCount, boolean endStream) {
+  public Object onResponseTrailers(long trailerCount) {
     assert bridgeUtility.validateCount(trailerCount);
     final Map trailers = bridgeUtility.retrieveHeaders();
     return filter.onResponseTrailers(trailers);


### PR DESCRIPTION
Description: Fixes incorrect signatures for the JNI calls on the trailers callback path in Android.
Risk Level: Low
Testing: Needs to be covered by AssertionFilter integration tests

Signed-off-by: Mike Schore <mike.schore@gmail.com>