### PR TITLE
stats: ensure client_scope_ destruction occurs ahead of main_common_ destruction

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -65,8 +65,9 @@ envoy_status_t Engine::run(std::string config, std::string log_level) {
   callbacks_.on_exit();
 
   // Ensure destructors run on Envoy's main thread.
-  postinit_callback_handler_.reset();
-  TS_UNCHECKED_READ(main_common_).reset();
+  postinit_callback_handler_.reset(nullptr);
+  client_scope_.reset(nullptr);
+  TS_UNCHECKED_READ(main_common_).reset(nullptr);
 
   return run_success ? ENVOY_SUCCESS : ENVOY_FAILURE;
 }


### PR DESCRIPTION
Description: scope destruction should happen ahead of destroying main_common_. Additionally while cross thread destruction is acceptable, this PR also moves destruction to happen in the context of the main thread.
Risk Level: med - resolve crash
Testing: repro in alpha builds of the lyft app.

Signed-off-by: Jose Nino <jnino@lyft.com>
