### PR TITLE
filters: support internal buffering

### DIFF
--- a/library/common/buffer/utility.cc
+++ b/library/common/buffer/utility.cc
@@ -28,6 +28,16 @@ envoy_data toBridgeData(Buffer::Instance& data) {
   return bridge_data;
 }
 
+envoy_data copyToBridgeData(const Buffer::Instance& data) {
+  envoy_data bridge_data;
+  bridge_data.length = data.length();
+  bridge_data.bytes = static_cast<uint8_t*>(safe_malloc(sizeof(uint8_t) * bridge_data.length));
+  data.copyOut(0, bridge_data.length, const_cast<uint8_t*>(bridge_data.bytes));
+  bridge_data.release = free;
+  bridge_data.context = const_cast<uint8_t*>(bridge_data.bytes);
+  return bridge_data;
+}
+
 } // namespace Utility
 } // namespace Buffer
 } // namespace Envoy

--- a/library/common/buffer/utility.h
+++ b/library/common/buffer/utility.h
@@ -11,21 +11,21 @@ namespace Utility {
 /**
  * Transform envoy_data to Envoy::Buffer::Instance.
  * @param headers, the envoy_data to transform.
- * @return Envoy::Buffer::InstancePtr, the 1:1 transformation of the envoy_data param.
+ * @return Envoy::Buffer::InstancePtr, the native transformation of the envoy_data param.
  */
 Buffer::InstancePtr toInternalData(envoy_data data);
 
 /**
  * Transform from Buffer::Instance to envoy_data.
  * @param data, the Buffer::Instance to transform.
- * @return envoy_data, the 1:1 transformation of the Buffer::Instance param.
+ * @return envoy_data, the bridge transformation of the Buffer::Instance param.
  */
 envoy_data toBridgeData(Buffer::Instance&);
 
 /**
  * Copy from Buffer::Instance to envoy_data.
- * @param data, the Buffer::Instance to transform.
- * @return envoy_data, the 1:1 transformation of the Buffer::Instance param.
+ * @param data, the Buffer::Instance to copy.
+ * @return envoy_data, the copy produced from the Buffer::Instance param.
  */
 envoy_data copyToBridgeData(const Buffer::Instance&);
 

--- a/library/common/buffer/utility.h
+++ b/library/common/buffer/utility.h
@@ -22,6 +22,13 @@ Buffer::InstancePtr toInternalData(envoy_data data);
  */
 envoy_data toBridgeData(Buffer::Instance&);
 
+/**
+ * Copy from Buffer::Instance to envoy_data.
+ * @param data, the Buffer::Instance to transform.
+ * @return envoy_data, the 1:1 transformation of the Buffer::Instance param.
+ */
+envoy_data copyToBridgeData(const Buffer::Instance&);
+
 } // namespace Utility
 } // namespace Buffer
 } // namespace Envoy

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -91,7 +91,8 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
 
   envoy_data in_data;
 
-  if (iteration_mode_ == IterationMode::Stopped && internal_buffer && internal_buffer->length() > 0) {
+  if (iteration_mode_ == IterationMode::Stopped && internal_buffer &&
+      internal_buffer->length() > 0) {
     // Pre-emptively buffer data to present aggregate to platform.
     internal_buffer->move(data);
     in_data = Buffer::Utility::copyToBridgeData(*internal_buffer);

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -108,7 +108,7 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
       // When platform filter iteration is Stopped, Resume must be used to start iterating again.
       // TODO(goaway): decide on the means to surface/handle errors here. Options include:
       // - crashing
-      // - creating an eror response for this stream
+      // - creating an error response for this stream
       // - letting Envoy handle any invalid resulting state via its own guards
     }
     break;

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -58,6 +58,7 @@ private:
   Http::FilterHeadersStatus onHeaders(Http::HeaderMap& headers, bool end_stream,
                                       envoy_filter_on_headers_f on_headers);
   Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream,
+                                Buffer::Instance* internal_buffer,
                                 envoy_filter_on_data_f on_data);
   Http::FilterTrailersStatus onTrailers(Http::HeaderMap& trailers,
                                         envoy_filter_on_trailers_f on_trailers);

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -58,8 +58,7 @@ private:
   Http::FilterHeadersStatus onHeaders(Http::HeaderMap& headers, bool end_stream,
                                       envoy_filter_on_headers_f on_headers);
   Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream,
-                                Buffer::Instance* internal_buffer,
-                                envoy_filter_on_data_f on_data);
+                                Buffer::Instance* internal_buffer, envoy_filter_on_data_f on_data);
   Http::FilterTrailersStatus onTrailers(Http::HeaderMap& trailers,
                                         envoy_filter_on_trailers_f on_trailers);
   const std::string filter_name_;

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -29,6 +29,8 @@ private:
 
 typedef std::shared_ptr<PlatformBridgeFilterConfig> PlatformBridgeFilterConfigSharedPtr;
 
+enum class IterationMode { Ongoing, Stopped };
+
 /**
  * Harness to bridge Envoy filter invocations up to the platform layer.
  */
@@ -60,6 +62,7 @@ private:
   Http::FilterTrailersStatus onTrailers(Http::HeaderMap& trailers,
                                         envoy_filter_on_trailers_f on_trailers);
   const std::string filter_name_;
+  IterationMode iteration_mode_;
   envoy_http_filter platform_filter_;
 };
 

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -29,7 +29,7 @@ private:
 
 typedef std::shared_ptr<PlatformBridgeFilterConfig> PlatformBridgeFilterConfigSharedPtr;
 
-enum class IterationMode { Ongoing, Stopped };
+enum class IterationState { Ongoing, Stopped };
 
 /**
  * Harness to bridge Envoy filter invocations up to the platform layer.
@@ -62,7 +62,7 @@ private:
   Http::FilterTrailersStatus onTrailers(Http::HeaderMap& trailers,
                                         envoy_filter_on_trailers_f on_trailers);
   const std::string filter_name_;
-  IterationMode iteration_mode_;
+  IterationState iteration_state_;
   envoy_http_filter platform_filter_;
 };
 

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -213,14 +213,18 @@ platform_filter_name: StopAndBufferOnRequestData
 
   Buffer::OwnedImpl first_chunk = Buffer::OwnedImpl("A");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(first_chunk, false));
+  // Since the return code can't be handled in a unit test, manually update the buffer here.
+  decoding_buffer.add(first_chunk);
   EXPECT_EQ(invocations.on_request_data_calls, 1);
 
   Buffer::OwnedImpl second_chunk = Buffer::OwnedImpl("B");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(second_chunk, false));
+  // Manual update not required, because once iteration is stopped, data is added directly.
   EXPECT_EQ(invocations.on_request_data_calls, 2);
 
   Buffer::OwnedImpl third_chunk = Buffer::OwnedImpl("C");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(third_chunk, false));
+  // Manual update not required, because once iteration is stopped, data is added directly.
   EXPECT_EQ(invocations.on_request_data_calls, 3);
 }
 

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -192,15 +192,18 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnRequestData) {
   platform_filter.on_request_data = [](envoy_data c_data, bool end_stream,
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    std::string expected_data[3] = { "A", "AB", "ABC" };
+    std::string expected_data[3] = {"A", "AB", "ABC"};
     EXPECT_EQ(to_string(c_data), expected_data[invocations->on_request_data_calls++]);
     EXPECT_FALSE(end_stream);
     return {kEnvoyFilterDataStatusStopIterationAndBuffer, envoy_nodata};
   };
 
   Buffer::OwnedImpl decoding_buffer;
-  EXPECT_CALL(decoder_callbacks_, decodingBuffer()).Times(3).WillRepeatedly(Return(&decoding_buffer));
-  EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer(_)).Times(3)
+  EXPECT_CALL(decoder_callbacks_, decodingBuffer())
+      .Times(3)
+      .WillRepeatedly(Return(&decoding_buffer));
+  EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer(_))
+      .Times(3)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(decoding_buffer);
       }));
@@ -212,13 +215,15 @@ platform_filter_name: StopAndBufferOnRequestData
   EXPECT_EQ(invocations.init_filter_calls, 1);
 
   Buffer::OwnedImpl first_chunk = Buffer::OwnedImpl("A");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(first_chunk, false));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer,
+            filter_->decodeData(first_chunk, false));
   // Since the return code can't be handled in a unit test, manually update the buffer here.
   decoding_buffer.move(first_chunk);
   EXPECT_EQ(invocations.on_request_data_calls, 1);
 
   Buffer::OwnedImpl second_chunk = Buffer::OwnedImpl("B");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(second_chunk, false));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
+            filter_->decodeData(second_chunk, false));
   // Manual update not required, because once iteration is stopped, data is added directly.
   EXPECT_EQ(invocations.on_request_data_calls, 2);
 
@@ -240,7 +245,7 @@ TEST_F(PlatformBridgeFilterTest, StopNoBufferOnRequestData) {
   platform_filter.on_request_data = [](envoy_data c_data, bool end_stream,
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    std::string expected_data[3] = { "A", "B", "C" };
+    std::string expected_data[3] = {"A", "B", "C"};
     EXPECT_EQ(to_string(c_data), expected_data[invocations->on_request_data_calls++]);
     EXPECT_FALSE(end_stream);
     return {kEnvoyFilterDataStatusStopIterationNoBuffer, envoy_nodata};
@@ -257,7 +262,8 @@ platform_filter_name: StopNoBufferOnRequestData
   EXPECT_EQ(invocations.on_request_data_calls, 1);
 
   Buffer::OwnedImpl second_chunk = Buffer::OwnedImpl("B");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(second_chunk, false));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
+            filter_->decodeData(second_chunk, false));
   EXPECT_EQ(invocations.on_request_data_calls, 2);
 
   Buffer::OwnedImpl third_chunk = Buffer::OwnedImpl("C");
@@ -370,17 +376,20 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnResponseData) {
     return context;
   };
   platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
-                                       const void* context) -> envoy_filter_data_status {
+                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    std::string expected_data[3] = { "A", "AB", "ABC" };
+    std::string expected_data[3] = {"A", "AB", "ABC"};
     EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls++]);
     EXPECT_FALSE(end_stream);
     return {kEnvoyFilterDataStatusStopIterationAndBuffer, envoy_nodata};
   };
 
   Buffer::OwnedImpl encoding_buffer;
-  EXPECT_CALL(encoder_callbacks_, encodingBuffer()).Times(3).WillRepeatedly(Return(&encoding_buffer));
-  EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_)).Times(3)
+  EXPECT_CALL(encoder_callbacks_, encodingBuffer())
+      .Times(3)
+      .WillRepeatedly(Return(&encoding_buffer));
+  EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_))
+      .Times(3)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(encoding_buffer);
       }));
@@ -392,13 +401,15 @@ platform_filter_name: StopAndBufferOnResponseData
   EXPECT_EQ(invocations.init_filter_calls, 1);
 
   Buffer::OwnedImpl first_chunk = Buffer::OwnedImpl("A");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(first_chunk, false));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer,
+            filter_->encodeData(first_chunk, false));
   // Since the return code can't be handled in a unit test, manually update the buffer here.
   encoding_buffer.move(first_chunk);
   EXPECT_EQ(invocations.on_response_data_calls, 1);
 
   Buffer::OwnedImpl second_chunk = Buffer::OwnedImpl("B");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(second_chunk, false));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
+            filter_->encodeData(second_chunk, false));
   // Manual update not required, because once iteration is stopped, data is added directly.
   EXPECT_EQ(invocations.on_response_data_calls, 2);
 
@@ -418,9 +429,9 @@ TEST_F(PlatformBridgeFilterTest, StopNoBufferOnResponseData) {
     return context;
   };
   platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
-                                       const void* context) -> envoy_filter_data_status {
+                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    std::string expected_data[3] = { "A", "B", "C" };
+    std::string expected_data[3] = {"A", "B", "C"};
     EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls++]);
     EXPECT_FALSE(end_stream);
     return {kEnvoyFilterDataStatusStopIterationNoBuffer, envoy_nodata};
@@ -437,7 +448,8 @@ platform_filter_name: StopNoBufferOnResponseData
   EXPECT_EQ(invocations.on_response_data_calls, 1);
 
   Buffer::OwnedImpl second_chunk = Buffer::OwnedImpl("B");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(second_chunk, false));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
+            filter_->encodeData(second_chunk, false));
   EXPECT_EQ(invocations.on_response_data_calls, 2);
 
   Buffer::OwnedImpl third_chunk = Buffer::OwnedImpl("C");

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -195,6 +195,7 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnRequestData) {
     std::string expected_data[3] = {"A", "AB", "ABC"};
     EXPECT_EQ(to_string(c_data), expected_data[invocations->on_request_data_calls++]);
     EXPECT_FALSE(end_stream);
+    c_data.release(c_data.context);
     return {kEnvoyFilterDataStatusStopIterationAndBuffer, envoy_nodata};
   };
 
@@ -248,6 +249,7 @@ TEST_F(PlatformBridgeFilterTest, StopNoBufferOnRequestData) {
     std::string expected_data[3] = {"A", "B", "C"};
     EXPECT_EQ(to_string(c_data), expected_data[invocations->on_request_data_calls++]);
     EXPECT_FALSE(end_stream);
+    c_data.release(c_data.context);
     return {kEnvoyFilterDataStatusStopIterationNoBuffer, envoy_nodata};
   };
 

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -383,6 +383,7 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnResponseData) {
     std::string expected_data[3] = {"A", "AB", "ABC"};
     EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls++]);
     EXPECT_FALSE(end_stream);
+    c_data.release(c_data.context);
     return {kEnvoyFilterDataStatusStopIterationAndBuffer, envoy_nodata};
   };
 
@@ -436,6 +437,7 @@ TEST_F(PlatformBridgeFilterTest, StopNoBufferOnResponseData) {
     std::string expected_data[3] = {"A", "B", "C"};
     EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls++]);
     EXPECT_FALSE(end_stream);
+    c_data.release(c_data.context);
     return {kEnvoyFilterDataStatusStopIterationNoBuffer, envoy_nodata};
   };
 

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -204,10 +204,6 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnRequestData) {
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(decoding_buffer);
       }));
-  //EXPECT_CALL(decoder_callbacks_, addDecodedData(_, _)).Times(2)
-  //    .WillRepeatedly(Invoke([&](Buffer::Instance& data, bool) -> void {
-  //      decoding_buffer.add(data);
-  //    }));
 
   setUpFilter(R"EOF(
 platform_filter_name: StopAndBufferOnRequestData
@@ -218,7 +214,7 @@ platform_filter_name: StopAndBufferOnRequestData
   Buffer::OwnedImpl first_chunk = Buffer::OwnedImpl("A");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(first_chunk, false));
   // Since the return code can't be handled in a unit test, manually update the buffer here.
-  decoding_buffer.add(first_chunk);
+  decoding_buffer.move(first_chunk);
   EXPECT_EQ(invocations.on_request_data_calls, 1);
 
   Buffer::OwnedImpl second_chunk = Buffer::OwnedImpl("B");
@@ -362,6 +358,91 @@ platform_filter_name: BasicContinueOnResponseData
 
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(response_data, true));
   EXPECT_EQ(invocations.on_response_data_calls, 1);
+}
+
+TEST_F(PlatformBridgeFilterTest, StopAndBufferOnResponseData) {
+  envoy_http_filter platform_filter;
+  filter_invocations invocations = {0, 0, 0, 0, 0, 0, 0, 0};
+  platform_filter.static_context = &invocations;
+  platform_filter.init_filter = [](const void* context) -> const void* {
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    invocations->init_filter_calls++;
+    return context;
+  };
+  platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
+                                       const void* context) -> envoy_filter_data_status {
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    std::string expected_data[3] = { "A", "AB", "ABC" };
+    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls++]);
+    EXPECT_FALSE(end_stream);
+    return {kEnvoyFilterDataStatusStopIterationAndBuffer, envoy_nodata};
+  };
+
+  Buffer::OwnedImpl encoding_buffer;
+  EXPECT_CALL(encoder_callbacks_, encodingBuffer()).Times(3).WillRepeatedly(Return(&encoding_buffer));
+  EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_)).Times(3)
+      .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
+        callback(encoding_buffer);
+      }));
+
+  setUpFilter(R"EOF(
+platform_filter_name: StopAndBufferOnResponseData
+)EOF",
+              &platform_filter);
+  EXPECT_EQ(invocations.init_filter_calls, 1);
+
+  Buffer::OwnedImpl first_chunk = Buffer::OwnedImpl("A");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(first_chunk, false));
+  // Since the return code can't be handled in a unit test, manually update the buffer here.
+  encoding_buffer.move(first_chunk);
+  EXPECT_EQ(invocations.on_response_data_calls, 1);
+
+  Buffer::OwnedImpl second_chunk = Buffer::OwnedImpl("B");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(second_chunk, false));
+  // Manual update not required, because once iteration is stopped, data is added directly.
+  EXPECT_EQ(invocations.on_response_data_calls, 2);
+
+  Buffer::OwnedImpl third_chunk = Buffer::OwnedImpl("C");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(third_chunk, false));
+  // Manual update not required, because once iteration is stopped, data is added directly.
+  EXPECT_EQ(invocations.on_response_data_calls, 3);
+}
+
+TEST_F(PlatformBridgeFilterTest, StopNoBufferOnResponseData) {
+  envoy_http_filter platform_filter;
+  filter_invocations invocations = {0, 0, 0, 0, 0, 0, 0, 0};
+  platform_filter.static_context = &invocations;
+  platform_filter.init_filter = [](const void* context) -> const void* {
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    invocations->init_filter_calls++;
+    return context;
+  };
+  platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
+                                       const void* context) -> envoy_filter_data_status {
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    std::string expected_data[3] = { "A", "B", "C" };
+    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls++]);
+    EXPECT_FALSE(end_stream);
+    return {kEnvoyFilterDataStatusStopIterationNoBuffer, envoy_nodata};
+  };
+
+  setUpFilter(R"EOF(
+platform_filter_name: StopNoBufferOnResponseData
+)EOF",
+              &platform_filter);
+  EXPECT_EQ(invocations.init_filter_calls, 1);
+
+  Buffer::OwnedImpl first_chunk = Buffer::OwnedImpl("A");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(first_chunk, false));
+  EXPECT_EQ(invocations.on_response_data_calls, 1);
+
+  Buffer::OwnedImpl second_chunk = Buffer::OwnedImpl("B");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(second_chunk, false));
+  EXPECT_EQ(invocations.on_response_data_calls, 2);
+
+  Buffer::OwnedImpl third_chunk = Buffer::OwnedImpl("C");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(third_chunk, false));
+  EXPECT_EQ(invocations.on_response_data_calls, 3);
 }
 
 TEST_F(PlatformBridgeFilterTest, BasicContinueOnResponseTrailers) {

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -200,10 +200,14 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnRequestData) {
 
   Buffer::OwnedImpl decoding_buffer;
   EXPECT_CALL(decoder_callbacks_, decodingBuffer()).Times(3).WillRepeatedly(Return(&decoding_buffer));
-  EXPECT_CALL(decoder_callbacks_, addDecodedData(_, _)).Times(2)
-      .WillRepeatedly(Invoke([&](Buffer::Instance& data, bool) -> void {
-        decoding_buffer.add(data);
+  EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer(_)).Times(3)
+      .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
+        callback(decoding_buffer);
       }));
+  //EXPECT_CALL(decoder_callbacks_, addDecodedData(_, _)).Times(2)
+  //    .WillRepeatedly(Invoke([&](Buffer::Instance& data, bool) -> void {
+  //      decoding_buffer.add(data);
+  //    }));
 
   setUpFilter(R"EOF(
 platform_filter_name: StopAndBufferOnRequestData


### PR DESCRIPTION
Description: Adds internal buffering support for platform filters. Filters may now utilize Envoy's internal buffering by returning the status StopIterationAndBuffer. The complete buffer will be passed on subsequent on*Data invocations until iteration is resumed. This change does not support modifying the buffer (support coming in #1100 ).
Risk Level: Moderate
Testing: Unit coverage, local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>