### PR TITLE
jni: make get_env skip JNI calls for the normal case

### DIFF
--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -15,16 +15,18 @@ void set_vm(JavaVM* vm) { static_jvm = vm; }
 JavaVM* get_vm() { return static_jvm; }
 
 JNIEnv* get_env() {
-  if (local_env) { return local_env; }
+  if (local_env) {
+    return local_env;
+  }
 
   jint result = static_jvm->GetEnv(reinterpret_cast<void**>(&local_env), JNI_VERSION);
   if (result == JNI_EDETACHED) {
     // Note: the only thread that should need to be attached is Envoy's engine std::thread.
-    JavaVMAttachArgs args = { JNI_VERSION, "EnvoyMain", NULL };
+    JavaVMAttachArgs args = {JNI_VERSION, "EnvoyMain", NULL};
     result = static_jvm->AttachCurrentThread(&local_env, &args);
   }
   // TODO(goaway): add assertions and uncomment
-  //ASSERT(result == JNI_OK);
+  // ASSERT(result == JNI_OK);
   return local_env;
 }
 

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -8,24 +8,24 @@
 // NOLINT(namespace-envoy)
 
 static JavaVM* static_jvm = nullptr;
+static thread_local JNIEnv* local_env = nullptr;
 
 void set_vm(JavaVM* vm) { static_jvm = vm; }
 
 JavaVM* get_vm() { return static_jvm; }
 
 JNIEnv* get_env() {
-  JNIEnv* env = nullptr;
-  int get_env_res = static_jvm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION);
-  if (get_env_res == JNI_EDETACHED) {
-    // TODO(goway): fix logging
-    // log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "environment is JNI_EDETACHED");
+  if (local_env) { return local_env; }
+
+  jint result = static_jvm->GetEnv(reinterpret_cast<void**>(&local_env), JNI_VERSION);
+  if (result == JNI_EDETACHED) {
     // Note: the only thread that should need to be attached is Envoy's engine std::thread.
-    // TODO: harden this piece of code to make sure that we are only needing to attach Envoy
-    // engine's std::thread, and that we detach it successfully.
-    static_jvm->AttachCurrentThread(&env, nullptr);
-    static_jvm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION);
+    JavaVMAttachArgs args = { JNI_VERSION, "EnvoyMain", NULL };
+    result = static_jvm->AttachCurrentThread(reinterpret_cast<void**>(&local_env), &args);
   }
-  return env;
+  // TODO(goaway): add assertions and uncomment
+  //ASSERT(result == JNI_OK);
+  return local_env;
 }
 
 void jvm_detach_thread() { static_jvm->DetachCurrentThread(); }

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -21,7 +21,7 @@ JNIEnv* get_env() {
   if (result == JNI_EDETACHED) {
     // Note: the only thread that should need to be attached is Envoy's engine std::thread.
     JavaVMAttachArgs args = { JNI_VERSION, "EnvoyMain", NULL };
-    result = static_jvm->AttachCurrentThread(reinterpret_cast<void**>(&local_env), &args);
+    result = static_jvm->AttachCurrentThread(&local_env, &args);
   }
   // TODO(goaway): add assertions and uncomment
   //ASSERT(result == JNI_OK);


### PR DESCRIPTION
Description: Previously, get_env would make unnecessary JNI calls every time it was called, making it relatively expensive, and encouraging passing the pointer around everywhere. This makes it faster in the normal case by skipping JNI calls except for the first time a thread uses it.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>