### PR TITLE
android: fix binary uploading for artifacts ci job

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: envoy_android_aar_sources
-          path: dist/envoy_aar_sources.zip
+          path: bazel-bin/envoy_mobile.zip
   main_ios_dist:
     name: main_ios_dist
     runs-on: macOS-latest


### PR DESCRIPTION
This was renamed a bit back but I suppose we never paid too much attention to this failure 😬 
Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: fix binary uploading for artifacts ci job
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
