### PR TITLE
platform bridge filter: offload no-ops to pass through filter

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -140,15 +140,6 @@ Http::FilterTrailersStatus PlatformBridgeFilter::decodeTrailers(Http::RequestTra
   return onTrailers(trailers, platform_filter_.on_request_trailers);
 }
 
-Http::FilterMetadataStatus PlatformBridgeFilter::decodeMetadata(Http::MetadataMap& /*metadata*/) {
-  return Http::FilterMetadataStatus::Continue;
-}
-
-Http::FilterHeadersStatus
-PlatformBridgeFilter::encode100ContinueHeaders(Http::ResponseHeaderMap& /*headers*/) {
-  return Http::FilterHeadersStatus::Continue;
-}
-
 Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
                                                               bool end_stream) {
   // Delegate to shared implementation for request and response path.
@@ -164,10 +155,6 @@ Http::FilterTrailersStatus
 PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
   // Delegate to shared implementation for request and response path.
   return onTrailers(trailers, platform_filter_.on_response_trailers);
-}
-
-Http::FilterMetadataStatus PlatformBridgeFilter::encodeMetadata(Http::MetadataMap& /*metadata*/) {
-  return Http::FilterMetadataStatus::Continue;
 }
 
 } // namespace PlatformBridge

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -45,15 +45,12 @@ public:
                                           bool end_stream) override;
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
   Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap& trailers) override;
-  Http::FilterMetadataStatus decodeMetadata(Http::MetadataMap& metadata) override;
 
   // StreamEncoderFilter
-  Http::FilterHeadersStatus encode100ContinueHeaders(Http::ResponseHeaderMap& headers) override;
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
                                           bool end_stream) override;
   Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
   Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap& trailers) override;
-  Http::FilterMetadataStatus encodeMetadata(Http::MetadataMap& metadata) override;
 
 private:
   Http::FilterHeadersStatus onHeaders(Http::HeaderMap& headers, bool end_stream,


### PR DESCRIPTION
Description: these functions are no-ops in the current implementation. They can be not overridden in order to delete uncovered code here.
Risk Level: low
Testing: no-op

Signed-off-by: Jose Nino <jnino@lyft.com>