### PR TITLE
stats: remove ability to force flush until required

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -110,16 +110,6 @@ void Engine::recordCounter(const std::string& elements, uint64_t count) {
   }
 }
 
-void Engine::flushStats() {
-  // The server will be null if the post-init callback has not been completed within run().
-  // In this case, we can simply ignore the flush.
-  if (server_) {
-    // Stats must be flushed from the main thread.
-    // Dispatching should be moved after https://github.com/lyft/envoy-mobile/issues/720
-    server_->dispatcher().post([this]() -> void { server_->flushStats(); });
-  }
-}
-
 Http::Dispatcher& Engine::httpDispatcher() { return *http_dispatcher_; }
 
 } // namespace Envoy

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -42,13 +42,6 @@ public:
    */
   void recordCounter(const std::string& elements, uint64_t count);
 
-  /**
-   * Flush the stats sinks outside of a flushing interval.
-   * Note: stats flushing may not be synchronous.
-   * Therefore, this function may return prior to flushing taking place.
-   */
-  void flushStats();
-
 private:
   envoy_status_t run(std::string config, std::string log_level);
 

--- a/library/common/jni/android_jni_interface.cc
+++ b/library/common/jni/android_jni_interface.cc
@@ -29,11 +29,3 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIE
   __android_log_write(ANDROID_LOG_INFO, "[Envoy]", "setting preferred network");
   return set_preferred_network(static_cast<envoy_network_t>(network));
 }
-
-extern "C" JNIEXPORT void JNICALL
-Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_flushStats(JNIEnv* env,
-                                                                   jclass // class
-) {
-  __android_log_write(ANDROID_LOG_INFO, "[Envoy]", "triggering stats flush");
-  flush_stats();
-}

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -72,12 +72,6 @@ void record_counter(const char* elements, uint64_t count) {
   }
 }
 
-void flush_stats() {
-  if (auto e = engine_.lock()) {
-    e->flushStats();
-  }
-}
-
 envoy_status_t register_platform_api(const char* name, void* api) {
   Envoy::Api::External::registerApi(std::string(name), api);
   return ENVOY_SUCCESS;

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -102,14 +102,6 @@ envoy_status_t set_preferred_network(envoy_network_t network);
 void record_counter(const char* elements, uint64_t count);
 
 /**
- * Flush the stats sinks outside of a flushing interval.
- * Note: flushing before the engine has started will result in a no-op.
- * Note: stats flushing may not be synchronous.
- * Therefore, this function may return prior to flushing taking place.
- */
-void flush_stats();
-
-/**
  * Statically register APIs leveraging platform libraries.
  * Warning: Must be completed before any calls to run_engine().
  * @param name, identifier of the platform API

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidAppLifecycleMonitor.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidAppLifecycleMonitor.java
@@ -34,16 +34,16 @@ public class AndroidAppLifecycleMonitor implements ActivityLifecycleCallbacks {
 
   @Override
   public void onActivityPaused(Activity activity) {
-    AndroidJniLibrary.flushStats();
+    /* Use for stats flushing when https://github.com/lyft/envoy-mobile/issues/754 is resolved */
   }
 
   @Override
   public void onActivityStopped(Activity activity) {
-    AndroidJniLibrary.flushStats();
+    /* Use for stats flushing when https://github.com/lyft/envoy-mobile/issues/754 is resolved */
   }
 
   @Override
   public void onActivityDestroyed(Activity activity) {
-    AndroidJniLibrary.flushStats();
+    /* Use for stats flushing when https://github.com/lyft/envoy-mobile/issues/754 is resolved */
   }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
@@ -49,11 +49,3 @@ public class AndroidJniLibrary {
    * @return The resulting status of the operation.
    */
   protected static native int setPreferredNetwork(int network);
-
-  /**
-   * Flush the stats sinks outside of a flushing interval. Note: stats flushing
-   * may not be synchronous. Therefore, this function may return prior to flushing
-   * taking place.
-   */
-  protected static native void flushStats();
-}

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
@@ -49,3 +49,4 @@ public class AndroidJniLibrary {
    * @return The resulting status of the operation.
    */
   protected static native int setPreferredNetwork(int network);
+}


### PR DESCRIPTION
Description: this functionality is not currently being used. Instead of having non-used code in the library (which is also not covered by tests), we should delete and bring back when it is actively being worked on
Risk Level: low - unused functionality
Related to: https://github.com/lyft/envoy-mobile/issues/754

Signed-off-by: Jose Nino <jnino@lyft.com>