### PR TITLE
filters: map Kotlin enum to correct Envoy status

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/FilterDataStatus.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/FilterDataStatus.kt
@@ -45,7 +45,7 @@ sealed class FilterDataStatus<T : Headers>(
    * This may be called by filters which must parse a larger block of the incoming data before
    * continuing processing, and will handle their own buffering.
    */
-  class StopIterationNoBuffer<T : Headers> : FilterDataStatus<T>(2)
+  class StopIterationNoBuffer<T : Headers> : FilterDataStatus<T>(3)
 
   /**
    * Resume previously-stopped iteration, possibly forwarding headers if iteration was stopped


### PR DESCRIPTION
Description: Hardcoding these isn't ideal, but it works for now. Down the road, we should map dynamically at runtime.
Risk Level: Low
Testing: Local with app filters

Signed-off-by: Mike Schore <mike.schore@gmail.com>
