### PR TITLE
config: rename decompressor name from "basic" to "gzip"

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -56,7 +56,7 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.decompressor.v3.Decompressor
               decompressor_library:
-                name: basic
+                name: gzip
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.compression.gzip.decompressor.v3.Gzip
                   # Maximum window bits to allow for any stream to be decompressed. Optimally this


### PR DESCRIPTION
This filter is configured exclusively with gzip decompression. If we were to add more in the future (i.e., brotli), this would be a good way to differentiate.

This change is especially useful since it'll transform `x-envoy-decompressor-basic-uncompressed-bytes` to use "gzip" instead of "basic" in the trailers it adds to responses.

Signed-off-by: Michael Rebello <me@michaelrebello.com>