### PR TITLE
jni: fix unreleased local refs

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -302,7 +302,7 @@ static void* jvm_on_error(envoy_error error, void* context) {
   error.message.release(error.message.context);
   // No further callbacks happen on this context. Delete the reference held by native code.
   env->DeleteGlobalRef(j_context);
-  env->DeleteLocalRef(jcls_JvmObserverContext)
+  env->DeleteLocalRef(jcls_JvmObserverContext);
   return result;
 }
 
@@ -326,7 +326,7 @@ static void* jvm_on_cancel(void* context) {
 
   // No further callbacks happen on this context. Delete the reference held by native code.
   env->DeleteGlobalRef(j_context);
-  env->DeleteLocalRef(jcls_JvmObserverContext)
+  env->DeleteLocalRef(jcls_JvmObserverContext);
   return result;
 }
 
@@ -346,7 +346,7 @@ static const void* jvm_http_filter_init(const void* context) {
   jobject j_filter = env->CallObjectMethod(j_context, jmid_create);
   __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_filter: %p", j_filter);
   jobject retained_filter = env->NewGlobalRef(j_filter);
-  env->DeleteLocalRef(jcls_JvmObserverContext)
+  env->DeleteLocalRef(jcls_JvmObserverContext);
   return retained_filter;
 }
 

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -302,6 +302,7 @@ static void* jvm_on_error(envoy_error error, void* context) {
   error.message.release(error.message.context);
   // No further callbacks happen on this context. Delete the reference held by native code.
   env->DeleteGlobalRef(j_context);
+  env->DeleteLocalRef(jcls_JvmObserverContext)
   return result;
 }
 
@@ -325,6 +326,7 @@ static void* jvm_on_cancel(void* context) {
 
   // No further callbacks happen on this context. Delete the reference held by native code.
   env->DeleteGlobalRef(j_context);
+  env->DeleteLocalRef(jcls_JvmObserverContext)
   return result;
 }
 
@@ -344,6 +346,7 @@ static const void* jvm_http_filter_init(const void* context) {
   jobject j_filter = env->CallObjectMethod(j_context, jmid_create);
   __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_filter: %p", j_filter);
   jobject retained_filter = env->NewGlobalRef(j_filter);
+  env->DeleteLocalRef(jcls_JvmObserverContext)
   return retained_filter;
 }
 

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -346,7 +346,7 @@ static const void* jvm_http_filter_init(const void* context) {
   jobject j_filter = env->CallObjectMethod(j_context, jmid_create);
   __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_filter: %p", j_filter);
   jobject retained_filter = env->NewGlobalRef(j_filter);
-  env->DeleteLocalRef(jcls_JvmObserverContext);
+  env->DeleteLocalRef(jcls_JvmFilterFactoryContext);
   return retained_filter;
 }
 


### PR DESCRIPTION
In the case when the JVM calls a native method, the native method will automatically handle local references within the method upon a the method's return.

However, in the case where the native method calls a JVM method, local references created will not be deleted after the method returns. In some of these cases, we have forgotten to clean up some of these local references prior to returning.

While we previously did not do this clean up for `on_error` and `on_cancel` and since these were rarer events, we did not observe any issues. However, with the introduction of platform based filters, we also did not clean this up for the filter initialization which does occur more often and we ran into issues.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: jni: fix unreleased local refs
Risk Level: low
Testing: ci
Docs Changes: na
Release Notes: na
[Optional Fixes #Issue]
[Optional Deprecated:]
