### PR TITLE
upstream: update with apple dns resolver

### DIFF
--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -48,10 +48,10 @@ def upstream_envoy_overrides():
     http_archive(
         name = "com_google_absl",
         patches = ["@envoy_mobile//bazel:abseil.patch"],
-        sha256 = "14ee08e2089c2a9b6bf27e1d10abc5629c69c4d0bab4b78ec5b65a29ea1c2af7",
-        strip_prefix = "abseil-cpp-cf3a1998e9d41709d4141e2f13375993cba1130e",
-        # 2020-03-05
-        urls = ["https://github.com/abseil/abseil-cpp/archive/cf3a1998e9d41709d4141e2f13375993cba1130e.tar.gz"],
+        sha256 = "573baccd67aa591b8c7209bfb0c77e0d15633d77ced39d1ccbb1232828f7f7d9",
+        strip_prefix = "abseil-cpp-ce4bc927755fdf0ed03d679d9c7fa041175bb3cb",
+        # 2020-08-08
+        urls = ["https://github.com/abseil/abseil-cpp/archive/ce4bc927755fdf0ed03d679d9c7fa041175bb3cb.tar.gz"],
     )
 
     # This should be kept in sync with Envoy itself, we just need to apply this patch

--- a/library/common/extensions/filters/http/platform_bridge/filter.proto
+++ b/library/common/extensions/filters/http/platform_bridge/filter.proto
@@ -5,5 +5,5 @@ package envoymobile.extensions.filters.http.platform_bridge;
 import "validate/validate.proto";
 
 message PlatformBridge {
-  string platform_filter_name = 1 [(validate.rules).string.min_bytes = 1];
+  string platform_filter_name = 1 [(validate.rules).string.min_len = 1];
 }


### PR DESCRIPTION
Updating to pull in https://github.com/envoyproxy/envoy/pull/13074 which will use Apple's DNS resolver for iOS in order to allow Envoy Mobile to ship on iOS 14 without triggering the "local area network" modal.

Signed-off-by: Michael Rebello <me@michaelrebello.com>