### PR TITLE
build: update to Xcode 12

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,11 +13,11 @@ build --swiftcopt=-Xfrontend --swiftcopt=-no-serialize-debugging-options
 build --host_force_python=PY3
 build --ios_minimum_os=11.0
 build --ios_simulator_device="iPhone 11"
-build --ios_simulator_version=13.5
+build --ios_simulator_version=14.0
 build --spawn_strategy=local
 build --verbose_failures
 build --workspace_status_command=envoy/bazel/get_workspace_status
-build --xcode_version=11.5
+build --xcode_version=12.0
 build --javabase=@bazel_tools//tools/jdk:jdk
 build --define disable_known_issue_asserts=true
 build --define cxxopts=-std=c++17

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -5,5 +5,5 @@ set -e
 # Leverage Envoy upstream's setup scripts to avoid repeating here.
 ${ENVOY_MOBILE_PATH:-'.'}/envoy/ci/mac_ci_setup.sh
 
-# https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.15-Readme.md#xcode
-sudo xcode-select --switch /Applications/Xcode_11.5.app
+# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode
+sudo xcode-select --switch /Applications/Xcode_12.app

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -38,8 +38,8 @@ Android requirements
 iOS requirements
 ----------------
 
-- Xcode 11.3
-- Swift 5.0
+- Xcode 12
+- Swift 5.x
 - Note: Requirements are listed in the :repo:`.bazelrc file <.bazelrc>` and CI scripts
 
 .. _android_aar:


### PR DESCRIPTION
This change is dependent on https://github.com/envoyproxy/envoy/pull/13140 to fix upstream build failures with Xcode 12.

Signed-off-by: Michael Rebello <me@michaelrebello.com>