### PR TITLE
coverage: continue to upload on error

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,8 @@ jobs:
           export CXX=clang++
           export COVERAGE_THRESHOLD=97
           ./envoy/test/run_envoy_bazel_coverage.sh //test/...
+      - name: 'package coverage'
+        run: |
           tar -czvf coverage.tar.gz generated/coverage
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,8 +6,8 @@ on:
       - main
   pull_request:
     paths:
-      - 'library/common/**'
-      - 'test/**'
+      # - 'library/common/**'
+      # - 'test/**'
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,11 +21,12 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/linux_ci_setup.sh
       - name: 'Run coverage'
+        continue-on-error: true
         run: |
           export PATH=/usr/lib/llvm-10/bin:$PATH
           export CC=clang
           export CXX=clang++
-          export COVERAGE_THRESHOLD=95
+          export COVERAGE_THRESHOLD=97
           ./envoy/test/run_envoy_bazel_coverage.sh //test/...
           tar -czvf coverage.tar.gz generated/coverage
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,8 +6,8 @@ on:
       - main
   pull_request:
     paths:
-      # - 'library/common/**'
-      # - 'test/**'
+      - 'library/common/**'
+      - 'test/**'
 
 jobs:
   coverage:
@@ -26,7 +26,7 @@ jobs:
           export PATH=/usr/lib/llvm-10/bin:$PATH
           export CC=clang
           export CXX=clang++
-          export COVERAGE_THRESHOLD=97
+          export COVERAGE_THRESHOLD=95
           ./envoy/test/run_envoy_bazel_coverage.sh //test/...
       - name: 'package coverage'
         run: |


### PR DESCRIPTION
Description: let the coverage report be uploaded even on failure. This allows contributors to see the report when the failure happens due to coverage below threshold errors.
Risk Level: low
Testing: testing by setting the coverage bar too high in an earlier commit.

Signed-off-by: Jose Nino <jnino@lyft.com>