### PR TITLE
filters: fix some missing JNI wiring

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -265,8 +265,9 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
   envoy_headers* pending_headers = nullptr;
+  // Avoid out-of-bounds access to array when checking for optional pending entities.
   if (size == 3) {
-    jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
+    jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
     pending_headers = to_native_headers_ptr(env, j_headers);
     env->DeleteLocalRef(j_headers);
   }
@@ -294,8 +295,9 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
   envoy_headers* pending_headers = nullptr;
+  // Avoid out-of-bounds access to array when checking for optional pending entities.
   if (size == 3) {
-    jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
+    jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
     pending_headers = to_native_headers_ptr(env, j_headers);
     env->DeleteLocalRef(j_headers);
   }
@@ -356,6 +358,7 @@ static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_he
 
   envoy_headers* pending_headers = nullptr;
   envoy_data* pending_data = nullptr;
+  // Avoid out-of-bounds access to array when checking for optional pending entities.
   if (size == 4) {
     jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
     pending_headers = to_native_headers_ptr(env, j_headers);
@@ -391,6 +394,7 @@ static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_h
 
   envoy_headers* pending_headers = nullptr;
   envoy_data* pending_data = nullptr;
+  // Avoid out-of-bounds access to array when checking for optional pending entities.
   if (size == 4) {
     jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
     pending_headers = to_native_headers_ptr(env, j_headers);

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -259,9 +259,17 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onRequestData", data, end_stream, const_cast<void*>(context)));
+  jsize size = env->GetArrayLength(result);
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
+
+  envoy_headers* pending_headers = nullptr;
+  if (size == 3) {
+    jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
+    pending_headers = to_native_headers_ptr(env, j_headers);
+    env->DeleteLocalRef(j_headers);
+  }
 
   int unboxed_status = unbox_integer(env, status);
   envoy_data native_data = buffer_to_native_data(env, j_data);
@@ -271,7 +279,8 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   env->DeleteLocalRef(j_data);
 
   return (envoy_filter_data_status){/*status*/ unboxed_status,
-                                    /*data*/ native_data};
+                                    /*data*/ native_data,
+                                    /*pending_headers*/ pending_headers};
 }
 
 static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data, bool end_stream,
@@ -279,9 +288,17 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onResponseData", data, end_stream, const_cast<void*>(context)));
+  jsize size = env->GetArrayLength(result);
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
+
+  envoy_headers* pending_headers = nullptr;
+  if (size == 3) {
+    jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
+    pending_headers = to_native_headers_ptr(env, j_headers);
+    env->DeleteLocalRef(j_headers);
+  }
 
   int unboxed_status = unbox_integer(env, status);
   envoy_data native_data = buffer_to_native_data(env, j_data);
@@ -291,7 +308,8 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   env->DeleteLocalRef(j_data);
 
   return (envoy_filter_data_status){/*status*/ unboxed_status,
-                                    /*data*/ native_data};
+                                    /*data*/ native_data,
+                                    /*pending_headers*/ pending_headers};
 }
 
 static void* jvm_on_metadata(envoy_headers metadata, void* context) {
@@ -328,19 +346,34 @@ static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_he
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onRequestTrailers", trailers, const_cast<void*>(context)));
+  jsize size = env->GetArrayLength(result);
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
   int unboxed_status = unbox_integer(env, status);
-  envoy_headers native_headers = to_native_headers(env, j_trailers);
+  envoy_headers native_trailers = to_native_headers(env, j_trailers);
+
+  envoy_headers* pending_headers = nullptr;
+  envoy_data* pending_data = nullptr;
+  if (size == 4) {
+    jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
+    pending_headers = to_native_headers_ptr(env, j_headers);
+    env->DeleteLocalRef(j_headers);
+
+    jobject j_data = static_cast<jobject>(env->GetObjectArrayElement(result, 3));
+    pending_data = buffer_to_native_data_ptr(env, j_data);
+    env->DeleteLocalRef(j_data);
+  }
 
   env->DeleteLocalRef(result);
   env->DeleteLocalRef(status);
   env->DeleteLocalRef(j_trailers);
 
   return (envoy_filter_trailers_status){/*status*/ unboxed_status,
-                                        /*trailers*/ native_headers};
+                                        /*trailers*/ native_trailers,
+                                        /*pending_headers*/ pending_headers,
+                                        /*pending_data*/ pending_data};
 }
 
 static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_headers trailers,
@@ -348,19 +381,34 @@ static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_h
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onResponseTrailers", trailers, const_cast<void*>(context)));
+  jsize size = env->GetArrayLength(result);
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
   int unboxed_status = unbox_integer(env, status);
-  envoy_headers native_headers = to_native_headers(env, j_trailers);
+  envoy_headers native_trailers = to_native_headers(env, j_trailers);
+
+  envoy_headers* pending_headers = nullptr;
+  envoy_data* pending_data = nullptr;
+  if (size == 4) {
+    jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
+    pending_headers = to_native_headers_ptr(env, j_headers);
+    env->DeleteLocalRef(j_headers);
+
+    jobject j_data = static_cast<jobject>(env->GetObjectArrayElement(result, 3));
+    pending_data = buffer_to_native_data_ptr(env, j_data);
+    env->DeleteLocalRef(j_data);
+  }
 
   env->DeleteLocalRef(result);
   env->DeleteLocalRef(status);
   env->DeleteLocalRef(j_trailers);
 
   return (envoy_filter_trailers_status){/*status*/ unboxed_status,
-                                        /*trailers*/ native_headers};
+                                        /*trailers*/ native_trailers,
+                                        /*pending_headers*/ pending_headers,
+                                        /*pending_data*/ pending_data};
 }
 
 static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks callbacks,

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -263,6 +263,9 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
+  int unboxed_status = unbox_integer(env, status);
+  envoy_data native_data = buffer_to_native_data(env, j_data);
+
   envoy_headers* pending_headers = nullptr;
   // Avoid out-of-bounds access to array when checking for optional pending entities.
   if (unboxed_status == kEnvoyFilterDataStatusResumeIteration) {
@@ -270,9 +273,6 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
     pending_headers = to_native_headers_ptr(env, j_headers);
     env->DeleteLocalRef(j_headers);
   }
-
-  int unboxed_status = unbox_integer(env, status);
-  envoy_data native_data = buffer_to_native_data(env, j_data);
 
   env->DeleteLocalRef(result);
   env->DeleteLocalRef(status);
@@ -292,6 +292,9 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
+  int unboxed_status = unbox_integer(env, status);
+  envoy_data native_data = buffer_to_native_data(env, j_data);
+
   envoy_headers* pending_headers = nullptr;
   // Avoid out-of-bounds access to array when checking for optional pending entities.
   if (unboxed_status == kEnvoyFilterDataStatusResumeIteration) {
@@ -299,9 +302,6 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
     pending_headers = to_native_headers_ptr(env, j_headers);
     env->DeleteLocalRef(j_headers);
   }
-
-  int unboxed_status = unbox_integer(env, status);
-  envoy_data native_data = buffer_to_native_data(env, j_data);
 
   env->DeleteLocalRef(result);
   env->DeleteLocalRef(status);

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -259,14 +259,13 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onRequestData", data, end_stream, const_cast<void*>(context)));
-  jsize size = env->GetArrayLength(result);
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
   envoy_headers* pending_headers = nullptr;
   // Avoid out-of-bounds access to array when checking for optional pending entities.
-  if (size == 3) {
+  if (unboxed_status == kEnvoyFilterDataStatusResumeIteration) {
     jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
     pending_headers = to_native_headers_ptr(env, j_headers);
     env->DeleteLocalRef(j_headers);
@@ -289,14 +288,13 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onResponseData", data, end_stream, const_cast<void*>(context)));
-  jsize size = env->GetArrayLength(result);
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
   envoy_headers* pending_headers = nullptr;
   // Avoid out-of-bounds access to array when checking for optional pending entities.
-  if (size == 3) {
+  if (unboxed_status == kEnvoyFilterDataStatusResumeIteration) {
     jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
     pending_headers = to_native_headers_ptr(env, j_headers);
     env->DeleteLocalRef(j_headers);
@@ -348,7 +346,6 @@ static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_he
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onRequestTrailers", trailers, const_cast<void*>(context)));
-  jsize size = env->GetArrayLength(result);
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
@@ -359,7 +356,7 @@ static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_he
   envoy_headers* pending_headers = nullptr;
   envoy_data* pending_data = nullptr;
   // Avoid out-of-bounds access to array when checking for optional pending entities.
-  if (size == 4) {
+  if (unboxed_status == kEnvoyFilterTrailersStatusResumeIteration) {
     jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
     pending_headers = to_native_headers_ptr(env, j_headers);
     env->DeleteLocalRef(j_headers);
@@ -384,7 +381,6 @@ static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_h
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onResponseTrailers", trailers, const_cast<void*>(context)));
-  jsize size = env->GetArrayLength(result);
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
@@ -395,7 +391,7 @@ static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_h
   envoy_headers* pending_headers = nullptr;
   envoy_data* pending_data = nullptr;
   // Avoid out-of-bounds access to array when checking for optional pending entities.
-  if (size == 4) {
+  if (unboxed_status == kEnvoyFilterTrailersStatusResumeIteration) {
     jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 2));
     pending_headers = to_native_headers_ptr(env, j_headers);
     env->DeleteLocalRef(j_headers);


### PR DESCRIPTION
Description: A miss at the JNI layer was causing optional pending entities attached to resume iteration return statuses to be dropped. Upcoming additional coverage for this will include new example app filters and integration tests.
Risk Level: Low
Testing: Local

Signed-off-by: Mike Schore <mike.schore@gmail.com>