### PR TITLE
stats: add gauge apis in jni and platform layers

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -86,6 +86,27 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   return record_counter(engine, env->GetStringUTFChars(elements, nullptr), count);
 }
 
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSet(
+    JNIEnv* env,
+    jclass, // class
+    jlong engine, jstring elements, jint value) {
+  return record_gauge_set(engine, env->GetStringUTFChars(elements, nullptr), value);
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeAdd(
+    JNIEnv* env,
+    jclass, // class
+    jlong engine, jstring elements, jint amount) {
+  return record_gauge_add(engine, env->GetStringUTFChars(elements, nullptr), amount);
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSub(
+    JNIEnv* env,
+    jclass, // class
+    jlong engine, jstring elements, jint amount) {
+  return record_gauge_sub(engine, env->GetStringUTFChars(elements, nullptr), amount);
+}
+
 // JvmCallbackContext
 
 static void pass_headers(JNIEnv* env, envoy_headers headers, jobject j_context) {

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -43,4 +43,19 @@ public class AndroidEngineImpl implements EnvoyEngine {
   public int recordCounter(String elements, int count) {
     return envoyEngine.recordCounter(elements, count);
   }
+
+  @Override
+  public int recordGaugeSet(String elements, int value) {
+    return envoyEngine.recordGaugeSet(elements, value);
+  }
+
+  @Override
+  public int recordGaugeAdd(String elements, int amount) {
+    return envoyEngine.recordGaugeAdd(elements, amount);
+  }
+
+  @Override
+  public int recordGaugeSub(String elements, int amount) {
+    return envoyEngine.recordGaugeSub(elements, amount);
+  }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -40,7 +40,34 @@ public interface EnvoyEngine {
    *
    * @param elements Elements of the counter stat.
    * @param count    Amount to add to the counter.
-   * @param A status indicating if the action was successful.
+   * @return A status indicating if the action was successful.
    */
   int recordCounter(String elements, int count);
+
+  /**
+   * Set a gauge of a given string of elements with the given value.
+   *
+   * @param elements Elements of the gauge stat.
+   * @param value Value to set to the gauge.
+   * @return A status indicating if the action was successful.
+   */
+  int recordGaugeSet(String elements, int vaule);
+
+  /**
+   * Add the gauge with the given string of elements and by the given amount.
+   *
+   * @param elements Elements of the gauge stat.
+   * @param amount Amount to add to the gauge.
+   * @return A status indicating if the action was successful.
+   */
+  int recordGaugeAdd(String elements, int amount);
+
+  /**
+   * Subtract from the gauge with the given string of elements and by the given amount.
+   *
+   * @param elements Elements of the gauge stat.
+   * @param amount Amount to subtract from the gauge.
+   * @return A status indicating if the action was successful.
+   */
+  int recordGaugeSub(String elements, int amount);
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -51,7 +51,7 @@ public interface EnvoyEngine {
    * @param value Value to set to the gauge.
    * @return A status indicating if the action was successful.
    */
-  int recordGaugeSet(String elements, int vaule);
+  int recordGaugeSet(String elements, int value);
 
   /**
    * Add the gauge with the given string of elements and by the given amount.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -85,4 +85,40 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   public int recordCounter(String elements, int count) {
     return JniLibrary.recordCounter(engineHandle, elements, count);
   }
+
+  /**
+   * Set a gauge of a given string of elements with the given value.
+   *
+   * @param elements Elements of the gauge stat.
+   * @param value Amount to set to the gauge.
+   * @return A status indicating if the action was successful.
+   */
+  @Override
+  public int recordGaugeSet(String elements, int value) {
+    return JniLibrary.recordGaugeSet(engineHandle, elements, value);
+  }
+
+  /**
+   * Add the gauge with the given string of elements and by the given amount.
+   *
+   * @param elements Elements of the gauge stat.
+   * @param amount Amount to add to the gauge.
+   * @return A status indicating if the action was successful.
+   */
+  @Override
+  public int recordGaugeAdd(String elements, int amount) {
+    return JniLibrary.recordGaugeAdd(engineHandle, elements, amount);
+  }
+
+  /**
+   * Subtract from the gauge with the given string of elements and by the given amount.
+   *
+   * @param elements Elements of the gauge stat.
+   * @param amount Amount to subtract from the gauge.
+   * @return A status indicating if the action was successful.
+   */
+  @Override
+  public int recordGaugeSub(String elements, int amount) {
+    return JniLibrary.recordGaugeSub(engineHandle, elements, amount);
+  }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -90,7 +90,7 @@ public class EnvoyEngineImpl implements EnvoyEngine {
    * Set a gauge of a given string of elements with the given value.
    *
    * @param elements Elements of the gauge stat.
-   * @param value Amount to set to the gauge.
+   * @param value Value to set to the gauge.
    * @return A status indicating if the action was successful.
    */
   @Override

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -168,7 +168,7 @@ class JniLibrary {
    *
    * @param engine,  handle to the engine that owns the gauge.
    * @param elements Elements of the gauge stat.
-   * @param value Amount to set to the gauge.
+   * @param value Value to set to the gauge.
    * @return A status indicating if the action was successful.
    */
   protected static native int recordGaugeSet(long engine, String elements, int value);

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -164,6 +164,36 @@ class JniLibrary {
   protected static native int recordCounter(long engine, String elements, int count);
 
   /**
+   * Set a gauge of a given string of elements with the given value.
+   *
+   * @param engine,  handle to the engine that owns the gauge.
+   * @param elements Elements of the gauge stat.
+   * @param value Amount to set to the gauge.
+   * @return A status indicating if the action was successful.
+   */
+  protected static native int recordGaugeSet(long engine, String elements, int value);
+
+  /**
+   * Add the gauge with the given string of elements and by the given amount.
+   *
+   * @param engine,  handle to the engine that owns the gauge.
+   * @param elements Elements of the gauge stat.
+   * @param amount Amount to add to the gauge.
+   * @return A status indicating if the action was successful.
+   */
+  protected static native int recordGaugeAdd(long engine, String elements, int amount);
+
+  /**
+   * Subtract from the gauge with the given string of elements and by the given amount.
+   *
+   * @param engine,  handle to the engine that owns the gauge.
+   * @param elements Elements of the gauge stat.
+   * @param amount Amount to subtract from the gauge.
+   * @return A status indicating if the action was successful.
+   */
+  protected static native int recordGaugeSub(long engine, String elements, int amount);
+
+  /**
    * Provides a configuration template that may be used for building platform
    * filter config chains.
    *

--- a/library/kotlin/src/io/envoyproxy/envoymobile/StatsClient.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/StatsClient.kt
@@ -12,4 +12,7 @@ interface StatsClient {
    * @return A counter based on the joined elements.
    */
   fun counter(vararg elements: Element): Counter
+
+  /** @return A gauge based on the joined elements. */
+  fun gauge(vararg elements: Element): Gauge
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/StatsClientImpl.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/StatsClientImpl.kt
@@ -12,4 +12,8 @@ internal class StatsClientImpl constructor(
   override fun counter(vararg elements: Element): Counter {
     return CounterImpl(engine, elements.asList())
   }
+
+  override fun gauge(vararg elements: Element): Gauge {
+    return GaugeImpl(engine, elements.asList())
+  }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -17,4 +17,10 @@ internal class MockEnvoyEngine : EnvoyEngine {
   override fun startStream(callbacks: EnvoyHTTPCallbacks?): EnvoyHTTPStream = MockEnvoyHTTPStream(callbacks!!)
 
   override fun recordCounter(elements: String, count: Int): Int = 0
+
+  override fun recordGaugeSet(elements: String, value: Int): Int = 0
+
+  override fun recordGaugeAdd(elements: String, amount: Int): Int = 0
+
+  override fun recordGaugeSub(elements: String, amount: Int): Int = 0
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/stats/Gauge.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/stats/Gauge.kt
@@ -1,0 +1,14 @@
+package io.envoyproxy.envoymobile
+
+/** A time series gauge. */
+interface Gauge {
+  
+  /** Set the gauge by the given value. */
+  fun set(value: Int)
+
+  /** Add the given amount to the gauge. */
+  fun add(amount: Int)
+
+  /** Subtract the given amount from the gauge. */
+  fun sub(amount: Int)
+}

--- a/library/kotlin/src/io/envoyproxy/envoymobile/stats/Gauge.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/stats/Gauge.kt
@@ -2,7 +2,7 @@ package io.envoyproxy.envoymobile
 
 /** A time series gauge. */
 interface Gauge {
-  
+
   /** Set the gauge by the given value. */
   fun set(value: Int)
 

--- a/library/kotlin/src/io/envoyproxy/envoymobile/stats/GaugeImpl.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/stats/GaugeImpl.kt
@@ -1,0 +1,35 @@
+package io.envoyproxy.envoymobile
+
+import io.envoyproxy.envoymobile.engine.EnvoyEngine
+import java.lang.ref.WeakReference
+
+/**
+ * Envoy implementation of a `Gauge`.
+ */
+internal class GaugeImpl : Gauge {
+  internal val envoyEngine: WeakReference<EnvoyEngine>
+  internal val elements: List<Element>
+
+  internal constructor(engine: EnvoyEngine, elements: List<Element>) {
+    this.envoyEngine = WeakReference<EnvoyEngine>(engine)
+    this.elements = elements
+  }
+
+  override fun set(value: Int) {
+    envoyEngine.get()?.recordGaugeSet(
+      elements.joinToString(separator = ".") { it.element }, value
+    )
+  }
+
+  override fun add(amount: Int) {
+    envoyEngine.get()?.recordGaugeAdd(
+      elements.joinToString(separator = ".") { it.element }, amount
+    )
+  }
+
+  override fun sub(amount: Int) {
+    envoyEngine.get()?.recordGaugeSub(
+      elements.joinToString(separator = ".") { it.element }, amount
+    )
+  }
+}

--- a/library/kotlin/test/io/envoyproxy/envoymobile/StatsClientImplTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/StatsClientImplTest.kt
@@ -33,4 +33,41 @@ class StatsClientImplTest {
     assertThat(elementsCaptor.getValue()).isEqualTo("test.stat")
     assertThat(countCaptor.getValue()).isEqualTo(5)
   }
+
+  @Test
+  fun `gauge delegates to engine with value for set`() {
+    val statsClient = StatsClientImpl(envoyEngine)
+    val gauge = statsClient.gauge(Element("test"), Element("stat"))
+    gauge.set(5)
+    val elementsCaptor = ArgumentCaptor.forClass(String::class.java)
+    val valueCaptor = ArgumentCaptor.forClass(Int::class.java)
+    verify(envoyEngine).recordGaugeSet(elementsCaptor.capture(), valueCaptor.capture())
+    assertThat(elementsCaptor.getValue()).isEqualTo("test.stat")
+    assertThat(valueCaptor.getValue()).isEqualTo(5)
+  }
+
+  @Test
+  fun `gauge delegates to engine with amount for add`() {
+    val statsClient = StatsClientImpl(envoyEngine)
+    val gauge = statsClient.gauge(Element("test"), Element("stat"))
+    gauge.add(5)
+    val elementsCaptor = ArgumentCaptor.forClass(String::class.java)
+    val amountCaptor = ArgumentCaptor.forClass(Int::class.java)
+    verify(envoyEngine).recordGaugeAdd(elementsCaptor.capture(), amountCaptor.capture())
+    assertThat(elementsCaptor.getValue()).isEqualTo("test.stat")
+    assertThat(amountCaptor.getValue()).isEqualTo(5)
+  }
+
+  @Test
+  fun `gauge delegates to engine with amount for sub`() {
+    val statsClient = StatsClientImpl(envoyEngine)
+    val gauge = statsClient.gauge(Element("test"), Element("stat"))
+    gauge.add(5)
+    gauge.sub(5)
+    val elementsCaptor = ArgumentCaptor.forClass(String::class.java)
+    val amountCaptor = ArgumentCaptor.forClass(Int::class.java)
+    verify(envoyEngine).recordGaugeSub(elementsCaptor.capture(), amountCaptor.capture())
+    assertThat(elementsCaptor.getValue()).isEqualTo("test.stat")
+    assertThat(amountCaptor.getValue()).isEqualTo(5)
+  }
 }

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -253,6 +253,33 @@ extern const int kEnvoyFailure;
  */
 - (int)recordCounter:(NSString *)elements count:(NSUInteger)count;
 
+/**
+ Set a gauge of a given string of elements with the given value.
+
+ @param elements Elements of the gauge stat.
+ @param value Value to set to the gauge.
+ @return A status indicating if the action was successful.
+ */
+- (int)recordGaugeSet:(NSString *)elements value:(NSUInteger)value;
+
+/**
+ Add the gauge with the given string of elements and by the given amount.
+
+ @param elements Elements of the counter stat.
+ @param amount Amount to add to the gauge.
+ @return A status indicating if the action was successful.
+ */
+- (int)recordGaugeAdd:(NSString *)elements amount:(NSUInteger)amount;
+
+/**
+ Subtract from the gauge with the given string of elements and by the given amount.
+
+ @param elements Elements of the gauge stat.
+ @param amount Amount to subtract from the gauge.
+ @return A status indicating if the action was successful.
+ */
+- (int)recordGaugeSub:(NSString *)elements amount:(NSUInteger)amount;
+
 @end
 
 #pragma mark - EnvoyEngineImpl

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -212,6 +212,18 @@ static void ios_http_filter_release(const void *context) {
   return record_counter(_engineHandle, elements.UTF8String, count);
 }
 
+- (int)recordGaugeSet:(NSString *)elements value:(NSUInteger)value {
+  return record_gauge_set(_engineHandle, elements.UTF8String, value);
+}
+
+- (int)recordGaugeAdd:(NSString *)elements amount:(NSUInteger)amount {
+  return record_gauge_add(_engineHandle, elements.UTF8String, amount);
+}
+
+- (int)recordGaugeSub:(NSString *)elements amount:(NSUInteger)amount {
+  return record_gauge_sub(_engineHandle, elements.UTF8String, amount);
+}
+
 #pragma mark - Private
 
 - (void)startObservingLifecycleNotifications {

--- a/library/swift/src/StatsClient.swift
+++ b/library/swift/src/StatsClient.swift
@@ -10,4 +10,9 @@ public protocol StatsClient: AnyObject {
   ///
   /// - returns: A Counter based on the joined elements.
   func counter(elements: [Element]) -> Counter
+
+  /// - parameter elements: Elements to identify a gauge
+  ///
+  /// - returns: A Gauge based on the joined elements.
+  func gauge(elements: [Element]) -> Gauge
 }

--- a/library/swift/src/StatsClientImpl.swift
+++ b/library/swift/src/StatsClientImpl.swift
@@ -15,4 +15,8 @@ extension StatsClientImpl: StatsClient {
   func counter(elements: [Element]) -> Counter {
     return CounterImpl(elements: elements, engine: self.engine)
   }
+
+  func gauge(elements: [Element]) -> Gauge {
+    return GaugeImpl(elements: elements, engine: self.engine)
+  }
 }

--- a/library/swift/src/mocks/MockEnvoyEngine.swift
+++ b/library/swift/src/mocks/MockEnvoyEngine.swift
@@ -9,6 +9,12 @@ final class MockEnvoyEngine: NSObject {
   static var onRunWithYAML: ((_ configYAML: String, _ logLevel: String?) -> Void)?
   /// Closure called when `recordCounter(_:count:)` is called.
   static var onRecordCounter: ((_ elements: String, _ count: UInt) -> Void)?
+  /// Closure called when `recordGaugeSet(_:value:)` is called.
+  static var onRecordGaugeSet: ((_ elements: String, _ value: UInt) -> Void)?
+  /// Closure called when `recordGaugeAdd(_:amount:)` is called.
+  static var onRecordGaugeAdd: ((_ elements: String, _ amount: UInt) -> Void)?
+  /// Closure called when `recordGaugeSub(_:amount:)` is called.
+  static var onRecordGaugeSub: ((_ elements: String, _ amount: UInt) -> Void)?
 }
 
 extension MockEnvoyEngine: EnvoyEngine {
@@ -32,6 +38,21 @@ extension MockEnvoyEngine: EnvoyEngine {
 
   func recordCounter(_ elements: String, count: UInt) -> Int32 {
     MockEnvoyEngine.onRecordCounter?(elements, count)
+    return kEnvoySuccess
+  }
+
+  func recordGaugeSet(_ elements: String, value: UInt) -> Int32 {
+    MockEnvoyEngine.onRecordGaugeSet?(elements, value)
+    return kEnvoySuccess
+  }
+
+  func recordGaugeAdd(_ elements: String, amount: UInt) -> Int32 {
+    MockEnvoyEngine.onRecordGaugeAdd?(elements, amount)
+    return kEnvoySuccess
+  }
+
+func recordGaugeSub(_ elements: String, amount: UInt) -> Int32 {
+    MockEnvoyEngine.onRecordGaugeSub?(elements, amount)
     return kEnvoySuccess
   }
 }

--- a/library/swift/src/stats/Gauge.swift
+++ b/library/swift/src/stats/Gauge.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A time series gauge.
+@objc
+public protocol Gauge: AnyObject {
+  /// Set the gauge with the given value.
+  func set(value: Int)
+
+  /// Add the given amount to the gauge.
+  func add(amount: Int)
+
+  /// Subtract the given amount from the gauge.
+  func sub(amount: Int)
+}

--- a/library/swift/src/stats/GaugeImpl.swift
+++ b/library/swift/src/stats/GaugeImpl.swift
@@ -1,0 +1,45 @@
+@_implementationOnly import EnvoyEngine
+import Foundation
+
+/// The implementation of time series gauge.
+@objcMembers
+class GaugeImpl: NSObject, Gauge {
+  private let series: String
+  private weak var engine: EnvoyEngine?
+
+  init(elements: [Element], engine: EnvoyEngine) {
+    self.series = elements.map { $0.value }.joined(separator: ".")
+    self.engine = engine
+    super.init()
+  }
+
+  /// Set the gauge with the given value.
+  /// TODO: potentially raise error to platform if the operation is not successful.
+  func set(value: Int) {
+    guard let engine = self.engine else {
+      return
+    }
+
+    engine.recordGaugeSet(self.series, value: numericCast(value))
+  }
+
+  /// Add the given amount to the gauge.
+  /// TODO: potentially raise error to platform if the operation is not successful.
+  func add(amount: Int) {
+    guard let engine = self.engine else {
+      return
+    }
+
+    engine.recordGaugeAdd(self.series, amount: numericCast(amount))
+  }
+
+  /// Subtract the given amount from the gauge.
+  /// TODO: potentially raise error to platform if the operation is not successful.
+  func sub(amount: Int) {
+    guard let engine = self.engine else {
+      return
+    }
+
+    engine.recordGaugeSub(self.series, amount: numericCast(amount))
+  }
+}

--- a/library/swift/test/StatsClientImplTests.swift
+++ b/library/swift/test/StatsClientImplTests.swift
@@ -95,5 +95,4 @@ final class StatsClientImplTests: XCTestCase {
     XCTAssertEqual(actualSeries, "test.stat")
     XCTAssertEqual(actualAmount, 5)
   }
-
 }

--- a/library/swift/test/StatsClientImplTests.swift
+++ b/library/swift/test/StatsClientImplTests.swift
@@ -50,4 +50,50 @@ final class StatsClientImplTests: XCTestCase {
       XCTAssertNil(weakEngine) // weakEngine is nil (and so Counter didn't keep it alive).
     }
   }
+
+  func testGaugeSetDelegatesToEngineWithValue() {
+    var actualSeries: String?
+    var actualValue: UInt?
+    MockEnvoyEngine.onRecordGaugeSet = { series, value in
+      actualSeries = series
+      actualValue = value
+    }
+    let mockEngine = MockEnvoyEngine()
+    let statsClient = StatsClientImpl(engine: mockEngine)
+    let gauge = statsClient.gauge(elements: ["test", "stat"])
+    gauge.set(value: 5)
+    XCTAssertEqual(actualSeries, "test.stat")
+    XCTAssertEqual(actualValue, 5)
+  }
+
+  func testGaugeAddDelegatesToEngineWithAmount() {
+    var actualSeries: String?
+    var actualAmount: UInt?
+    MockEnvoyEngine.onRecordGaugeAdd = { series, amount in
+      actualSeries = series
+      actualAmount = amount
+    }
+    let mockEngine = MockEnvoyEngine()
+    let statsClient = StatsClientImpl(engine: mockEngine)
+    let gauge = statsClient.gauge(elements: ["test", "stat"])
+    gauge.add(amount: 5)
+    XCTAssertEqual(actualSeries, "test.stat")
+    XCTAssertEqual(actualAmount, 5)
+  }
+
+  func testGaugeSubDelegatesToEngineWithAmount() {
+    var actualSeries: String?
+    var actualAmount: UInt?
+    MockEnvoyEngine.onRecordGaugeSub = { series, amount in
+      actualSeries = series
+      actualAmount = amount
+    }
+    let mockEngine = MockEnvoyEngine()
+    let statsClient = StatsClientImpl(engine: mockEngine)
+    let gauge = statsClient.gauge(elements: ["test", "stat"])
+    gauge.sub(amount: 5)
+    XCTAssertEqual(actualSeries, "test.stat")
+    XCTAssertEqual(actualAmount, 5)
+  }
+
 }


### PR DESCRIPTION
Description: Add Gauge Apis in the platform layers, after this change, gauge will be available for both iOS and Android platforms.
Risk Level: Medium
Testing: Unit tests and end to end in the Lyft Android app

Signed-off-by: Jingwei Hao <jingwei.hao@gmail.com>