### PR TITLE
stats: emit more upstream stats

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -202,10 +202,10 @@ stats_config:
       patterns:
         - safe_regex:
             google_re2: {}
-            regex: '^cluster\.[\w]+?\.upstream_cx_active'
+            regex: '^cluster\.[\w]+?\.upstream_cx_[\w]+'
         - safe_regex:
             google_re2: {}
-            regex: '^cluster\.[\w]+?\.upstream_rq_(?:[12345]xx|active|retry.*|time|total|unknown)'
+            regex: '^cluster\.[\w]+?\.upstream_rq_[\w]+'
         - safe_regex:
             google_re2: {}
             regex: '^http.dispatcher.*'


### PR DESCRIPTION
Description: this PR expands the regex for upstream request and connection stats in order to enable envoy mobile to emit more series pertaining to those stats trees. This will help owners to determine, with more granularity, the health of mobile networks.
Risk Level: med - emission of ~2 dozen new stats.
Testing: tested with the local-stats branch to verify emission.

Signed-off-by: Jose Nino <jnino@lyft.com>
