### PR TITLE
jni: separate Android and base JNI interfaces

### DIFF
--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
 cc_binary(
     name = "libenvoy_jni.so",
     srcs = [
+        "android_jni_interface.cc",
         "jni_interface.cc",
     ],
     copts = ["-std=c++17"],

--- a/library/common/jni/android_jni_interface.cc
+++ b/library/common/jni/android_jni_interface.cc
@@ -1,0 +1,38 @@
+#include <android/log.h>
+#include <ares.h>
+#include <jni.h>
+
+#include "library/common/main_interface.h"
+
+// NOLINT(namespace-envoy)
+
+// AndroidJniLibrary
+
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
+                                                                   jclass, // class
+                                                                   jobject connectivity_manager) {
+  // See note above about c-ares.
+  // c-ares jvm init is necessary in order to let c-ares perform DNS resolution in Envoy.
+  // More information can be found at:
+  // https://c-ares.haxx.se/ares_library_init_android.html
+  ares_library_init_jvm(get_vm());
+
+  return ares_library_init_android(connectivity_manager);
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIEnv* env,
+                                                                            jclass, // class
+                                                                            jint network) {
+  __android_log_write(ANDROID_LOG_INFO, "[Envoy]", "setting preferred network");
+  return set_preferred_network(static_cast<envoy_network_t>(network));
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_flushStats(JNIEnv* env,
+                                                                   jclass // class
+) {
+  __android_log_write(ANDROID_LOG_INFO, "[Envoy]", "triggering stats flush");
+  flush_stats();
+}

--- a/library/common/jni/android_jni_interface.cc
+++ b/library/common/jni/android_jni_interface.cc
@@ -2,6 +2,7 @@
 #include <ares.h>
 #include <jni.h>
 
+#include "library/common/jni/jni_utility.h"
 #include "library/common/main_interface.h"
 
 // NOLINT(namespace-envoy)

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -62,42 +62,11 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_filterTemplateString(JNIEnv* en
   return result;
 }
 
-// AndroidJniLibrary
-
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
-                                                                   jclass, // class
-                                                                   jobject connectivity_manager) {
-  // See note above about c-ares.
-  // c-ares jvm init is necessary in order to let c-ares perform DNS resolution in Envoy.
-  // More information can be found at:
-  // https://c-ares.haxx.se/ares_library_init_android.html
-  ares_library_init_jvm(get_vm());
-
-  return ares_library_init_android(connectivity_manager);
-}
-
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIEnv* env,
-                                                                            jclass, // class
-                                                                            jint network) {
-  __android_log_write(ANDROID_LOG_INFO, "[Envoy]", "setting preferred network");
-  return set_preferred_network(static_cast<envoy_network_t>(network));
-}
-
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordCounter(JNIEnv* env,
                                                                jclass, // class
                                                                jstring elements, jint count) {
   record_counter(env->GetStringUTFChars(elements, nullptr), count);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_flushStats(JNIEnv* env,
-                                                                   jclass // class
-) {
-  __android_log_write(ANDROID_LOG_INFO, "[Envoy]", "triggering stats flush");
-  flush_stats();
 }
 
 // JvmCallbackContext


### PR DESCRIPTION
Description: Split interfaces to allow for creation of a non-Android build target.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>