### PR TITLE
java: add Android and Java async filter callback support

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -363,7 +363,8 @@ static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_h
                                         /*trailers*/ native_headers};
 }
 
-static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks callbacks, const void* context) {
+static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks callbacks,
+                                                  const void* context) {
 
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_http_filter_set_request_callbacks");
 
@@ -371,7 +372,8 @@ static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks ca
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
 
-  envoy_http_filter_callbacks* on_heap_callbacks = static_cast<envoy_http_filter_callbacks*>(safe_malloc(sizeof(envoy_http_filter_callbacks)));
+  envoy_http_filter_callbacks* on_heap_callbacks =
+      static_cast<envoy_http_filter_callbacks*>(safe_malloc(sizeof(envoy_http_filter_callbacks)));
   *on_heap_callbacks = callbacks;
   jlong callback_handle = reinterpret_cast<jlong>(on_heap_callbacks);
 
@@ -380,7 +382,8 @@ static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks ca
   env->CallVoidMethod(j_context, jmid_setRequestFilterCallbacks, callback_handle);
 }
 
-static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks callbacks, const void* context) {
+static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks callbacks,
+                                                   const void* context) {
 
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_http_filter_set_response_callbacks");
 
@@ -388,7 +391,8 @@ static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks c
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
 
-  envoy_http_filter_callbacks* on_heap_callbacks = static_cast<envoy_http_filter_callbacks*>(safe_malloc(sizeof(envoy_http_filter_callbacks)));
+  envoy_http_filter_callbacks* on_heap_callbacks =
+      static_cast<envoy_http_filter_callbacks*>(safe_malloc(sizeof(envoy_http_filter_callbacks)));
   *on_heap_callbacks = callbacks;
   jlong callback_handle = reinterpret_cast<jlong>(on_heap_callbacks);
 
@@ -398,8 +402,8 @@ static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks c
 }
 
 static envoy_filter_resume_status
-jvm_http_filter_on_resume(const char* method, envoy_headers *headers, envoy_data *data,
-                          envoy_headers *trailers, bool end_stream, const void* context) {
+jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data* data,
+                          envoy_headers* trailers, bool end_stream, const void* context) {
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_resume");
 
   JNIEnv* env = get_env();
@@ -432,7 +436,8 @@ jvm_http_filter_on_resume(const char* method, envoy_headers *headers, envoy_data
       env->GetMethodID(jcls_JvmCallbackContext, method, "(J)Ljava/lang/Object;");
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
-  jobjectArray result = static_cast<jobjectArray>(env->CallObjectMethod(j_context, jmid_onResume, headers_length, j_in_data, trailers_length));
+  jobjectArray result = static_cast<jobjectArray>(
+      env->CallObjectMethod(j_context, jmid_onResume, headers_length, j_in_data, trailers_length));
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
 
@@ -459,20 +464,20 @@ jvm_http_filter_on_resume(const char* method, envoy_headers *headers, envoy_data
 }
 
 static envoy_filter_resume_status
-jvm_http_filter_on_resume_request(envoy_headers *headers, envoy_data *data, envoy_headers *trailers,
-                                  bool end_stream, const void *context) {
+jvm_http_filter_on_resume_request(envoy_headers* headers, envoy_data* data, envoy_headers* trailers,
+                                  bool end_stream, const void* context) {
   return jvm_http_filter_on_resume("onResumeRequest", headers, data, trailers, end_stream, context);
 }
 
 static envoy_filter_resume_status
-jvm_http_filter_on_resume_response(envoy_headers *headers, envoy_data *data, envoy_headers *trailers,
-                                  bool end_stream, const void *context) {
-  return jvm_http_filter_on_resume("onResumeResponse", headers, data, trailers, end_stream, context);
+jvm_http_filter_on_resume_response(envoy_headers* headers, envoy_data* data,
+                                   envoy_headers* trailers, bool end_stream, const void* context) {
+  return jvm_http_filter_on_resume("onResumeResponse", headers, data, trailers, end_stream,
+                                   context);
 }
 
 static void ios_http_filter_set_request_callbacks(envoy_http_filter_callbacks callbacks,
-                                                  const void *context) {
-}
+                                                  const void* context) {}
 
 static void* jvm_on_error(envoy_error error, void* context) {
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_error");
@@ -626,7 +631,8 @@ Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callResumeIte
   // Context is only passed here to ensure it's not inadvertently gc'd during execution of this
   // function. To be extra safe, do an explicit retain with a GlobalRef.
   jobject retained_context = env->NewGlobalRef(j_context);
-  envoy_http_filter_callbacks* callbacks = reinterpret_cast<envoy_http_filter_callbacks*>(callback_handle);
+  envoy_http_filter_callbacks* callbacks =
+      reinterpret_cast<envoy_http_filter_callbacks*>(callback_handle);
   callbacks->resume_iteration(callbacks->callback_context);
   env->DeleteGlobalRef(retained_context);
 }
@@ -635,7 +641,8 @@ extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callReleaseCallbacks(
     JNIEnv* env, jclass, jlong callback_handle) {
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "callReleaseCallbacks");
-  envoy_http_filter_callbacks* callbacks = reinterpret_cast<envoy_http_filter_callbacks*>(callback_handle);
+  envoy_http_filter_callbacks* callbacks =
+      reinterpret_cast<envoy_http_filter_callbacks*>(callback_handle);
   callbacks->release_callbacks(callbacks->callback_context);
   free(callbacks);
 }

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -380,6 +380,8 @@ static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks ca
   jmethodID jmid_setRequestFilterCallbacks =
       env->GetMethodID(jcls_JvmCallbackContext, "setRequestFilterCallbacks", "(J)V");
   env->CallVoidMethod(j_context, jmid_setRequestFilterCallbacks, callback_handle);
+
+  env->DeleteLocalRef(jcls_JvmCallbackContext);
 }
 
 static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks callbacks,
@@ -399,6 +401,8 @@ static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks c
   jmethodID jmid_setResponseFilterCallbacks =
       env->GetMethodID(jcls_JvmCallbackContext, "setResponseFilterCallbacks", "(J)V");
   env->CallVoidMethod(j_context, jmid_setResponseFilterCallbacks, callback_handle);
+
+  env->DeleteLocalRef(jcls_JvmCallbackContext);
 }
 
 static envoy_filter_resume_status

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -109,9 +109,10 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 
 // JvmCallbackContext
 
-static void pass_headers(JNIEnv* env, envoy_headers headers, jobject j_context) {
+static void pass_headers(const char* method, envoy_headers headers, jobject j_context) {
+  JNIEnv* env = get_env();
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
-  jmethodID jmid_passHeader = env->GetMethodID(jcls_JvmCallbackContext, "passHeader", "([B[BZ)V");
+  jmethodID jmid_passHeader = env->GetMethodID(jcls_JvmCallbackContext, method, "([B[BZ)V");
   env->PushLocalFrame(headers.length * 2);
   jboolean start_headers = JNI_TRUE;
 
@@ -162,7 +163,7 @@ static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_
   __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_headers");
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
-  pass_headers(env, headers, j_context);
+  pass_headers("passHeader", headers, j_context);
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onHeaders =
@@ -304,7 +305,7 @@ static void* jvm_on_trailers(const char* method, envoy_headers trailers, void* c
 
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
-  pass_headers(env, trailers, j_context);
+  pass_headers("passHeader", trailers, j_context);
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onTrailers =
@@ -360,6 +361,117 @@ static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_h
 
   return (envoy_filter_trailers_status){/*status*/ unboxed_status,
                                         /*trailers*/ native_headers};
+}
+
+static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks callbacks, const void* context) {
+
+  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_http_filter_set_request_callbacks");
+
+  JNIEnv* env = get_env();
+  jobject j_context = static_cast<jobject>(const_cast<void*>(context));
+  jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
+
+  envoy_http_filter_callbacks* on_heap_callbacks = static_cast<envoy_http_filter_callbacks*>(safe_malloc(sizeof(envoy_http_filter_callbacks)));
+  *on_heap_callbacks = callbacks;
+  jlong callback_handle = reinterpret_cast<jlong>(on_heap_callbacks);
+
+  jmethodID jmid_setRequestFilterCallbacks =
+      env->GetMethodID(jcls_JvmCallbackContext, "setRequestFilterCallbacks", "(J)V");
+  env->CallVoidMethod(j_context, jmid_setRequestFilterCallbacks, callback_handle);
+}
+
+static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks callbacks, const void* context) {
+
+  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_http_filter_set_response_callbacks");
+
+  JNIEnv* env = get_env();
+  jobject j_context = static_cast<jobject>(const_cast<void*>(context));
+  jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
+
+  envoy_http_filter_callbacks* on_heap_callbacks = static_cast<envoy_http_filter_callbacks*>(safe_malloc(sizeof(envoy_http_filter_callbacks)));
+  *on_heap_callbacks = callbacks;
+  jlong callback_handle = reinterpret_cast<jlong>(on_heap_callbacks);
+
+  jmethodID jmid_setResponseFilterCallbacks =
+      env->GetMethodID(jcls_JvmCallbackContext, "setResponseFilterCallbacks", "(J)V");
+  env->CallVoidMethod(j_context, jmid_setResponseFilterCallbacks, callback_handle);
+}
+
+static envoy_filter_resume_status
+jvm_http_filter_on_resume(const char* method, envoy_headers *headers, envoy_data *data,
+                          envoy_headers *trailers, bool end_stream, const void* context) {
+  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_resume");
+
+  JNIEnv* env = get_env();
+  jobject j_context = static_cast<jobject>(const_cast<void*>(context));
+  jlong headers_length = -1;
+  if (headers) {
+    headers_length = (jlong)headers->length;
+    pass_headers("passHeader", *headers, j_context);
+  }
+  jbyteArray j_in_data = NULL;
+  if (data) {
+    j_in_data = env->NewByteArray(data->length);
+    // TODO: check if copied via isCopy.
+    // TODO: check for NULL.
+    // https://github.com/lyft/envoy-mobile/issues/758
+    void* critical_data = env->GetPrimitiveArrayCritical(j_in_data, nullptr);
+    memcpy(critical_data, data->bytes, data->length);
+    // Here '0' (for which there is no named constant) indicates we want to commit the changes back
+    // to the JVM and free the c array, where applicable.
+    env->ReleasePrimitiveArrayCritical(j_in_data, critical_data, 0);
+  }
+  jlong trailers_length = -1;
+  if (trailers) {
+    trailers_length = (jlong)trailers->length;
+    pass_headers("passTrailer", *trailers, j_context);
+  }
+
+  jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
+  jmethodID jmid_onResume =
+      env->GetMethodID(jcls_JvmCallbackContext, method, "(J)Ljava/lang/Object;");
+  // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
+  // TODO: make this cast safer.
+  jobjectArray result = static_cast<jobjectArray>(env->CallObjectMethod(j_context, jmid_onResume, headers_length, j_in_data, trailers_length));
+
+  env->DeleteLocalRef(jcls_JvmCallbackContext);
+
+  jobject status = env->GetObjectArrayElement(result, 0);
+  jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
+  jobject j_data = static_cast<jobject>(env->GetObjectArrayElement(result, 2));
+  jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 3));
+
+  int unboxed_status = unbox_integer(env, status);
+  envoy_headers* pending_headers = to_native_headers_ptr(env, j_headers);
+  envoy_data* pending_data = buffer_to_native_data_ptr(env, j_data);
+  envoy_headers* pending_trailers = to_native_headers_ptr(env, j_trailers);
+
+  env->DeleteLocalRef(result);
+  env->DeleteLocalRef(status);
+  env->DeleteLocalRef(j_headers);
+  env->DeleteLocalRef(j_data);
+  env->DeleteLocalRef(j_trailers);
+
+  return (envoy_filter_resume_status){/*status*/ unboxed_status,
+                                      /*pending_headers*/ pending_headers,
+                                      /*pending_data*/ pending_data,
+                                      /*pending_trailers*/ pending_trailers};
+}
+
+static envoy_filter_resume_status
+jvm_http_filter_on_resume_request(envoy_headers *headers, envoy_data *data, envoy_headers *trailers,
+                                  bool end_stream, const void *context) {
+  return jvm_http_filter_on_resume("onResumeRequest", headers, data, trailers, end_stream, context);
+}
+
+static envoy_filter_resume_status
+jvm_http_filter_on_resume_response(envoy_headers *headers, envoy_data *data, envoy_headers *trailers,
+                                  bool end_stream, const void *context) {
+  return jvm_http_filter_on_resume("onResumeResponse", headers, data, trailers, end_stream, context);
+}
+
+static void ios_http_filter_set_request_callbacks(envoy_http_filter_callbacks callbacks,
+                                                  const void *context) {
 }
 
 static void* jvm_on_error(envoy_error error, void* context) {
@@ -494,6 +606,10 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* e
   api->on_response_headers = jvm_http_filter_on_response_headers;
   api->on_response_data = jvm_http_filter_on_response_data;
   api->on_response_trailers = jvm_http_filter_on_response_trailers;
+  api->set_request_callbacks = jvm_http_filter_set_request_callbacks;
+  api->on_resume_request = jvm_http_filter_on_resume_request;
+  api->set_response_callbacks = jvm_http_filter_set_response_callbacks;
+  api->on_resume_response = jvm_http_filter_on_resume_response;
   api->release_filter = jni_delete_const_global_ref;
   api->static_context = retained_context;
   api->instance_context = NULL;
@@ -502,6 +618,29 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* e
   env->DeleteLocalRef(jcls_JvmFilterFactoryContext);
   return ENVOY_SUCCESS;
 }
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callResumeIteration(
+    JNIEnv* env, jclass, jlong callback_handle, jobject j_context) {
+  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "callResumeIteration");
+  // Context is only passed here to ensure it's not inadvertently gc'd during execution of this
+  // function. To be extra safe, do an explicit retain with a GlobalRef.
+  jobject retained_context = env->NewGlobalRef(j_context);
+  envoy_http_filter_callbacks* callbacks = reinterpret_cast<envoy_http_filter_callbacks*>(callback_handle);
+  callbacks->resume_iteration(callbacks->callback_context);
+  env->DeleteGlobalRef(retained_context);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callReleaseCallbacks(
+    JNIEnv* env, jclass, jlong callback_handle) {
+  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "callReleaseCallbacks");
+  envoy_http_filter_callbacks* callbacks = reinterpret_cast<envoy_http_filter_callbacks*>(callback_handle);
+  callbacks->release_callbacks(callbacks->callback_context);
+  free(callbacks);
+}
+
+// EnvoyHTTPStream
 
 // Note: JLjava_nio_ByteBuffer_2Z is the mangled signature of the java method.
 // https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/design.html

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -79,6 +79,21 @@ envoy_data buffer_to_native_data(JNIEnv* env, jobject j_data) {
   return native_data;
 }
 
+envoy_data* buffer_to_native_data_ptr(JNIEnv* env, jobject j_data) {
+  // Note: This check works for LocalRefs and GlobalRefs, but will not work for WeakGlobalRefs.
+  // Such usage would generally be inappropriate anyways; like C++ weak_ptrs, one should
+  // acquire a new strong reference before attempting to interact with an object held by
+  // a WeakGlobalRef. See:
+  // https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#weak
+  if (j_data == NULL) {
+    return nullptr;
+  }
+
+  envoy_data* native_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_header)));
+  *native_data = buffer_to_native_data(env, j_data);
+  return native_data;
+}
+
 envoy_headers to_native_headers(JNIEnv* env, jobjectArray headers) {
   // Note that headers is a flattened array of key/value pairs.
   // Therefore, the length of the native header array is n envoy_data or n/2 envoy_header.
@@ -109,5 +124,20 @@ envoy_headers to_native_headers(JNIEnv* env, jobjectArray headers) {
   }
 
   envoy_headers native_headers = {length / 2, header_array};
+  return native_headers;
+}
+
+envoy_headers* to_native_headers_ptr(JNIEnv* env, jobjectArray headers) {
+  // Note: This check works for LocalRefs and GlobalRefs, but will not work for WeakGlobalRefs.
+  // Such usage would generally be inappropriate anyways; like C++ weak_ptrs, one should
+  // acquire a new strong reference before attempting to interact with an object held by
+  // a WeakGlobalRef. See:
+  // https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#weak
+  if (headers == NULL) {
+    return nullptr;
+  }
+
+  envoy_headers* native_headers = static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_header)));
+  *native_headers = to_native_headers(env, headers);
   return native_headers;
 }

--- a/library/common/jni/jni_utility.h
+++ b/library/common/jni/jni_utility.h
@@ -22,4 +22,8 @@ envoy_data array_to_native_data(JNIEnv* env, jbyteArray j_data);
 
 envoy_data buffer_to_native_data(JNIEnv* env, jobject j_data);
 
+envoy_data* buffer_to_native_data_ptr(JNIEnv* env, jobject j_data);
+
 envoy_headers to_native_headers(JNIEnv* env, jobjectArray headers);
+
+envoy_headers* to_native_headers_ptr(JNIEnv* env, jobjectArray headers);

--- a/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/BUILD
@@ -26,7 +26,6 @@ java_library(
         "EnvoyConfiguration.java",
         "EnvoyEngine.java",
         "EnvoyEngineImpl.java",
-        "EnvoyHTTPFilterCallbacks.java",
         "EnvoyHTTPFilterCallbacksImpl.java",
         "EnvoyHTTPStream.java",
         "EnvoyNativeResourceRegistry.java",

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPFilterCallbacksImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyHTTPFilterCallbacksImpl.java
@@ -1,7 +1,6 @@
 package io.envoyproxy.envoymobile.engine;
 
-import io.envoyproxy.envoymobile.engine.EnvoyNativeResourceReleaser;
-import io.envoyproxy.envoymobile.engine.EnvoyNativeResourceWrapper;
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterCallbacks;
 
 final class EnvoyHTTPFilterCallbacksImpl
     implements EnvoyHTTPFilterCallbacks, EnvoyNativeResourceWrapper {

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyNativeResourceRegistry.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyNativeResourceRegistry.java
@@ -16,7 +16,7 @@ public enum EnvoyNativeResourceRegistry {
   SINGLETON;
 
   // References are automatically enqueued when the gc flags them as unreachable.
-  private ReferenceQueue refQueue;
+  private ReferenceQueue<EnvoyNativeResourceWrapper> refQueue;
   // Maintains references in the object graph while we wait for them to be enqueued.
   private Set refMaintainer;
   // Blocks on the reference queue and calls the releaser of queued references.
@@ -47,6 +47,7 @@ public enum EnvoyNativeResourceRegistry {
       super(owner, refQueue);
       this.nativeHandle = nativeHandle;
       this.releaser = releaser;
+      refQueue = new ReferenceQueue<>();
       refQueueThread = new RefQueueThread();
       refMaintainer = new ConcurrentHashMap().newKeySet();
       refQueueThread.start();

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -10,11 +10,13 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilter;
  * Wrapper class for EnvoyHTTPFilter for receiving JNI calls.
  */
 class JvmFilterContext {
-  private final JvmBridgeUtility bridgeUtility;
+  private final JvmBridgeUtility headerUtility;
+  private final JvmBridgeUtility trailerUtility;
   private final EnvoyHTTPFilter filter;
 
   public JvmFilterContext(EnvoyHTTPFilter filter) {
-    bridgeUtility = new JvmBridgeUtility();
+    headerUtility = new JvmBridgeUtility();
+    trailerUtility = new JvmBridgeUtility();
     this.filter = filter;
   }
 
@@ -26,7 +28,18 @@ class JvmFilterContext {
    * @param start,      indicates this is the first header pair of the block.
    */
   public void passHeader(byte[] key, byte[] value, boolean start) {
-    bridgeUtility.passHeader(key, value, start);
+    headerUtility.passHeader(key, value, start);
+  }
+
+  /**
+   * Delegates trailer retrieval to the secondary bridge utility.
+   *
+   * @param key,        the name of the HTTP trailer.
+   * @param value,      the value of the HTTP trailer.
+   * @param start,      indicates this is the first trailer pair of the block.
+   */
+  public void passTrailer(byte[] key, byte[] value, boolean start) {
+    trailerUtility.passHeader(key, value, start);
   }
 
   /**
@@ -37,8 +50,8 @@ class JvmFilterContext {
    * @return Object[],   pair of HTTP filter status and optional modified headers.
    */
   public Object onRequestHeaders(long headerCount, boolean endStream) {
-    assert bridgeUtility.validateCount(headerCount);
-    final Map headers = bridgeUtility.retrieveHeaders();
+    assert headerUtility.validateCount(headerCount);
+    final Map headers = headerUtility.retrieveHeaders();
     return toJniFilterHeadersStatus(filter.onRequestHeaders(headers, endStream));
   }
 
@@ -61,8 +74,8 @@ class JvmFilterContext {
    * @return Object[],    pair of HTTP filter status and optional modified trailers.
    */
   public Object onRequestTrailers(long trailerCount) {
-    assert bridgeUtility.validateCount(trailerCount);
-    final Map trailers = bridgeUtility.retrieveHeaders();
+    assert headerUtility.validateCount(trailerCount);
+    final Map trailers = headerUtility.retrieveHeaders();
     return toJniFilterHeadersStatus(filter.onRequestTrailers(trailers));
   }
 
@@ -74,8 +87,8 @@ class JvmFilterContext {
    * @return Object[],   pair of HTTP filter status and optional modified headers.
    */
   public Object onResponseHeaders(long headerCount, boolean endStream) {
-    assert bridgeUtility.validateCount(headerCount);
-    final Map headers = bridgeUtility.retrieveHeaders();
+    assert headerUtility.validateCount(headerCount);
+    final Map headers = headerUtility.retrieveHeaders();
     return toJniFilterHeadersStatus(filter.onResponseHeaders(headers, endStream));
   }
 
@@ -98,9 +111,63 @@ class JvmFilterContext {
    * @return Object[],    pair of HTTP filter status and optional modified trailers.
    */
   public Object onResponseTrailers(long trailerCount) {
-    assert bridgeUtility.validateCount(trailerCount);
-    final Map trailers = bridgeUtility.retrieveHeaders();
+    assert headerUtility.validateCount(trailerCount);
+    final Map trailers = headerUtility.retrieveHeaders();
     return toJniFilterHeadersStatus(filter.onResponseTrailers(trailers));
+  }
+
+  /**
+   * 
+   */
+  public Object onResumeRequest(long headerCount, byte[] data, long trailerCount, boolean endStream) {
+    // Headers are optional in this call, and a negative length indicates omission.
+    Map<String, List<String>> headers = null;
+    if (headerCount >= 0) {
+      assert headerUtility.validateCount(headerCount);
+      headers = headerUtility.retrieveHeaders();
+    }
+    ByteBuffer dataBuffer = data == null ? null : ByteBuffer.wrap(data);
+    // Trailers are optional in this call, and a negative length indicates omission.
+    Map<String, List<String>> trailers = null;
+    if (trailerCount >= 0) {
+      assert trailerUtility.validateCount(trailerCount);
+      trailers = trailerUtility.retrieveHeaders();
+    }
+    return filter.onResumeRequest(headers, dataBuffer, trailers, endStream);
+  }
+
+  /**
+   *
+   */
+  public Object onResumeResponse(long headerCount, byte[] data, long trailerCount, boolean endStream) {
+    // Headers are optional in this call, and a negative length indicates omission.
+    Map<String, List<String>> headers = null;
+    if (headerCount >= 0) {
+      assert headerUtility.validateCount(headerCount);
+      headers = headerUtility.retrieveHeaders();
+    }
+    ByteBuffer dataBuffer = data == null ? null : ByteBuffer.wrap(data);
+    // Trailers are optional in this call, and a negative length indicates omission.
+    Map<String, List<String>> trailers = null;
+    if (trailerCount >= 0) {
+      assert trailerUtility.validateCount(trailerCount);
+      trailers = trailerUtility.retrieveHeaders();
+    }
+    return filter.onResumeResponse(headers, dataBuffer, trailers, endStream);
+  }
+
+  /**
+   *
+   */
+  public void setRequestFilterCallbacks(long callbackHandle) {
+    filter.setRequestFilterCallbacks(EnvoyHTTPFilterCallbacksImpl.create(callbackHandle));
+  }
+
+  /**
+   *
+   */
+  public void setResponseFilterCallbacks(long callbackHandle) {
+    filter.setResponseFilterCallbacks(EnvoyHTTPFilterCallbacksImpl.create(callbackHandle));
   }
 
   private static byte[][] toJniHeaders(Object headers) {

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -117,9 +117,10 @@ class JvmFilterContext {
   }
 
   /**
-   * 
+   *
    */
-  public Object onResumeRequest(long headerCount, byte[] data, long trailerCount, boolean endStream) {
+  public Object onResumeRequest(long headerCount, byte[] data, long trailerCount,
+                                boolean endStream) {
     // Headers are optional in this call, and a negative length indicates omission.
     Map<String, List<String>> headers = null;
     if (headerCount >= 0) {
@@ -139,7 +140,8 @@ class JvmFilterContext {
   /**
    *
    */
-  public Object onResumeResponse(long headerCount, byte[] data, long trailerCount, boolean endStream) {
+  public Object onResumeResponse(long headerCount, byte[] data, long trailerCount,
+                                 boolean endStream) {
     // Headers are optional in this call, and a negative length indicates omission.
     Map<String, List<String>> headers = null;
     if (headerCount >= 0) {

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/BUILD
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/BUILD
@@ -7,6 +7,7 @@ java_library(
     srcs = [
         "EnvoyHTTPCallbacks.java",
         "EnvoyHTTPFilter.java",
+        "EnvoyHTTPFilterCallbacks.java",
         "EnvoyHTTPFilterFactory.java",
         "EnvoyOnEngineRunning.java",
         "EnvoyStatus.java",

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
@@ -53,4 +53,37 @@ public interface EnvoyHTTPFilter {
    * @param trailers, the trailers received.
    */
   Object[] onResponseTrailers(Map<String, List<String>> trailers);
+
+  /**
+   * Provides asynchronous callbacks to implementations that elect to use them.
+   *
+   * @param callbacks, thread-safe internal callbacks that enable asynchronous filter interaction.
+   */
+  void setRequestFilterCallbacks(EnvoyHTTPFilterCallbacks callbacks);
+
+  /**
+   * Called when request filter iteration has been asynchronsouly resumed via callback.
+   *
+   * @param headers,  pending headers that have not yet been forwarded along the filter chain.
+   * @param data,     pending data that has not yet been forwarded along the filter chain.
+   * @param trailers, pending trailers that have not yet been forwarded along the filter chain.
+   */
+  Object[] onResumeRequest(Map<String, List<String>> headers, ByteBuffer data, Map<String, List<String>> trailers, boolean endStream);
+
+  /**
+   * Provides asynchronous callbacks to implementations that elect to use them.
+   *
+   * @param callbacks, thread-safe internal callbacks that enable asynchronous filter interaction.
+   */
+ void setResponseFilterCallbacks(EnvoyHTTPFilterCallbacks callbacks);
+
+  /**
+   * Called when response filter iteration has been asynchronsouly resumed via callback.
+   *
+   * @param headers,  pending headers that have not yet been forwarded along the filter chain.
+   * @param data,     pending data that has not yet been forwarded along the filter chain.
+   * @param trailers, pending trailers that have not yet been forwarded along the filter chain.
+   */
+  Object[] onResumeResponse(Map<String, List<String>> headers, ByteBuffer data, Map<String, List<String>> trailers, boolean endStream);
+
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
@@ -68,14 +68,15 @@ public interface EnvoyHTTPFilter {
    * @param data,     pending data that has not yet been forwarded along the filter chain.
    * @param trailers, pending trailers that have not yet been forwarded along the filter chain.
    */
-  Object[] onResumeRequest(Map<String, List<String>> headers, ByteBuffer data, Map<String, List<String>> trailers, boolean endStream);
+  Object[] onResumeRequest(Map<String, List<String>> headers, ByteBuffer data,
+                           Map<String, List<String>> trailers, boolean endStream);
 
   /**
    * Provides asynchronous callbacks to implementations that elect to use them.
    *
    * @param callbacks, thread-safe internal callbacks that enable asynchronous filter interaction.
    */
- void setResponseFilterCallbacks(EnvoyHTTPFilterCallbacks callbacks);
+  void setResponseFilterCallbacks(EnvoyHTTPFilterCallbacks callbacks);
 
   /**
    * Called when response filter iteration has been asynchronsouly resumed via callback.
@@ -84,6 +85,6 @@ public interface EnvoyHTTPFilter {
    * @param data,     pending data that has not yet been forwarded along the filter chain.
    * @param trailers, pending trailers that have not yet been forwarded along the filter chain.
    */
-  Object[] onResumeResponse(Map<String, List<String>> headers, ByteBuffer data, Map<String, List<String>> trailers, boolean endStream);
-
+  Object[] onResumeResponse(Map<String, List<String>> headers, ByteBuffer data,
+                            Map<String, List<String>> trailers, boolean endStream);
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilterCallbacks.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilterCallbacks.java
@@ -1,3 +1,3 @@
-package io.envoyproxy.envoymobile.engine;
+package io.envoyproxy.envoymobile.engine.types;
 
 public interface EnvoyHTTPFilterCallbacks { void resumeIteration(); }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/Filter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/Filter.kt
@@ -1,5 +1,6 @@
 package io.envoyproxy.envoymobile
 
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterCallbacks
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilter
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory
 import java.nio.ByteBuffer
@@ -94,5 +95,45 @@ internal class EnvoyHTTPFilterAdapter(
       }
     }
     return arrayOf(0, trailers)
+  }
+
+  override fun setRequestFilterCallbacks(callbacks: EnvoyHTTPFilterCallbacks) {
+    (filter as? AsyncRequestFilter)?.let { asyncRequestFilter ->
+      asyncRequestFilter.setRequestFilterCallbacks(RequestFilterCallbacksImpl(callbacks))
+    }
+  }
+
+  override fun onResumeRequest(headers: Map<String, List<String>>?, data: ByteBuffer?, trailers: Map<String, List<String>>?, endStream: Boolean): Array<Any?> {
+    (filter as? AsyncRequestFilter)?.let { asyncRequestFilter ->
+      val result = asyncRequestFilter.onResumeRequest(
+        headers?.let(::RequestHeaders),
+        data,
+        trailers?.let(::RequestTrailers),
+        endStream)
+      return when (result) {
+        is FilterResumeStatus.ResumeIteration<*, *> -> arrayOf(result.status, result.headers?.headers, result.data, result.trailers?.headers)
+      }
+    }
+    return arrayOf(-1, headers, data, trailers)
+  }
+
+  override fun setResponseFilterCallbacks(callbacks: EnvoyHTTPFilterCallbacks) {
+    (filter as? AsyncResponseFilter)?.let { asyncResponseFilter ->
+      asyncResponseFilter.setResponseFilterCallbacks(ResponseFilterCallbacksImpl(callbacks))
+    }
+  }
+
+  override fun onResumeResponse(headers: Map<String, List<String>>?, data: ByteBuffer?, trailers: Map<String, List<String>>?, endStream: Boolean): Array<Any?> {
+    (filter as? AsyncResponseFilter)?.let { asyncResponseFilter ->
+      val result = asyncResponseFilter.onResumeResponse(
+        headers?.let(::ResponseHeaders),
+        data,
+        trailers?.let(::ResponseTrailers),
+        endStream)
+      return when (result) {
+        is FilterResumeStatus.ResumeIteration<*, *> -> arrayOf(result.status, result.headers?.headers, result.data, result.trailers?.headers)
+      }
+    }
+    return arrayOf(-1, headers, data, trailers)
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/Filter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/Filter.kt
@@ -1,7 +1,7 @@
 package io.envoyproxy.envoymobile
 
-import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterCallbacks
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilter
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterCallbacks
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory
 import java.nio.ByteBuffer
 
@@ -109,7 +109,8 @@ internal class EnvoyHTTPFilterAdapter(
         headers?.let(::RequestHeaders),
         data,
         trailers?.let(::RequestTrailers),
-        endStream)
+        endStream
+      )
       return when (result) {
         is FilterResumeStatus.ResumeIteration<*, *> -> arrayOf(result.status, result.headers?.headers, result.data, result.trailers?.headers)
       }
@@ -129,7 +130,8 @@ internal class EnvoyHTTPFilterAdapter(
         headers?.let(::ResponseHeaders),
         data,
         trailers?.let(::ResponseTrailers),
-        endStream)
+        endStream
+      )
       return when (result) {
         is FilterResumeStatus.ResumeIteration<*, *> -> arrayOf(result.status, result.headers?.headers, result.data, result.trailers?.headers)
       }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/FilterResumeStatus.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/FilterResumeStatus.kt
@@ -5,7 +5,9 @@ import java.nio.ByteBuffer
 /*
  * Status to be returned by filters after resuming iteration asynchronously.
  */
-sealed class FilterResumeStatus<T : Headers, U : Trailers> {
+sealed class FilterResumeStatus<T : Headers, U : Trailers>(
+  val status: Int
+) {
   /**
    * Resume previously-stopped iteration, potentially forwarding headers, data, and/or trailers
    * that have not yet been passed along the filter chain.
@@ -24,5 +26,5 @@ sealed class FilterResumeStatus<T : Headers, U : Trailers> {
     val headers: T?,
     val data: ByteBuffer?,
     val trailers: U?
-  ) : FilterResumeStatus<T, U>()
+  ) : FilterResumeStatus<T, U>(-1)
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/RequestFilterCallbacksImpl.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/RequestFilterCallbacksImpl.kt
@@ -1,0 +1,15 @@
+package io.envoyproxy.envoymobile
+
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterCallbacks
+
+/**
+ * Envoy implementation of `RequestFilterCallbacks`.
+ */
+internal class RequestFilterCallbacksImpl constructor(
+  internal val callbacks: EnvoyHTTPFilterCallbacks
+) : RequestFilterCallbacks {
+
+  override fun resumeRequest() {
+    callbacks.resumeIteration();
+  }
+}

--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/RequestFilterCallbacksImpl.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/RequestFilterCallbacksImpl.kt
@@ -10,6 +10,6 @@ internal class RequestFilterCallbacksImpl constructor(
 ) : RequestFilterCallbacks {
 
   override fun resumeRequest() {
-    callbacks.resumeIteration();
+    callbacks.resumeIteration()
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/ResponseFilterCallbacksImpl.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/ResponseFilterCallbacksImpl.kt
@@ -1,0 +1,15 @@
+package io.envoyproxy.envoymobile
+
+import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterCallbacks
+
+/**
+ * Envoy implementation of `ResponseFilterCallbacks`.
+ */
+internal class ResponseFilterCallbacksImpl constructor(
+  internal val callbacks: EnvoyHTTPFilterCallbacks
+) : ResponseFilterCallbacks {
+
+  override fun resumeResponse() {
+    callbacks.resumeIteration();
+  }
+}

--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/ResponseFilterCallbacksImpl.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/ResponseFilterCallbacksImpl.kt
@@ -10,6 +10,6 @@ internal class ResponseFilterCallbacksImpl constructor(
 ) : ResponseFilterCallbacks {
 
   override fun resumeResponse() {
-    callbacks.resumeIteration();
+    callbacks.resumeIteration()
   }
 }


### PR DESCRIPTION
Description: Adds support for asynchronous filter callbacks to be set and called on Android and Java filters.
Risk Level: Moderate
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>