### PR TITLE
docs: update doc to reflect recent api changes

### DIFF
--- a/docs/root/api/api.rst
+++ b/docs/root/api/api.rst
@@ -12,3 +12,4 @@ provided is grouped by feature and provides examples for both iOS and Android in
   starting_envoy
   http
   grpc
+  stats

--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -7,32 +7,34 @@ Starting Envoy
 ``StreamClient``
 ----------------
 
-Starting an instance of Envoy Mobile for performing requests is done by creating a ``StreamClient``.
+Starting an instance of Envoy Mobile is done by building the ``Engine`` instance with ``EngineBuilder``. Requests are performed by the ``StatsClient`` provided by ``Engine``.
 
-To do so, create a ``StreamClientBuilder`` and call ``build()`` (see below).
+To obtain a ``StatsClient``, call ``streamClient()`` on the ``Engine`` instance (see below).
 
-After the client is created, it should be stored and used to start network requests/streams.
+After the stream client is obtain, it should be stored and used to start network requests/streams.
 
 **Kotlin example**::
 
-  val streamClient = AndroidStreamClientBuilder(getApplication())
+  val streamClient = AndroidEngineBuilder(getApplication())
     .addLogLevel(LogLevel.WARN)
     ...
     .build()
+    .streamClient()
 
 **Swift example**::
 
-  let streamClient = try StreamClientBuilder()
+  let streamClient = try EngineBuilder()
     .addLogLevel(.warn)
     ...
     .build()
+    .streamClient()
 
 -----------------------
-``StreamClientBuilder``
+``EngineBuilder``
 -----------------------
 
-This type is used to configure an instance of ``StreamClient`` before finally
-creating the client using ``.build()``.
+This type is used to configure an instance of ``Engine`` before finally
+creating the engine using ``.build()``.
 
 Available builders are 1:1 between iOS/Android, and are documented below.
 
@@ -195,19 +197,21 @@ This may be done by initializing a builder with the contents of the YAML file yo
 
 **Kotlin example**::
 
-  val streamClient = AndroidStreamClientBuilder(baseContext, Yaml(yamlFileString))
+  val streamClient = AndroidEngineBuilder(baseContext, Yaml(yamlFileString))
     .addLogLevel(LogLevel.WARN)
     .addStatsFlushSeconds(60)
     ...
     .build()
+    .streamClient()
 
 **Swift example**::
 
-  let streamClient = try StreamClientBuilder(yaml: yamlFileString)
+  let streamClient = try EngineBuilder(yaml: yamlFileString)
     .addLogLevel(.warn)
     .addStatsFlushSeconds(60)
     ...
     .build()
+    .streamClient()
 
 .. attention::
 
@@ -219,7 +223,7 @@ This may be done by initializing a builder with the contents of the YAML file yo
 Making requests
 ---------------
 
-Now that you have an Envoy Mobile instance, you can start making requests:
+Now that you have a stream client instance, you can start making requests:
 
 - :ref:`HTTP requests and streams <api_http>`
 - :ref:`gRPC streams <api_grpc>`

--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -29,9 +29,9 @@ After the stream client is obtain, it should be stored and used to start network
     .build()
     .streamClient()
 
------------------------
+-----------------
 ``EngineBuilder``
------------------------
+-----------------
 
 This type is used to configure an instance of ``Engine`` before finally
 creating the engine using ``.build()``.

--- a/docs/root/api/stats.rst
+++ b/docs/root/api/stats.rst
@@ -1,0 +1,23 @@
+.. _api_stats:
+
+Stats
+=========================
+
+----------------
+``StatsClient``
+----------------
+
+To use Envoy Mobile's stats function, obtain an instance of ``StatsClient`` from ``Engine`` (refer to :ref:`api_starting_envoy` for building an engine instance), and store the stats client to create ``Counter`` instances.
+
+**Kotlin example**::
+
+  statsClient.counter(Element("foo"), Element"bar"))
+
+**Swift example**::
+  
+  statsClient.counter(elements: ["foo", "bar"])
+ 
+The ``counter`` method from stats client takes a variable number of elements and returns a ``Counter`` instance, the elements are used to for a dot(.) delimited string. For the example code above, the formed string is ``foo.bar``, this string serves as the identifier of the counter.
+
+Store the counter instance, and call the ``increment`` method to increment the counter wherever it applies.
+

--- a/docs/root/api/stats.rst
+++ b/docs/root/api/stats.rst
@@ -24,7 +24,7 @@ Store the counter instance, and call the ``increment`` method to increment the c
 The count argument of ``increment`` is defauled with value 1.
 
 **Example**::
-  
+
   // Increment the counter by 1
   // Kotlin, Swift
   counter.increment()

--- a/docs/root/api/stats.rst
+++ b/docs/root/api/stats.rst
@@ -11,7 +11,7 @@ To use Envoy Mobile's stats function, obtain an instance of ``StatsClient`` from
 
 **Kotlin example**::
 
-  statsClient.counter(Element("foo"), Element"bar"))
+  statsClient.counter(Element("foo"), Element("bar"))
 
 **Swift example**::
 
@@ -20,3 +20,19 @@ To use Envoy Mobile's stats function, obtain an instance of ``StatsClient`` from
 The ``counter`` method from stats client takes a variable number of elements and returns a ``Counter`` instance, the elements are used to for a dot(.) delimited string. For the example code above, the formed string is ``foo.bar``, this string serves as the identifier of the counter.
 
 Store the counter instance, and call the ``increment`` method to increment the counter wherever it applies.
+
+The count argument of ``increment`` is defauled with value 1.
+
+**Example**::
+  
+  // Increment the counter by 1
+  // Kotlin, Swift
+  counter.increment()
+
+  // Increment the counter by 5
+  // Kotlin
+  counter.increment(count = 5)
+
+  // Increment the counter by 5
+  // Swift
+  counter.increment(count: 5)

--- a/docs/root/api/stats.rst
+++ b/docs/root/api/stats.rst
@@ -14,10 +14,9 @@ To use Envoy Mobile's stats function, obtain an instance of ``StatsClient`` from
   statsClient.counter(Element("foo"), Element"bar"))
 
 **Swift example**::
-  
+
   statsClient.counter(elements: ["foo", "bar"])
- 
+
 The ``counter`` method from stats client takes a variable number of elements and returns a ``Counter`` instance, the elements are used to for a dot(.) delimited string. For the example code above, the formed string is ``foo.bar``, this string serves as the identifier of the counter.
 
 Store the counter instance, and call the ``increment`` method to increment the counter wherever it applies.
-

--- a/docs/root/api/stats.rst
+++ b/docs/root/api/stats.rst
@@ -31,7 +31,7 @@ The count argument of ``increment`` is defauled with value 1.
 
   // Increment the counter by 5
   // Kotlin
-  counter.increment(count = 5)
+  counter.increment(5)
 
   // Increment the counter by 5
   // Swift

--- a/docs/root/api/stats.rst
+++ b/docs/root/api/stats.rst
@@ -1,11 +1,11 @@
 .. _api_stats:
 
 Stats
-=========================
+=====
 
-----------------
+---------------
 ``StatsClient``
-----------------
+---------------
 
 To use Envoy Mobile's stats function, obtain an instance of ``StatsClient`` from ``Engine`` (refer to :ref:`api_starting_envoy` for building an engine instance), and store the stats client to create ``Counter`` instances.
 


### PR DESCRIPTION
Updates the [Start Envoy](https://github.com/lyft/envoy-mobile/blob/main/docs/root/api/starting_envoy.rst) section and adds doc for `Stats` to reflect the api changes introduced by https://github.com/lyft/envoy-mobile/commit/b9a4334916159eebe68a544690a1eb9e4023dbc4

Signed-off-by: Jingwei Hao <jingweih@lyft.com>