### PR TITLE
platform: fix inconsistencies between swift/kotlin

### DIFF
--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -11,7 +11,7 @@ Starting an instance of Envoy Mobile is done by building the ``Engine`` instance
 
 To obtain a ``StatsClient``, call ``streamClient()`` on the ``Engine`` instance (see below).
 
-After the stream client is obtain, it should be stored and used to start network requests/streams.
+After the stream client is obtained, it should be stored and used to start network requests/streams.
 
 **Kotlin example**::
 

--- a/docs/root/api/stats.rst
+++ b/docs/root/api/stats.rst
@@ -21,7 +21,7 @@ The ``counter`` method from stats client takes a variable number of elements and
 
 Store the counter instance, and call the ``increment`` method to increment the counter wherever it applies.
 
-The count argument of ``increment`` is defauled with value 1.
+The count argument of ``increment`` is defaulted with a value of ``1``.
 
 **Example**::
 

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -19,7 +19,7 @@ final class ViewController: UITableViewController {
       self.client = try EngineBuilder()
         .addFilter(factory: DemoFilter.init)
         .build()
-        .streamClient
+        .streamClient()
     } catch let error {
       NSLog("starting Envoy failed: \(error)")
     }

--- a/library/swift/src/Engine.swift
+++ b/library/swift/src/Engine.swift
@@ -4,9 +4,9 @@ import Foundation
 /// that instance.
 @objc
 public protocol Engine: AnyObject {
-  /// A client for opening and managing HTTP streams
-  var streamClient: StreamClient { get }
+  /// - returns: A client for opening and managing HTTP streams.
+  func streamClient() -> StreamClient
 
   /// A client for recording time series metrics.
-  var statsClient: StatsClient { get }
+  func statsClient() -> StatsClient
 }

--- a/library/swift/src/EngineImpl.swift
+++ b/library/swift/src/EngineImpl.swift
@@ -3,10 +3,10 @@ import Foundation
 
 /// Envoy Mobile Engine implementation.
 @objcMembers
-final class EngineImpl: NSObject, Engine {
+final class EngineImpl: NSObject {
   private let engine: EnvoyEngine
-  let statsClient: StatsClient
-  let streamClient: StreamClient
+  private let statsClientImpl: StatsClientImpl
+  private let streamClientImpl: StreamClientImpl
 
   private enum ConfigurationType {
     case yaml(String)
@@ -15,8 +15,8 @@ final class EngineImpl: NSObject, Engine {
 
   private init(configType: ConfigurationType, logLevel: LogLevel, engine: EnvoyEngine) {
     self.engine = engine
-    self.statsClient = StatsClientImpl(engine: engine)
-    self.streamClient = StreamClientImpl(engine: engine)
+    self.statsClientImpl = StatsClientImpl(engine: engine)
+    self.streamClientImpl = StreamClientImpl(engine: engine)
     super.init()
 
     switch configType {
@@ -43,5 +43,15 @@ final class EngineImpl: NSObject, Engine {
   /// - parameter engine:     The underlying engine to use for starting Envoy.
   convenience init(configYAML: String, logLevel: LogLevel = .info, engine: EnvoyEngine) {
     self.init(configType: .yaml(configYAML), logLevel: logLevel, engine: engine)
+  }
+}
+
+extension EngineImpl: Engine {
+  func streamClient() -> StreamClient {
+    return self.streamClientImpl
+  }
+
+  func statsClient() -> StatsClient {
+    return self.statsClientImpl
   }
 }


### PR DESCRIPTION
- Convert `statsClient`/`streamClient` accessors to functions in Swift as they are in Kotlin
- Update docs with the above changes
- Fix some typos in docs

Signed-off-by: Michael Rebello <me@michaelrebello.com>