### PR TITLE
ci: increase mac_dist timeout to 75 minutes

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -10,7 +10,7 @@ jobs:
   macdist:
     name: mac_dist
     runs-on: macOS-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Description: Increase timeout since mac_dist is still timing out mid-compile.

Signed-off-by: Mike Schore <mike.schore@gmail.com>
