### PR TITLE
dispatcher: post to next iteration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "envoy"]
 	path = envoy
-	url = https://github.com/envoyproxy/envoy.git
+	url = https://github.com/junr03/envoy.git

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -517,7 +517,7 @@ void Dispatcher::cleanup(envoy_stream_t stream_handle) {
   // TODO: currently upstream Envoy does not have a deferred delete version for shared_ptr. This
   // means that instead of efficiently queuing the deletes for one event in the event loop, all
   // deletes here get queued up as individual posts.
-  TS_UNCHECKED_READ(event_dispatcher_)->post([direct_stream]() -> void {
+  TS_UNCHECKED_READ(event_dispatcher_)->postNextIteration([direct_stream]() -> void {
     ENVOY_LOG(debug, "[S{}] deferred deletion of stream", direct_stream->stream_handle_);
   });
   // However, the entry in the map should not exist after cleanup.


### PR DESCRIPTION
Description: after much investigation, we believe that recent crashes around stream cancellation (e.g. #1017 and #1016) come about due to breaking assumptions between ActiveStream destruction in Http::ConnectionManager and DirectStream destruction in Http::Dispatcher. While the former is deferred deleted via Event::Dispatcher::deferredDelete, the latter is destroyed via a post. In a [recent comment]()https://github.com/antoniovicente/envoy/blob/88fd2492bb2ee434966e04849928bea55f70d094/source/common/event/libevent_scheduler.h in Envoy's usage of libevent it became evident that the relative ordering  of execution of a post and a deferredDelete scheduled onto the same thread's Event::Dispatcher was not guaranteed for the current iteration of the event loop. 

This PR uses a temporary fork of envoy, where a `postNextIteration` function is introduced to the Event::Dispatcher's interface with the intention of forcing the pre-assumed ordering of stream destruction. The team at Lyft wants to verify this change internally before submitting the `postNextIteration` change to upstream envoy.
Risk Level: high, changes stream destruction via changes to the event dispatcher. However, the hypothesis is that this change will provide the previously assumed ordering that is desired (more comments in Http::Dispatcher::resetStream on the desired ordering).
Testing: local execution. Current unit and integration testing of the Http::Dispatcher.

Signed-off-by: Jose Nino <jnino@lyft.com>