### PR TITLE
dispatcher: rename onReset to onError for consistency with callbacks

### DIFF
--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -122,7 +122,7 @@ private:
     void closeStream();
     void onComplete();
     void onCancel();
-    void onReset();
+    void onError();
     void mapLocalResponseToError(const ResponseHeaderMap& headers);
 
     // ResponseEncoder

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -1191,7 +1191,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   // Expect that when a reset is received, the Http::Dispatcher::DirectStream fires
   // runResetCallbacks. The Http::ConnectionManager depends on the Http::Dispatcher::DirectStream
   // firing this tight loop to let the Http::ConnectionManager clean up its stream state.
-  EXPECT_CALL(callbacks, onResetStream(StreamResetReason::RemoteReset, _));
+  EXPECT_CALL(callbacks, onErrorStream(StreamResetReason::RemoteReset, _));
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   EXPECT_CALL(event_dispatcher_, deferredDelete_(_)).Times(1);
   response_encoder_->getStream().resetStream(StreamResetReason::RemoteReset);

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -1191,7 +1191,7 @@ TEST_F(DispatcherTest, RemoteResetAfterStreamStart) {
   // Expect that when a reset is received, the Http::Dispatcher::DirectStream fires
   // runResetCallbacks. The Http::ConnectionManager depends on the Http::Dispatcher::DirectStream
   // firing this tight loop to let the Http::ConnectionManager clean up its stream state.
-  EXPECT_CALL(callbacks, onErrorStream(StreamResetReason::RemoteReset, _));
+  EXPECT_CALL(callbacks, onResetStream(StreamResetReason::RemoteReset, _));
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   EXPECT_CALL(event_dispatcher_, deferredDelete_(_)).Times(1);
   response_encoder_->getStream().resetStream(StreamResetReason::RemoteReset);


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>
