### PR TITLE
dispatcher: schedule deletion for next event loop iteration

### DIFF
--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -2,6 +2,7 @@
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/event/schedulable_cb.h"
 #include "envoy/http/api_listener.h"
 #include "envoy/http/codec.h"
 #include "envoy/http/header_map.h"
@@ -265,6 +266,7 @@ private:
   // Shared synthetic address across DirectStreams.
   Network::Address::InstanceConstSharedPtr address_;
   Thread::ThreadSynchronizer synchronizer_;
+  std::vector<Event::SchedulableCallbackPtr> deferred_deleted_stream_cbs_;
 };
 
 } // namespace Http


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
