### PR TITLE
filters: tag set callbacks methods as mutating in swift protocols

### DIFF
--- a/library/swift/src/filters/AsyncRequestFilter.swift
+++ b/library/swift/src/filters/AsyncRequestFilter.swift
@@ -6,7 +6,7 @@ public protocol AsyncRequestFilter: RequestFilter {
   /// use.
   ///
   /// - parameter callbacks: The callbacks for this filter to use to interact with the chain.
-  func setRequestFilterCallbacks(_ callbacks: RequestFilterCallbacks)
+  mutating func setRequestFilterCallbacks(_ callbacks: RequestFilterCallbacks)
 
   /// Invoked explicitly in response to an asynchronous `resumeRequest()` callback when filter
   /// iteration has been stopped. The parameters passed to this invocation will be a snapshot

--- a/library/swift/src/filters/AsyncResponseFilter.swift
+++ b/library/swift/src/filters/AsyncResponseFilter.swift
@@ -6,7 +6,7 @@ public protocol AsyncResponseFilter: ResponseFilter {
   /// use.
   ///
   /// - parameter callbacks: The callbacks for this filter to use to interact with the chain.
-  func setResponseFilterCallbacks(_ callbacks: ResponseFilterCallbacks)
+  mutating func setResponseFilterCallbacks(_ callbacks: ResponseFilterCallbacks)
 
   /// Invoked explicitly in response to an asynchronous `resumeResponse()` callback when filter
   /// iteration has been stopped. The parameters passed to this invocation will be a snapshot

--- a/library/swift/src/filters/Filter.swift
+++ b/library/swift/src/filters/Filter.swift
@@ -106,7 +106,7 @@ extension EnvoyHTTPFilter {
       }
     }
 
-    if let asyncRequestFilter = filter as? AsyncRequestFilter {
+    if var asyncRequestFilter = filter as? AsyncRequestFilter {
       self.setRequestFilterCallbacks = { envoyCallbacks in
         asyncRequestFilter.setRequestFilterCallbacks(
           RequestFilterCallbacksImpl(callbacks: envoyCallbacks)
@@ -131,7 +131,7 @@ extension EnvoyHTTPFilter {
       }
     }
 
-    if let asyncResponseFilter = filter as? AsyncResponseFilter {
+    if var asyncResponseFilter = filter as? AsyncResponseFilter {
       self.setResponseFilterCallbacks = { envoyCallbacks in
         asyncResponseFilter.setResponseFilterCallbacks(
           ResponseFilterCallbacksImpl(callbacks: envoyCallbacks)


### PR DESCRIPTION
Description: This allows structs to implement to protocol and store callbacks in an instance variable (as well as classes, which ignore it).
Risk Level: Low - doesn't break class-based implementations.
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
