### PR TITLE
ci: increase delay before checking iOS simulator

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -49,7 +49,7 @@ jobs:
       - name: 'Run swift app'
         run: bazelisk run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
       - name: 'Wait for simulator to start & perform requests'
-        run: sleep 180
+        run: sleep 300
       # Print out the log in case the liveliness check fails.
       # This allows the author to decide if the failure is a flake or a real problem.
       - name: 'Cat log'


### PR DESCRIPTION
Description: Increases the sleep before attempting to cat iOS logs in CI to 5 minutes. We're still occasionally trying too early, resulting in flakiness.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>