### PR TITLE
Introduce Counter protocol

### DIFF
--- a/library/swift/src/StatsClientImpl.swift
+++ b/library/swift/src/StatsClientImpl.swift
@@ -13,6 +13,6 @@ final class StatsClientImpl: NSObject {
 
 extension StatsClientImpl: StatsClient {
   func counter(elements: [Element]) -> Counter {
-    return Counter(elements: elements, engine: self.engine)
+    return CounterImpl(elements: elements, engine: self.engine)
   }
 }

--- a/library/swift/src/stats/Counter.swift
+++ b/library/swift/src/stats/Counter.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// A time series counter.
 @objcMembers
-public class Counter: NSObject {
+open public class Counter: NSObject {
   private let series: String
   private weak var engine: EnvoyEngine?
 

--- a/library/swift/src/stats/Counter.swift
+++ b/library/swift/src/stats/Counter.swift
@@ -1,24 +1,15 @@
-@_implementationOnly import EnvoyEngine
 import Foundation
 
 /// A time series counter.
-@objcMembers
-open public class Counter: NSObject {
-  private let series: String
-  private weak var engine: EnvoyEngine?
-
-  init(elements: [Element], engine: EnvoyEngine) {
-    self.series = elements.map { $0.value }.joined(separator: ".")
-    self.engine = engine
-    super.init()
-  }
-
+@objc
+public protocol Counter: AnyObject {
   /// Increment the counter by the given count.
-  public func increment(count: Int = 1) {
-    guard let engine = self.engine else {
-      return
-    }
+  func increment(count: Int)
+}
 
-    engine.recordCounter(self.series, count: numericCast(count))
+extension Counter {
+  /// Increment the counter by 1.
+  public func increment() {
+    self.increment(count: 1)
   }
 }

--- a/library/swift/src/stats/CounterImpl.swift
+++ b/library/swift/src/stats/CounterImpl.swift
@@ -1,0 +1,24 @@
+@_implementationOnly import EnvoyEngine
+import Foundation
+
+/// The implementation of time series counter.
+@objcMembers
+class CounterImpl: NSObject, Counter {
+  private let series: String
+  private weak var engine: EnvoyEngine?
+
+  init(elements: [Element], engine: EnvoyEngine) {
+    self.series = elements.map { $0.value }.joined(separator: ".")
+    self.engine = engine
+    super.init()
+  }
+
+  /// Increment the counter by the given count.
+  func increment(count: Int) {
+    guard let engine = self.engine else {
+      return
+    }
+
+    engine.recordCounter(self.series, count: numericCast(count))
+  }
+}

--- a/library/swift/test/BUILD
+++ b/library/swift/test/BUILD
@@ -70,3 +70,10 @@ envoy_mobile_swift_test(
         "//library/objective-c:envoy_engine_objc_lib",
     ],
 )
+
+envoy_mobile_swift_test(
+    name = "counter_tests",
+    srcs = [
+        "CounterTests.swift",
+    ],
+)

--- a/library/swift/test/CounterTests.swift
+++ b/library/swift/test/CounterTests.swift
@@ -1,0 +1,18 @@
+import Envoy
+import Foundation
+import XCTest
+
+final class CounterTests: XCTestCase {
+    func testConvenientMethodDelegatesToTheMainMethod() {
+        struct MockCounterImpl: Counter {
+            var wasIncremented = false
+            func increment(count: Int) {
+                self.wasIncremented = true
+            }
+        }
+
+        let counter = MockCounterImpl()
+        counter.increment()
+        XCTAssertTrue(counter.wasIncremented)
+    }
+}

--- a/library/swift/test/CounterTests.swift
+++ b/library/swift/test/CounterTests.swift
@@ -1,5 +1,4 @@
 import Envoy
-import Foundation
 import XCTest
 
 final class CounterTests: XCTestCase {

--- a/library/swift/test/CounterTests.swift
+++ b/library/swift/test/CounterTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class CounterTests: XCTestCase {
     func testConvenientMethodDelegatesToTheMainMethod() {
-        struct MockCounterImpl: Counter {
+        class MockCounterImpl: Counter {
             var wasIncremented = false
             func increment(count: Int) {
                 self.wasIncremented = true

--- a/library/swift/test/CounterTests.swift
+++ b/library/swift/test/CounterTests.swift
@@ -4,14 +4,14 @@ import XCTest
 final class CounterTests: XCTestCase {
     func testConvenientMethodDelegatesToTheMainMethod() {
         class MockCounterImpl: Counter {
-            var wasIncremented = false
+            var count: Int?
             func increment(count: Int) {
-                self.wasIncremented = true
+                self.count = count
             }
         }
 
         let counter = MockCounterImpl()
         counter.increment()
-        XCTAssertTrue(counter.wasIncremented)
+        XCTAssertEqual(1, counter.count)
     }
 }


### PR DESCRIPTION
Description: Make `StatsClient` protocol's interface return `Counter` protocol (as opposed to `Counter` class) to make mocking of the `StatsClient` easier.

Use case: in our Lyft application we need a way to mock `StatsClient` (protocol). An instance of the object conforming to this protocol can be created with the use of Envoy engine. In unit tests, we do not want to use Envoy engine and hence we need a way to create a custom object conforming to `StatsClient` protocol.
To implement a `StatsClient` protocol one needs to implements `func counter(_ elements: [Element]) -> Counter` method. In order to implement this method a developer needs to be able to initialize a new instance of `Counter`, it's currently not possible to do from outside of the module in which `Counter` is defined because:
1. `Counter` does  not provide any public initializer.
2. `Counter` cannot be subclassed since public classes don't allow for subclassing from outside of the module in which they are defined.

Risk Level: Low, additive change
Testing: No testing performed since it shouldn't influence the way framework works
Docs Changes: No changes
Release Notes: No changes
