### PR TITLE
cleanup: remove PlatformStub filter

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -40,10 +40,6 @@ static_resources:
                         max_interval: 60s
         http_filters:
 {{ platform_filter_chain }}
-          - name: envoy.filters.http.platform_bridge
-            typed_config:
-              "@type": type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge
-              platform_filter_name: PlatformStub
           - name: envoy.filters.http.dynamic_forward_proxy
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -58,10 +58,6 @@ envoy_status_t reset_stream(envoy_stream_t stream) {
 envoy_engine_t init_engine() {
   // TODO(goaway): return new handle once multiple engine support is in place.
   // https://github.com/lyft/envoy-mobile/issues/332
-
-  // Register stub implementation of a platform filter (hardcoded in configuration).
-  register_platform_api("PlatformStub", safe_calloc(1, sizeof(envoy_http_filter)));
-
   return 1;
 }
 


### PR DESCRIPTION
Description: The was only needed prior to dynamic registration of platform filters. It's benign, but thoroughly unnecessary now.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
