### PR TITLE
Revert "stats: update method names of counter"

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -104,7 +104,7 @@ Engine::~Engine() {
   main_thread_.join();
 }
 
-envoy_status_t Engine::recordCounterInc(const std::string& elements, uint64_t count) {
+envoy_status_t Engine::recordCounter(const std::string& elements, uint64_t count) {
   if (server_ && client_scope_) {
     std::string name = Stats::Utility::sanitizeStatsName(elements);
     server_->dispatcher().post([this, name, count]() -> void {

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -40,7 +40,7 @@ public:
    * @param elements, joined elements of the timeseries.
    * @param count, amount to add to the counter.
    */
-  envoy_status_t recordCounterInc(const std::string& elements, uint64_t count);
+  envoy_status_t recordCounter(const std::string& elements, uint64_t count);
 
   /**
    * Set a gauge of a given string of elements with the given value.

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -70,7 +70,7 @@ envoy_status_t record_counter(envoy_engine_t, const char* elements, uint64_t cou
   // TODO: use specific engine once multiple engine support is in place.
   // https://github.com/lyft/envoy-mobile/issues/332
   if (auto e = engine_.lock()) {
-    return e->recordCounterInc(std::string(elements), count);
+    return e->recordCounter(std::string(elements), count);
   }
   return ENVOY_FAILURE;
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -40,8 +40,8 @@ public class AndroidEngineImpl implements EnvoyEngine {
   }
 
   @Override
-  public int recordCounterInc(String elements, int count) {
-    return envoyEngine.recordCounterInc(elements, count);
+  public int recordCounter(String elements, int count) {
+    return envoyEngine.recordCounter(elements, count);
   }
 
   @Override

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -42,7 +42,7 @@ public interface EnvoyEngine {
    * @param count    Amount to add to the counter.
    * @return A status indicating if the action was successful.
    */
-  int recordCounterInc(String elements, int count);
+  int recordCounter(String elements, int count);
 
   /**
    * Set a gauge of a given string of elements with the given value.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -82,8 +82,8 @@ public class EnvoyEngineImpl implements EnvoyEngine {
    * @return A status indicating if the action was successful.
    */
   @Override
-  public int recordCounterInc(String elements, int count) {
-    return JniLibrary.recordCounterInc(engineHandle, elements, count);
+  public int recordCounter(String elements, int count) {
+    return JniLibrary.recordCounter(engineHandle, elements, count);
   }
 
   /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -161,7 +161,7 @@ class JniLibrary {
    * @param count Amount to add to the counter.
    * @return A status indicating if the action was successful.
    */
-  protected static native int recordCounterInc(long engine, String elements, int count);
+  protected static native int recordCounter(long engine, String elements, int count);
 
   /**
    * Set a gauge of a given string of elements with the given value.

--- a/library/kotlin/src/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -16,7 +16,7 @@ internal class MockEnvoyEngine : EnvoyEngine {
 
   override fun startStream(callbacks: EnvoyHTTPCallbacks?): EnvoyHTTPStream = MockEnvoyHTTPStream(callbacks!!)
 
-  override fun recordCounterInc(elements: String, count: Int): Int = 0
+  override fun recordCounter(elements: String, count: Int): Int = 0
 
   override fun recordGaugeSet(elements: String, value: Int): Int = 0
 

--- a/library/kotlin/src/io/envoyproxy/envoymobile/stats/CounterImpl.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/stats/CounterImpl.kt
@@ -17,7 +17,7 @@ internal class CounterImpl : Counter {
 
   // TODO: potentially raise error to platform if the operation is not successful.
   override fun increment(count: Int) {
-    envoyEngine.get()?.recordCounterInc(
+    envoyEngine.get()?.recordCounter(
       elements.joinToString(separator = ".") { it.element }, count
     )
   }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/StatsClientImplTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/StatsClientImplTest.kt
@@ -17,7 +17,7 @@ class StatsClientImplTest {
     counter.increment()
     val elementsCaptor = ArgumentCaptor.forClass(String::class.java)
     val countCaptor = ArgumentCaptor.forClass(Int::class.java)
-    verify(envoyEngine).recordCounterInc(elementsCaptor.capture(), countCaptor.capture())
+    verify(envoyEngine).recordCounter(elementsCaptor.capture(), countCaptor.capture())
     assertThat(elementsCaptor.getValue()).isEqualTo("test.stat")
     assertThat(countCaptor.getValue()).isEqualTo(1)
   }
@@ -29,7 +29,7 @@ class StatsClientImplTest {
     counter.increment(5)
     val elementsCaptor = ArgumentCaptor.forClass(String::class.java)
     val countCaptor = ArgumentCaptor.forClass(Int::class.java)
-    verify(envoyEngine).recordCounterInc(elementsCaptor.capture(), countCaptor.capture())
+    verify(envoyEngine).recordCounter(elementsCaptor.capture(), countCaptor.capture())
     assertThat(elementsCaptor.getValue()).isEqualTo("test.stat")
     assertThat(countCaptor.getValue()).isEqualTo(5)
   }

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -312,7 +312,7 @@ extern const int kEnvoyFailure;
  @param count Amount to add to the counter.
  @return A status indicating if the action was successful.
  */
-- (int)recordCounterInc:(NSString *)elements count:(NSUInteger)count;
+- (int)recordCounter:(NSString *)elements count:(NSUInteger)count;
 
 /**
  Set a gauge of a given string of elements with the given value.

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -302,7 +302,7 @@ static void ios_http_filter_release(const void *context) {
                                            callbacks:callbacks];
 }
 
-- (int)recordCounterInc:(NSString *)elements count:(NSUInteger)count {
+- (int)recordCounter:(NSString *)elements count:(NSUInteger)count {
   return record_counter(_engineHandle, elements.UTF8String, count);
 }
 

--- a/library/swift/src/mocks/MockEnvoyEngine.swift
+++ b/library/swift/src/mocks/MockEnvoyEngine.swift
@@ -7,7 +7,7 @@ final class MockEnvoyEngine: NSObject {
   static var onRunWithConfig: ((_ config: EnvoyConfiguration, _ logLevel: String?) -> Void)?
   /// Closure called when `run(withConfigYAML:)` is called.
   static var onRunWithYAML: ((_ configYAML: String, _ logLevel: String?) -> Void)?
-  /// Closure called when `recordCounterInc(_:count:)` is called.
+  /// Closure called when `recordCounter(_:count:)` is called.
   static var onRecordCounter: ((_ elements: String, _ count: UInt) -> Void)?
   /// Closure called when `recordGaugeSet(_:value:)` is called.
   static var onRecordGaugeSet: ((_ elements: String, _ value: UInt) -> Void)?
@@ -36,7 +36,7 @@ extension MockEnvoyEngine: EnvoyEngine {
     return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks)
   }
 
-  func recordCounterInc(_ elements: String, count: UInt) -> Int32 {
+  func recordCounter(_ elements: String, count: UInt) -> Int32 {
     MockEnvoyEngine.onRecordCounter?(elements, count)
     return kEnvoySuccess
   }

--- a/library/swift/src/stats/CounterImpl.swift
+++ b/library/swift/src/stats/CounterImpl.swift
@@ -20,6 +20,6 @@ class CounterImpl: NSObject, Counter {
       return
     }
 
-    engine.recordCounterInc(self.series, count: numericCast(count))
+    engine.recordCounter(self.series, count: numericCast(count))
   }
 }


### PR DESCRIPTION
Reverts lyft/envoy-mobile#1134

lyft/envoy-mobile#1134 introduced a bug where the jni method for `recordCounterInc` is mis-declared.

Signed-off-by: Jingwei Hao <jingwei.hao@gmail.com>