### PR TITLE
jni: ensure we delete local refs

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -117,7 +117,7 @@ static void pass_headers(JNIEnv* env, envoy_headers headers, jobject j_context) 
 
 // Platform callback implementation
 // These methods call jvm methods which means the local references created will not be
-// released automatically. Manual book keeping is required for these methods.
+// released automatically. Manual bookkeeping is required for these methods.
 
 static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_stream,
                             void* context) {

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -138,7 +138,7 @@ static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_
   if (end_stream) {
     env->DeleteGlobalRef(j_context);
   }
-  
+
   return result;
 }
 
@@ -282,9 +282,7 @@ static void* jvm_on_trailers(const char* method, envoy_headers trailers, void* c
   jobject result = env->CallObjectMethod(j_context, jmid_onTrailers, (jlong)trailers.length);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
-  if (end_stream) {
-    env->DeleteGlobalRef(j_context);
-  }
+  env->DeleteGlobalRef(j_context);
 
   return result;
 }

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -116,6 +116,8 @@ static void pass_headers(JNIEnv* env, envoy_headers headers, jobject j_context) 
 }
 
 // Platform callback implementation
+// These methods call jvm methods which means the local references created will not be
+// released automatically. Manual book keeping is required for these methods.
 
 static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_stream,
                             void* context) {
@@ -133,6 +135,10 @@ static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_
                                          end_stream ? JNI_TRUE : JNI_FALSE);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
+  if (end_stream) {
+    env->DeleteGlobalRef(j_context);
+  }
+  
   return result;
 }
 
@@ -149,8 +155,15 @@ jvm_http_filter_on_request_headers(envoy_headers headers, bool end_stream, const
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
-  return (envoy_filter_headers_status){/*status*/ unbox_integer(env, status),
-                                       /*headers*/ to_native_headers(env, j_headers)};
+  int unboxed_status = unbox_integer(env, status);
+  envoy_headers native_headers = to_native_headers(env, j_headers);
+
+  env->DeleteLocalRef(result);
+  env->DeleteLocalRef(status);
+  env->DeleteLocalRef(j_headers);
+
+  return (envoy_filter_headers_status){/*status*/ unboxed_status,
+                                       /*headers*/ native_headers};
 }
 
 static envoy_filter_headers_status
@@ -162,8 +175,15 @@ jvm_http_filter_on_response_headers(envoy_headers headers, bool end_stream, cons
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
-  return (envoy_filter_headers_status){/*status*/ unbox_integer(env, status),
-                                       /*headers*/ to_native_headers(env, j_headers)};
+  int unboxed_status = unbox_integer(env, status);
+  envoy_headers native_headers = to_native_headers(env, j_headers);
+
+  env->DeleteLocalRef(result);
+  env->DeleteLocalRef(status);
+  env->DeleteLocalRef(j_headers);
+
+  return (envoy_filter_headers_status){/*status*/ unboxed_status,
+                                       /*headers*/ native_headers};
 }
 
 static void* jvm_on_data(const char* method, envoy_data data, bool end_stream, void* context) {
@@ -190,6 +210,10 @@ static void* jvm_on_data(const char* method, envoy_data data, bool end_stream, v
   data.release(data.context);
   env->DeleteLocalRef(j_data);
   env->DeleteLocalRef(jcls_JvmCallbackContext);
+  if (end_stream) {
+    env->DeleteGlobalRef(j_context);
+  }
+
   return result;
 }
 
@@ -206,8 +230,15 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
-  return (envoy_filter_data_status){/*status*/ unbox_integer(env, status),
-                                    /*data*/ buffer_to_native_data(env, j_data)};
+  int unboxed_status = unbox_integer(env, status);
+  envoy_data native_data = buffer_to_native_data(env, j_data);
+
+  env->DeleteLocalRef(result);
+  env->DeleteLocalRef(status);
+  env->DeleteLocalRef(j_data);
+
+  return (envoy_filter_data_status){/*status*/ unboxed_status,
+                                    /*data*/ native_data};
 }
 
 static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data, bool end_stream,
@@ -219,8 +250,15 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
-  return (envoy_filter_data_status){/*status*/ unbox_integer(env, status),
-                                    /*data*/ buffer_to_native_data(env, j_data)};
+  int unboxed_status = unbox_integer(env, status);
+  envoy_data native_data = buffer_to_native_data(env, j_data);
+
+  env->DeleteLocalRef(result);
+  env->DeleteLocalRef(status);
+  env->DeleteLocalRef(j_data);
+
+  return (envoy_filter_data_status){/*status*/ unboxed_status,
+                                    /*data*/ native_data};
 }
 
 static void* jvm_on_metadata(envoy_headers metadata, void* context) {
@@ -244,6 +282,10 @@ static void* jvm_on_trailers(const char* method, envoy_headers trailers, void* c
   jobject result = env->CallObjectMethod(j_context, jmid_onTrailers, (jlong)trailers.length);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
+  if (end_stream) {
+    env->DeleteGlobalRef(j_context);
+  }
+
   return result;
 }
 
@@ -260,8 +302,15 @@ static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_he
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
-  return (envoy_filter_trailers_status){/*status*/ unbox_integer(env, status),
-                                        /*trailers*/ to_native_headers(env, j_trailers)};
+  int unboxed_status = unbox_integer(env, status);
+  envoy_headers native_headers = to_native_headers(env, j_trailers);
+
+  env->DeleteLocalRef(result);
+  env->DeleteLocalRef(status);
+  env->DeleteLocalRef(j_trailers);
+
+  return (envoy_filter_trailers_status){/*status*/ unboxed_status,
+                                        /*trailers*/ native_headers};
 }
 
 static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_headers trailers,
@@ -273,8 +322,15 @@ static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_h
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
-  return (envoy_filter_trailers_status){/*status*/ unbox_integer(env, status),
-                                        /*trailers*/ to_native_headers(env, j_trailers)};
+  int unboxed_status = unbox_integer(env, status);
+  envoy_headers native_headers = to_native_headers(env, j_trailers);
+
+  env->DeleteLocalRef(result);
+  env->DeleteLocalRef(status);
+  env->DeleteLocalRef(j_trailers);
+
+  return (envoy_filter_trailers_status){/*status*/ unboxed_status,
+                                        /*trailers*/ native_headers};
 }
 
 static void* jvm_on_error(envoy_error error, void* context) {
@@ -303,6 +359,7 @@ static void* jvm_on_error(envoy_error error, void* context) {
   // No further callbacks happen on this context. Delete the reference held by native code.
   env->DeleteGlobalRef(j_context);
   env->DeleteLocalRef(jcls_JvmObserverContext);
+  env->DeleteLocalRef(j_error_message);
   return result;
 }
 
@@ -346,7 +403,10 @@ static const void* jvm_http_filter_init(const void* context) {
   jobject j_filter = env->CallObjectMethod(j_context, jmid_create);
   __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_filter: %p", j_filter);
   jobject retained_filter = env->NewGlobalRef(j_filter);
+
   env->DeleteLocalRef(jcls_JvmFilterFactoryContext);
+  env->DeleteLocalRef(j_filter);
+
   return retained_filter;
 }
 

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -135,9 +135,6 @@ static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_
                                          end_stream ? JNI_TRUE : JNI_FALSE);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
-  if (end_stream) {
-    env->DeleteGlobalRef(j_context);
-  }
 
   return result;
 }
@@ -210,9 +207,6 @@ static void* jvm_on_data(const char* method, envoy_data data, bool end_stream, v
   data.release(data.context);
   env->DeleteLocalRef(j_data);
   env->DeleteLocalRef(jcls_JvmCallbackContext);
-  if (end_stream) {
-    env->DeleteGlobalRef(j_context);
-  }
 
   return result;
 }
@@ -282,7 +276,6 @@ static void* jvm_on_trailers(const char* method, envoy_headers trailers, void* c
   jobject result = env->CallObjectMethod(j_context, jmid_onTrailers, (jlong)trailers.length);
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
-  env->DeleteGlobalRef(j_context);
 
   return result;
 }

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -360,6 +360,7 @@ static void* jvm_on_error(envoy_error error, void* context) {
   env->DeleteGlobalRef(j_context);
   env->DeleteLocalRef(jcls_JvmObserverContext);
   env->DeleteLocalRef(j_error_message);
+
   return result;
 }
 


### PR DESCRIPTION
Continuation from https://github.com/lyft/envoy-mobile/pull/1057.

Doing an audit of all the JNI methods which call into a java context.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: jni: ensure we delete local refs
Risk Level: moderate
Testing: manually
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
