### PR TITLE
build: cache local asan builds independently

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,6 +48,7 @@ build:asan-dev --copt -fno-omit-frame-pointer
 build:asan-dev --copt -fno-optimize-sibling-calls
 build:asan-dev --copt -fsanitize=address
 build:asan-dev --linkopt -fsanitize=address
+build:asan-dev --platform_suffix=-asan
 
 # Exclude debug info from the release binary since it makes it too large to fit
 # into a zip file. This shouldn't affect crash reports.


### PR DESCRIPTION
Description: Previously, setting `--config=asan-dev` would blow away the local build cache, forcing one to rebuild from scratch both to run asan, and then again for normal builds after. This change caches asan builds separately so that both normal builds and asan builds may benefit from caching without clobbering each other.
Risk Level: Low
Testing: Local

Signed-off-by: Mike Schore <mike.schore@gmail.com>
