### PR TITLE
filters: setup unit test coverage for PlatformBridgeFilter

### DIFF
--- a/test/common/extensions/filters/http/platform_bridge/BUILD
+++ b/test/common/extensions/filters/http/platform_bridge/BUILD
@@ -1,0 +1,23 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load(
+    "@envoy//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "platform_bridge_filter_test",
+    srcs = ["platform_bridge_filter_test.cc"],
+    extension_name = "envoy.filters.http.platform_bridge",
+    repository = "@envoy",
+    deps = [
+        "//library/common/api:external_api_lib",
+        "//library/common/extensions/filters/http/platform_bridge:config",
+        "//library/common/extensions/filters/http/platform_bridge:pkg_cc_proto",
+        "@envoy//test/mocks/http:http_mocks",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -47,16 +47,16 @@ public:
 
 TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestHeaders) {
   envoy_http_filter platform_filter;
-  filter_invocations i = {0, 0, 0, 0, 0, 0, 0, 0};
-  platform_filter.static_context = &i;
+  filter_invocations invocations = {0, 0, 0, 0, 0, 0, 0, 0};
+  platform_filter.static_context = &invocations;
   platform_filter.init_filter = [](const void* context) -> const void* {
-    filter_invocations* i = static_cast<filter_invocations*>(const_cast<void*>(context));
-    i->init_filter_calls++;
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    invocations->init_filter_calls++;
     return context;
   };
   platform_filter.on_request_headers = [](envoy_headers c_headers, bool end_stream,
                                           const void* context) -> envoy_filter_headers_status {
-    filter_invocations* i = static_cast<filter_invocations*>(const_cast<void*>(context));
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
     EXPECT_EQ(std::string(reinterpret_cast<const char*>(c_headers.headers[0].key.bytes),
                           c_headers.headers[0].key.length),
@@ -65,7 +65,7 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestHeaders) {
                           c_headers.headers[0].value.length),
               "test.code");
     EXPECT_TRUE(end_stream);
-    i->on_request_headers_calls++;
+    invocations->on_request_headers_calls++;
     return {kEnvoyFilterHeadersStatusContinue, c_headers};
   };
 
@@ -73,12 +73,12 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestHeaders) {
 platform_filter_name: BasicContinueOnRequestHeaders
 )EOF",
               &platform_filter);
-  EXPECT_EQ(i.init_filter_calls, 1);
+  EXPECT_EQ(invocations.init_filter_calls, 1);
 
   Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
-  EXPECT_EQ(i.on_request_headers_calls, 1);
+  EXPECT_EQ(invocations.on_request_headers_calls, 1);
 }
 
 } // namespace

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -1,0 +1,76 @@
+#include "test/mocks/http/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+#include "library/common/api/external.h"
+#include "library/common/extensions/filters/http/platform_bridge/filter.h"
+#include "library/common/extensions/filters/http/platform_bridge/filter.pb.h"
+
+using testing::ByMove;
+using testing::Return;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace PlatformBridge {
+namespace {
+
+class PlatformBridgeFilterTest : public testing::Test {
+public:
+  void setUpFilter(std::string&& yaml, envoy_http_filter* platform_filter) {
+    envoymobile::extensions::filters::http::platform_bridge::PlatformBridge config;
+    TestUtility::loadFromYaml(yaml, config);
+    Api::External::registerApi(config.platform_filter_name(), platform_filter);
+
+    config_ = std::make_shared<PlatformBridgeFilterConfig>(config);
+    filter_ = std::make_unique<PlatformBridgeFilter>(config_);
+    filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+    filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+  }
+
+  typedef struct {
+    unsigned int init_filter_calls;
+    unsigned int on_request_headers_calls;
+    unsigned int on_request_data_calls;
+    unsigned int on_request_trailers_calls;
+    unsigned int on_response_headers_calls;
+    unsigned int on_response_data_calls;
+    unsigned int on_response_trailers_calls;
+    unsigned int release_filter_calls;
+  } filter_invocations;
+
+  PlatformBridgeFilterConfigSharedPtr config_{};
+  std::unique_ptr<PlatformBridgeFilter> filter_{};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
+};
+
+TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestHeaders) {
+  envoy_http_filter platform_filter;
+  filter_invocations i = {0, 0, 0, 0, 0, 0, 0, 0};
+  platform_filter.static_context = &i;
+  platform_filter.instance_context = &i;
+  platform_filter.on_request_headers = [](envoy_headers c_headers, bool end_stream,
+                                          void* context) -> envoy_filter_headers_status {
+    filter_invocations* i = static_cast<filter_invocations*>(context);
+    i->on_request_headers_calls++;
+    envoy_headers empty_headers = {0, nullptr};
+    return {kEnvoyFilterHeadersStatusContinue, empty_headers};
+  };
+                               
+  setUpFilter(R"EOF(
+platform_filter_name: BasicContinueOnRequestHeaders
+)EOF", &platform_filter);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter_->decodeHeaders(request_headers, true));
+  EXPECT_EQ(i.on_request_headers_calls, 1);
+}
+
+} // namespace
+} // namespace PlatformBridge
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -58,8 +58,12 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestHeaders) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* i = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(std::string(reinterpret_cast<const char*>(c_headers.headers[0].key.bytes), c_headers.headers[0].key.length), ":authority");
-    EXPECT_EQ(std::string(reinterpret_cast<const char*>(c_headers.headers[0].value.bytes), c_headers.headers[0].value.length), "test.code");
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(c_headers.headers[0].key.bytes),
+                          c_headers.headers[0].key.length),
+              ":authority");
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(c_headers.headers[0].value.bytes),
+                          c_headers.headers[0].value.length),
+              "test.code");
     EXPECT_TRUE(end_stream);
     i->on_request_headers_calls++;
     return {kEnvoyFilterHeadersStatusContinue, c_headers};
@@ -67,13 +71,13 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestHeaders) {
 
   setUpFilter(R"EOF(
 platform_filter_name: BasicContinueOnRequestHeaders
-)EOF", &platform_filter);
+)EOF",
+              &platform_filter);
   EXPECT_EQ(i.init_filter_calls, 1);
 
   Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
   EXPECT_EQ(i.on_request_headers_calls, 1);
 }
 


### PR DESCRIPTION
Description: Adds basic framework for unit coverage of the PlatformBridgeFilter.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
