### PR TITLE
assertion filter: add response assertion support

### DIFF
--- a/library/common/extensions/filters/http/assertion/filter.cc
+++ b/library/common/extensions/filters/http/assertion/filter.cc
@@ -138,7 +138,7 @@ Http::FilterHeadersStatus AssertionFilter::encodeHeaders(Http::ResponseHeaderMap
   config_->rootMatcher().onHttpResponseHeaders(headers, statuses_);
   auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
   if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
-    encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                        "Response Headers do not match configured expectations",
                                        nullptr, absl::nullopt, "");
     return Http::FilterHeadersStatus::StopIteration;
@@ -149,7 +149,7 @@ Http::FilterHeadersStatus AssertionFilter::encodeHeaders(Http::ResponseHeaderMap
     config_->rootMatcher().onResponseBody(empty_buffer, statuses_);
     auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
     if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
-      encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+      decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                          "Response Body does not match configured expectations",
                                          nullptr, absl::nullopt, "");
       return Http::FilterHeadersStatus::StopIteration;
@@ -159,13 +159,13 @@ Http::FilterHeadersStatus AssertionFilter::encodeHeaders(Http::ResponseHeaderMap
     config_->rootMatcher().onHttpResponseTrailers(*empty_trailers, statuses_);
     auto& finalMatchStatus = config_->rootMatcher().matchStatus(statuses_);
     if (!finalMatchStatus.matches_ && !finalMatchStatus.might_change_status_) {
-      encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+      decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                          "Response Trailers do not match configured expectations",
                                          nullptr, absl::nullopt, "");
       return Http::FilterHeadersStatus::StopIteration;
     }
     if (!finalMatchStatus.matches_) {
-      encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+      decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                          "Response Body does not match configured expectations",
                                          nullptr, absl::nullopt, "");
       return Http::FilterHeadersStatus::StopIteration;
@@ -179,7 +179,7 @@ Http::FilterDataStatus AssertionFilter::encodeData(Buffer::Instance& data, bool 
   config_->rootMatcher().onResponseBody(data, statuses_);
   auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
   if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
-    encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                        "Response Body does not match configured expectations",
                                        nullptr, absl::nullopt, "");
     return Http::FilterDataStatus::StopIterationNoBuffer;
@@ -190,13 +190,13 @@ Http::FilterDataStatus AssertionFilter::encodeData(Buffer::Instance& data, bool 
     config_->rootMatcher().onHttpResponseTrailers(*empty_trailers, statuses_);
     auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
     if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
-      encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+      decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                          "Response Trailers do not match configured expectations",
                                          nullptr, absl::nullopt, "");
       return Http::FilterDataStatus::StopIterationNoBuffer;
     }
     if (!matchStatus.matches_) {
-      encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+      decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                          "Response Body does not match configured expectations",
                                          nullptr, absl::nullopt, "");
       return Http::FilterDataStatus::StopIterationNoBuffer;
@@ -209,13 +209,13 @@ Http::FilterTrailersStatus AssertionFilter::encodeTrailers(Http::ResponseTrailer
   config_->rootMatcher().onHttpResponseTrailers(trailers, statuses_);
   auto& matchStatus = config_->rootMatcher().matchStatus(statuses_);
   if (!matchStatus.matches_ && !matchStatus.might_change_status_) {
-    encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                        "Response Trailers do not match configured expectations",
                                        nullptr, absl::nullopt, "");
     return Http::FilterTrailersStatus::StopIteration;
   }
   if (!matchStatus.matches_) {
-    encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                        "Response Body does not match configured expectations",
                                        nullptr, absl::nullopt, "");
     return Http::FilterTrailersStatus::StopIteration;

--- a/library/common/extensions/filters/http/assertion/filter.cc
+++ b/library/common/extensions/filters/http/assertion/filter.cc
@@ -133,7 +133,8 @@ Http::FilterTrailersStatus AssertionFilter::decodeTrailers(Http::RequestTrailerM
   return Http::FilterTrailersStatus::Continue;
 }
 
-Http::FilterHeadersStatus AssertionFilter::encodeHeaders(Http::ResponseHeaderMap& headers, bool end_stream) {
+Http::FilterHeadersStatus AssertionFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
+                                                         bool end_stream) {
   config_->rootMatcher().onHttpResponseHeaders(headers, statuses_);
   if (!config_->rootMatcher().matchStatus(statuses_).matches_) {
     decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,

--- a/library/common/extensions/filters/http/assertion/filter.cc
+++ b/library/common/extensions/filters/http/assertion/filter.cc
@@ -137,7 +137,7 @@ Http::FilterHeadersStatus AssertionFilter::encodeHeaders(Http::ResponseHeaderMap
                                                          bool end_stream) {
   config_->rootMatcher().onHttpResponseHeaders(headers, statuses_);
   if (!config_->rootMatcher().matchStatus(statuses_).matches_) {
-    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                        "Request Headers do not match configured expectations",
                                        nullptr, absl::nullopt, "");
     return Http::FilterHeadersStatus::StopIteration;
@@ -153,7 +153,7 @@ Http::FilterHeadersStatus AssertionFilter::encodeHeaders(Http::ResponseHeaderMap
 Http::FilterDataStatus AssertionFilter::encodeData(Buffer::Instance& data, bool end_stream) {
   config_->rootMatcher().onResponseBody(data, statuses_);
   if (!config_->rootMatcher().matchStatus(statuses_).matches_) {
-    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                        "Request Body does not match configured expectations",
                                        nullptr, absl::nullopt, "");
     return Http::FilterDataStatus::StopIterationNoBuffer;
@@ -169,7 +169,7 @@ Http::FilterDataStatus AssertionFilter::encodeData(Buffer::Instance& data, bool 
 Http::FilterTrailersStatus AssertionFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
   config_->rootMatcher().onHttpResponseTrailers(trailers, statuses_);
   if (!config_->rootMatcher().matchStatus(statuses_).matches_) {
-    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
                                        "Request Trailers do not match configured expectations",
                                        nullptr, absl::nullopt, "");
     return Http::FilterTrailersStatus::StopIteration;

--- a/library/common/extensions/filters/http/assertion/filter.cc
+++ b/library/common/extensions/filters/http/assertion/filter.cc
@@ -158,7 +158,7 @@ Http::FilterHeadersStatus AssertionFilter::encodeHeaders(Http::ResponseHeaderMap
       return Http::FilterHeadersStatus::StopIteration;
     }
 
-    // Check of there are unsatisfied assertions about stream trailers.
+    // Check if there are unsatisfied assertions about stream trailers.
     auto empty_trailers = Http::ResponseTrailerMapImpl::create();
     config_->rootMatcher().onHttpResponseTrailers(*empty_trailers, statuses_);
     auto& finalMatchStatus = config_->rootMatcher().matchStatus(statuses_);
@@ -194,7 +194,7 @@ Http::FilterDataStatus AssertionFilter::encodeData(Buffer::Instance& data, bool 
   }
 
   if (end_stream) {
-    // Check of there are unsatisfied assertions about stream trailers.
+    // Check if there are unsatisfied assertions about stream trailers.
     auto empty_trailers = Http::ResponseTrailerMapImpl::create();
     config_->rootMatcher().onHttpResponseTrailers(*empty_trailers, statuses_);
     auto& match_status = config_->rootMatcher().matchStatus(statuses_);

--- a/library/common/extensions/filters/http/assertion/filter.h
+++ b/library/common/extensions/filters/http/assertion/filter.h
@@ -39,6 +39,12 @@ public:
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
   Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap& trailers) override;
 
+  // StreamEncoderFilter
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
+                                          bool end_stream) override;
+  Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
+  Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap& trailers) override;
+
 private:
   const AssertionFilterConfigSharedPtr config_;
   Extensions::Common::Matcher::Matcher::MatchStatusVector statuses_;

--- a/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -263,8 +263,6 @@ match_config:
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
 }
 
-// DIVIDE
-
 TEST_F(AssertionFilterTest, ResponseHeadersMatchWithEndStream) {
   setUpFilter(R"EOF(
 match_config:

--- a/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -263,6 +263,243 @@ match_config:
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
 }
 
+// DIVIDE
+
+TEST_F(AssertionFilterTest, ResponseHeadersMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_headers_match:
+    headers:
+      - name: ":status"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_headers_match:
+    headers:
+      - name: ":status"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersNoMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_headers_match:
+    headers:
+      - name: ":status"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "no.match"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Headers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersNoMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_headers_match:
+    headers:
+      - name: ":status"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "no.match"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Headers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers, false));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersMatchWithEndstreamAndDataMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_response_headers_match:
+        headers:
+          - name: ":status"
+            exact_match: test.code
+    - http_response_generic_body_match:
+        patterns:
+        - string_match: match_me
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersMatchWithEndstreamAndTrailersMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_response_headers_match:
+        headers:
+          - name: ":status"
+            exact_match: test.code
+    - http_response_trailers_match:
+        headers:
+          - name: "test-trailer"
+            exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(*body, false));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataNoMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataMatchWithEndStreamAndTrailersMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_response_generic_body_match:
+        patterns:
+          - string_match: match_me
+    - http_response_trailers_match:
+        headers:
+          - name: "test-trailer"
+            exact_match: test.code
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataNoMatchAfterTrailers) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_response_headers_match:
+        headers:
+          - name: ":status"
+            exact_match: test.code
+    - http_response_generic_body_match:
+        patterns:
+        - string_match: match_me
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+  Http::TestResponseTrailerMapImpl response_trailers{{"test-trailer", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue,
+            filter_->encodeData(*body, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration,
+            filter_->encodeTrailers(response_trailers));
+}
+
+TEST_F(AssertionFilterTest, ResponseTrailersMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_trailers_match:
+    headers:
+      - name: "test-trailer"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseTrailerMapImpl response_trailers{{"test-trailer", "test.code"}};
+
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
+}
+
+TEST_F(AssertionFilterTest, ResponseTrailersNoMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_trailers_match:
+    headers:
+      - name: "test-trailer"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseTrailerMapImpl response_trailers{{"test-trailer", "no.match"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->encodeTrailers(response_trailers));
+}
+
 } // namespace
 } // namespace Assertion
 } // namespace HttpFilters

--- a/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -461,12 +461,9 @@ match_config:
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::InternalServerError,
                              "Response Body does not match configured expectations", _, _, ""));
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->encodeHeaders(response_headers, false));
-  EXPECT_EQ(Http::FilterDataStatus::Continue,
-            filter_->encodeData(*body, false));
-  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration,
-            filter_->encodeTrailers(response_trailers));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(*body, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->encodeTrailers(response_trailers));
 }
 
 TEST_F(AssertionFilterTest, ResponseTrailersMatch) {


### PR DESCRIPTION
Description: Adds response assertions to the AssertionFilter, using a 500 status code to distinguish response from request assertion failures.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>