### PR TITLE
assertion filter: update to be pass-through

### DIFF
--- a/library/common/extensions/filters/http/assertion/BUILD
+++ b/library/common/extensions/filters/http/assertion/BUILD
@@ -18,6 +18,7 @@ envoy_cc_library(
         ":pkg_cc_proto",
         "@envoy//include/envoy/http:codes_interface",
         "@envoy//include/envoy/http:filter_interface",
+        "@envoy//source/common/http:header_map_lib",
         "@envoy//source/extensions/common/matcher:matcher_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],

--- a/library/common/extensions/filters/http/assertion/filter.cc
+++ b/library/common/extensions/filters/http/assertion/filter.cc
@@ -1,6 +1,7 @@
 #include "library/common/extensions/filters/http/assertion/filter.h"
 
 #include "common/http/header_map_impl.h"
+
 #include "envoy/http/codes.h"
 #include "envoy/server/filter_config.h"
 

--- a/library/common/extensions/filters/http/assertion/filter.cc
+++ b/library/common/extensions/filters/http/assertion/filter.cc
@@ -1,9 +1,9 @@
 #include "library/common/extensions/filters/http/assertion/filter.h"
 
-#include "common/http/header_map_impl.h"
-
 #include "envoy/http/codes.h"
 #include "envoy/server/filter_config.h"
+
+#include "common/http/header_map_impl.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/library/common/extensions/filters/http/assertion/filter.cc
+++ b/library/common/extensions/filters/http/assertion/filter.cc
@@ -23,8 +23,7 @@ AssertionFilter::AssertionFilter(AssertionFilterConfigSharedPtr config) : config
   config_->rootMatcher().onNewStream(statuses_);
 }
 
-Http::FilterHeadersStatus AssertionFilter::decodeHeaders(Http::RequestHeaderMap& headers,
-                                                         bool) {
+Http::FilterHeadersStatus AssertionFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
   config_->rootMatcher().onHttpRequestHeaders(headers, statuses_);
   if (!config_->rootMatcher().matchStatus(statuses_).matches_) {
     decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,

--- a/library/common/extensions/filters/http/assertion/filter.cc
+++ b/library/common/extensions/filters/http/assertion/filter.cc
@@ -53,7 +53,7 @@ Http::FilterHeadersStatus AssertionFilter::decodeHeaders(Http::RequestHeaderMap&
       return Http::FilterHeadersStatus::StopIteration;
     }
 
-    // Check of there are unsatisfied assertions about stream trailers.
+    // Check if there are unsatisfied assertions about stream trailers.
     auto empty_trailers = Http::RequestTrailerMapImpl::create();
     config_->rootMatcher().onHttpRequestTrailers(*empty_trailers, statuses_);
     auto& finalMatchStatus = config_->rootMatcher().matchStatus(statuses_);
@@ -89,7 +89,7 @@ Http::FilterDataStatus AssertionFilter::decodeData(Buffer::Instance& data, bool 
   }
 
   if (end_stream) {
-    // Check of there are unsatisfied assertions about stream trailers.
+    // Check if there are unsatisfied assertions about stream trailers.
     auto empty_trailers = Http::RequestTrailerMapImpl::create();
     config_->rootMatcher().onHttpRequestTrailers(*empty_trailers, statuses_);
     auto& match_status = config_->rootMatcher().matchStatus(statuses_);

--- a/library/common/extensions/filters/http/assertion/filter.cc
+++ b/library/common/extensions/filters/http/assertion/filter.cc
@@ -20,6 +20,11 @@ Extensions::Common::Matcher::Matcher& AssertionFilterConfig::rootMatcher() const
   return *matchers_[0];
 }
 
+// Implementation of this filter is complicated by the fact that the streaming matchers have no
+// explicit mechanism to handle end_stream. This means that we must infer that matching has failed
+// if the stream ends with still-unsatisfied matches. We do this by potentially passing empty
+// body data and empty trailers to the matchers in the event the stream ends without including
+// these entities.
 AssertionFilter::AssertionFilter(AssertionFilterConfigSharedPtr config) : config_(config) {
   statuses_ = Extensions::Common::Matcher::Matcher::MatchStatusVector(config_->matchersSize());
   config_->rootMatcher().onNewStream(statuses_);
@@ -28,8 +33,8 @@ AssertionFilter::AssertionFilter(AssertionFilterConfigSharedPtr config) : config
 Http::FilterHeadersStatus AssertionFilter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                          bool end_stream) {
   config_->rootMatcher().onHttpRequestHeaders(headers, statuses_);
-  auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
-  if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
+  auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+  if (!match_status.matches_ && !match_status.might_change_status_) {
     decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
                                        "Request Headers do not match configured expectations",
                                        nullptr, absl::nullopt, "");
@@ -37,16 +42,18 @@ Http::FilterHeadersStatus AssertionFilter::decodeHeaders(Http::RequestHeaderMap&
   }
 
   if (end_stream) {
+    // Check if there are unsatisfied assertions about stream data.
     Buffer::OwnedImpl empty_buffer;
     config_->rootMatcher().onRequestBody(empty_buffer, statuses_);
-    auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
-    if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
+    auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+    if (!match_status.matches_ && !match_status.might_change_status_) {
       decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
                                          "Request Body does not match configured expectations",
                                          nullptr, absl::nullopt, "");
       return Http::FilterHeadersStatus::StopIteration;
     }
 
+    // Check of there are unsatisfied assertions about stream trailers.
     auto empty_trailers = Http::RequestTrailerMapImpl::create();
     config_->rootMatcher().onHttpRequestTrailers(*empty_trailers, statuses_);
     auto& finalMatchStatus = config_->rootMatcher().matchStatus(statuses_);
@@ -56,6 +63,10 @@ Http::FilterHeadersStatus AssertionFilter::decodeHeaders(Http::RequestHeaderMap&
                                          nullptr, absl::nullopt, "");
       return Http::FilterHeadersStatus::StopIteration;
     }
+
+    // Because a stream only contains a single set of headers or trailers, if either fail to
+    // satisfy assertions, might_change_status_ will be false. Therefore if matches_ is still
+    // unsatisfied here, it must be because of body data.
     if (!finalMatchStatus.matches_) {
       decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
                                          "Request Body does not match configured expectations",
@@ -69,8 +80,8 @@ Http::FilterHeadersStatus AssertionFilter::decodeHeaders(Http::RequestHeaderMap&
 
 Http::FilterDataStatus AssertionFilter::decodeData(Buffer::Instance& data, bool end_stream) {
   config_->rootMatcher().onRequestBody(data, statuses_);
-  auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
-  if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
+  auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+  if (!match_status.matches_ && !match_status.might_change_status_) {
     decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
                                        "Request Body does not match configured expectations",
                                        nullptr, absl::nullopt, "");
@@ -78,16 +89,20 @@ Http::FilterDataStatus AssertionFilter::decodeData(Buffer::Instance& data, bool 
   }
 
   if (end_stream) {
+    // Check of there are unsatisfied assertions about stream trailers.
     auto empty_trailers = Http::RequestTrailerMapImpl::create();
     config_->rootMatcher().onHttpRequestTrailers(*empty_trailers, statuses_);
-    auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
-    if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
+    auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+    if (!match_status.matches_ && !match_status.might_change_status_) {
       decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
                                          "Request Trailers do not match configured expectations",
                                          nullptr, absl::nullopt, "");
       return Http::FilterDataStatus::StopIterationNoBuffer;
     }
-    if (!matchStatus.matches_) {
+    // Because a stream only contains a single set of headers or trailers, if either fail to
+    // satisfy assertions, might_change_status_ will be false. Therefore if matches_ is still
+    // unsatisfied here, it must be because of body data.
+    if (!match_status.matches_) {
       decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
                                          "Request Body does not match configured expectations",
                                          nullptr, absl::nullopt, "");
@@ -99,14 +114,17 @@ Http::FilterDataStatus AssertionFilter::decodeData(Buffer::Instance& data, bool 
 
 Http::FilterTrailersStatus AssertionFilter::decodeTrailers(Http::RequestTrailerMap& trailers) {
   config_->rootMatcher().onHttpRequestTrailers(trailers, statuses_);
-  auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
-  if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
+  auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+  if (!match_status.matches_ && !match_status.might_change_status_) {
     decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
                                        "Request Trailers do not match configured expectations",
                                        nullptr, absl::nullopt, "");
     return Http::FilterTrailersStatus::StopIteration;
   }
-  if (!matchStatus.matches_) {
+  // Because a stream only contains a single set of headers or trailers, if either fail to
+  // satisfy assertions, might_change_status_ will be false. Therefore if matches_ is still
+  // unsatisfied here, it must be because of body data.
+  if (!match_status.matches_) {
     decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
                                        "Request Body does not match configured expectations",
                                        nullptr, absl::nullopt, "");

--- a/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -31,7 +31,7 @@ public:
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
 };
 
-TEST_F(AssertionFilterTest, HeadersMatchWithEndStream) {
+TEST_F(AssertionFilterTest, RequestHeadersMatchWithEndStream) {
   setUpFilter(R"EOF(
 match_config:
   http_request_headers_match:
@@ -45,7 +45,7 @@ match_config:
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 
-TEST_F(AssertionFilterTest, HeadersMatch) {
+TEST_F(AssertionFilterTest, RequestHeadersMatch) {
   setUpFilter(R"EOF(
 match_config:
   http_request_headers_match:
@@ -59,7 +59,7 @@ match_config:
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 }
 
-TEST_F(AssertionFilterTest, HeadersNoMatch) {
+TEST_F(AssertionFilterTest, RequestHeadersNoMatchWithEndStream) {
   setUpFilter(R"EOF(
 match_config:
   http_request_headers_match:
@@ -77,49 +77,25 @@ match_config:
             filter_->decodeHeaders(request_headers, true));
 }
 
-TEST_F(AssertionFilterTest, DataMatchWithEndStream) {
+TEST_F(AssertionFilterTest, RequestHeadersNoMatch) {
   setUpFilter(R"EOF(
 match_config:
-  http_request_generic_body_match:
-    patterns:
-      - string_match: match_me
+  http_request_headers_match:
+    headers:
+      - name: ":authority"
+        exact_match: test.code
 )EOF");
 
-  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
-
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(*body, true));
-}
-
-TEST_F(AssertionFilterTest, DataMatch) {
-  setUpFilter(R"EOF(
-match_config:
-  http_request_generic_body_match:
-    patterns:
-      - string_match: match_me
-)EOF");
-
-  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
-
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(*body, false));
-}
-
-TEST_F(AssertionFilterTest, DataNoMatch) {
-  setUpFilter(R"EOF(
-match_config:
-  http_request_generic_body_match:
-    patterns:
-      - string_match: match_me
-)EOF");
-
-  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "no.match"}};
 
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::BadRequest,
-                             "Request Body does not match configured expectations", _, _, ""));
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(*body, true));
+                             "Request Headers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
 }
 
-TEST_F(AssertionFilterTest, DataMissing) {
+TEST_F(AssertionFilterTest, RequestHeadersMatchWithEndstreamAndDataMissing) {
   setUpFilter(R"EOF(
 match_config:
   and_match:
@@ -142,7 +118,124 @@ match_config:
             filter_->decodeHeaders(request_headers, true));
 }
 
-TEST_F(AssertionFilterTest, TrailersMatch) {
+TEST_F(AssertionFilterTest, RequestHeadersMatchWithEndstreamAndTrailersMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_request_headers_match:
+        headers:
+          - name: ":authority"
+            exact_match: test.code
+    - http_request_trailers_match:
+        headers:
+          - name: "test-trailer"
+            exact_match: test.code
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, true));
+}
+
+TEST_F(AssertionFilterTest, RequestDataMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, RequestDataMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(*body, false));
+}
+
+TEST_F(AssertionFilterTest, RequestDataNoMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, RequestDataMatchWithEndStreamAndTrailersMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_request_generic_body_match:
+        patterns:
+          - string_match: match_me
+    - http_request_trailers_match:
+        headers:
+          - name: "test-trailer"
+            exact_match: test.code
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, RequestDataNoMatchAfterTrailers) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_request_headers_match:
+        headers:
+          - name: ":authority"
+            exact_match: test.code
+    - http_request_generic_body_match:
+        patterns:
+        - string_match: match_me
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+  Http::TestRequestTrailerMapImpl request_trailers{{"test-trailer", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter_->decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue,
+            filter_->decodeData(*body, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration,
+            filter_->decodeTrailers(request_trailers));
+}
+
+TEST_F(AssertionFilterTest, RequestTrailersMatch) {
   setUpFilter(R"EOF(
 match_config:
   http_request_trailers_match:
@@ -156,7 +249,7 @@ match_config:
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
 
-TEST_F(AssertionFilterTest, TrailersNoMatch) {
+TEST_F(AssertionFilterTest, RequestTrailersNoMatch) {
   setUpFilter(R"EOF(
 match_config:
   http_request_trailers_match:

--- a/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -42,10 +42,7 @@ match_config:
 
   Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
 
-  EXPECT_CALL(
-      decoder_callbacks_,
-      sendLocalReply(Http::Code::OK, "Request Headers match configured expectations", _, _, ""));
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(request_headers, true));
 }
 
@@ -91,10 +88,7 @@ match_config:
 
   Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
 
-  EXPECT_CALL(
-      decoder_callbacks_,
-      sendLocalReply(Http::Code::OK, "Request Body match configured expectations", _, _, ""));
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(*body, true));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(*body, true));
 }
 
 TEST_F(AssertionFilterTest, DataMatch) {
@@ -137,10 +131,7 @@ match_config:
 
   Http::TestRequestTrailerMapImpl request_trailers{{"test-trailer", "test.code"}};
 
-  EXPECT_CALL(
-      decoder_callbacks_,
-      sendLocalReply(Http::Code::OK, "Request Trailers match configured expectations", _, _, ""));
-  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
 
 TEST_F(AssertionFilterTest, TrailersNoMatch) {

--- a/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -227,12 +227,9 @@ match_config:
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::BadRequest,
                              "Request Body does not match configured expectations", _, _, ""));
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(request_headers, false));
-  EXPECT_EQ(Http::FilterDataStatus::Continue,
-            filter_->decodeData(*body, false));
-  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration,
-            filter_->decodeTrailers(request_trailers));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(*body, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
 }
 
 TEST_F(AssertionFilterTest, RequestTrailersMatch) {

--- a/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -119,6 +119,22 @@ match_config:
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(*body, true));
 }
 
+TEST_F(AssertionFilterTest, DataMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+}
+
 TEST_F(AssertionFilterTest, TrailersMatch) {
   setUpFilter(R"EOF(
 match_config:

--- a/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -42,8 +42,7 @@ match_config:
 
   Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 
 TEST_F(AssertionFilterTest, HeadersMatch) {

--- a/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -122,9 +122,15 @@ match_config:
 TEST_F(AssertionFilterTest, DataMissing) {
   setUpFilter(R"EOF(
 match_config:
-  http_request_generic_body_match:
-    patterns:
-      - string_match: match_me
+  and_match:
+    rules:
+    - http_request_headers_match:
+        headers:
+          - name: ":authority"
+            exact_match: test.code
+    - http_request_generic_body_match:
+        patterns:
+        - string_match: match_me
 )EOF");
 
   Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
@@ -132,7 +138,8 @@ match_config:
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::BadRequest,
                              "Request Body does not match configured expectations", _, _, ""));
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, true));
 }
 
 TEST_F(AssertionFilterTest, TrailersMatch) {


### PR DESCRIPTION
Description: Updates theAssertionFilter to always return ::Continue when validation checks pass. Fixes some bugs when requests should have failed, but wouldn't, or should have passed, but wouldn't:
- Processing would be aborted for truncated requests, but potentially still appear to pass: e.g., a filter set up to validate conditions on headers and body could return 200 for headers-only requests, skipping body validation.
- If data was streamed, but the first chunk didn't pass all data assertions on its own, processing would fail, even if later chunks would have passed validation.
- Testing of conditions before and after another filter wasn't possible.

For integration tests, there's not much downside to the pass-through behavior, since the Router can always be configured to return a 200 direct response, or any other sentinel value.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>