### PR TITLE
ci: increase max size of binary

### DIFF
--- a/ci/test_size_regression.sh
+++ b/ci/test_size_regression.sh
@@ -2,7 +2,7 @@
 
 # Checks the absolute size and the relative size increase of a file.
 
-MAX_SIZE=5700000 # 5.7MB
+MAX_SIZE=5800000 # 5.8MB
 MAX_PERC=1
 
 if [ `uname` == "Darwin" ]


### PR DESCRIPTION
The most recent Envoy bump requires this: https://github.com/lyft/envoy-mobile/pull/1076

```
The new binary is 2.00 % different in size compared to main.
The new binary is 5790759 bytes.
The current size (5790759) is larger than the maximum size (5700000).
```

Signed-off-by: Michael Rebello <me@michaelrebello.com>