### PR TITLE
filters: fix objc null checks to account for collections

### DIFF
--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -3,7 +3,7 @@
 #import "library/common/types/c_types.h"
 
 static inline envoy_data toNativeData(NSData *data) {
-  if (data == nil || data == (id)[NSNull null]) {
+  if (data == nil || [data isEqual:[NSNull null]]) {
     return envoy_nodata;
   }
 
@@ -14,7 +14,7 @@ static inline envoy_data toNativeData(NSData *data) {
 }
 
 static inline envoy_data *toNativeDataPtr(NSData *data) {
-  if (data == nil || data == (id)[NSNull null]) {
+  if (data == nil || [data isEqual:[NSNull null]]) {
     return NULL;
   }
 
@@ -32,7 +32,7 @@ static inline envoy_data toManagedNativeString(NSString *s) {
 }
 
 static inline envoy_headers toNativeHeaders(EnvoyHeaders *headers) {
-  if (headers == nil || headers == (id)[NSNull null]) {
+  if (headers == nil || [headers isEqual:[NSNull null]]) {
     return envoy_noheaders;
   }
 
@@ -56,7 +56,7 @@ static inline envoy_headers toNativeHeaders(EnvoyHeaders *headers) {
 }
 
 static inline envoy_headers *toNativeHeadersPtr(EnvoyHeaders *headers) {
-  if (headers == nil || headers == (id)[NSNull null]) {
+  if (headers == nil || [headers isEqual:[NSNull null]]) {
     return NULL;
   }
 

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -3,7 +3,7 @@
 #import "library/common/types/c_types.h"
 
 static inline envoy_data toNativeData(NSData *data) {
-  if (data == nil) {
+  if (data == nil || data == (id)[NSNull null]) {
     return envoy_nodata;
   }
 
@@ -14,7 +14,7 @@ static inline envoy_data toNativeData(NSData *data) {
 }
 
 static inline envoy_data *toNativeDataPtr(NSData *data) {
-  if (data == nil) {
+  if (data == nil || data == (id)[NSNull null]) {
     return NULL;
   }
 
@@ -32,7 +32,7 @@ static inline envoy_data toManagedNativeString(NSString *s) {
 }
 
 static inline envoy_headers toNativeHeaders(EnvoyHeaders *headers) {
-  if (headers == nil) {
+  if (headers == nil || headers == (id)[NSNull null]) {
     return envoy_noheaders;
   }
 
@@ -56,7 +56,7 @@ static inline envoy_headers toNativeHeaders(EnvoyHeaders *headers) {
 }
 
 static inline envoy_headers *toNativeHeadersPtr(EnvoyHeaders *headers) {
-  if (headers == nil) {
+  if (headers == nil || headers == (id)[NSNull null]) {
     return NULL;
   }
 


### PR DESCRIPTION
Description: Objective-C collections that don't allow nil use NSNull as a sentinel for missing values. Because these mappers may be used on values that come from collections, this fixes their null checks to be sensitive to NSNull as well as nil.
Risk Level: Low
Testing: Local

Signed-off-by: Mike Schore <mike.schore@gmail.com>
