### PR TITLE
filters: fix weak pointer capture for filter callbacks

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -68,22 +68,31 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
   ASSERT(platform_filter_.instance_context,
          fmt::format("init_filter unsuccessful for {}", filter_name_));
   iteration_state_ = IterationState::Ongoing;
+}
+
+void PlatformBridgeFilter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) {
+  decoder_callbacks_ = &callbacks;
 
   if (platform_filter_.set_request_callbacks) {
     platform_request_callbacks_.resume_iteration = envoy_filter_callback_resume_decoding;
     platform_request_callbacks_.release_callbacks = envoy_filter_release_callbacks;
     // We use a weak_ptr wrapper for the filter to ensure presence before dispatching callbacks.
     platform_request_callbacks_.callback_context =
-        new PlatformBridgeFilterWeakPtr{weak_from_this()};
+        new PlatformBridgeFilterWeakPtr{shared_from_this()};
     platform_filter_.set_request_callbacks(platform_request_callbacks_,
                                            platform_filter_.instance_context);
   }
+}
+
+void PlatformBridgeFilter::setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) {
+  encoder_callbacks_ = &callbacks;
 
   if (platform_filter_.set_response_callbacks) {
     platform_response_callbacks_.resume_iteration = envoy_filter_callback_resume_encoding;
     platform_response_callbacks_.release_callbacks = envoy_filter_release_callbacks;
+    // We use a weak_ptr wrapper for the filter to ensure presence before dispatching callbacks.
     platform_response_callbacks_.callback_context =
-        new PlatformBridgeFilterWeakPtr{weak_from_this()};
+        new PlatformBridgeFilterWeakPtr{shared_from_this()};
     platform_filter_.set_response_callbacks(platform_response_callbacks_,
                                             platform_filter_.instance_context);
   }

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -70,7 +70,8 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
   iteration_state_ = IterationState::Ongoing;
 }
 
-void PlatformBridgeFilter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) {
+void PlatformBridgeFilter::setDecoderFilterCallbacks(
+    Http::StreamDecoderFilterCallbacks& callbacks) {
   decoder_callbacks_ = &callbacks;
 
   if (platform_filter_.set_request_callbacks) {
@@ -84,7 +85,8 @@ void PlatformBridgeFilter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCa
   }
 }
 
-void PlatformBridgeFilter::setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) {
+void PlatformBridgeFilter::setEncoderFilterCallbacks(
+    Http::StreamEncoderFilterCallbacks& callbacks) {
   encoder_callbacks_ = &callbacks;
 
   if (platform_filter_.set_response_callbacks) {

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -63,12 +63,14 @@ public:
   void onDestroy() override;
 
   // StreamDecoderFilter
+  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override;
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
                                           bool end_stream) override;
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
   Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap& trailers) override;
 
   // StreamEncoderFilter
+  void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) override;
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
                                           bool end_stream) override;
   Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;


### PR DESCRIPTION
Description: This change moves platform filter callback setup from the PlatformBridgeFilter constructor into its own callback setup path. It's not possible to use shared/weak_from_this in the constructor because the shared pointer state doesn't exist yet.
Risk Level: Low
Testing: Local

Signed-off-by: Mike Schore <mike.schore@gmail.com>