### PR TITLE
filters: fix ordering of optional entities in swift statuses

### DIFF
--- a/library/swift/src/filters/Filter.swift
+++ b/library/swift/src/filters/Filter.swift
@@ -40,7 +40,7 @@ extension EnvoyHTTPFilter {
         case .stopIterationNoBuffer:
           return [kEnvoyFilterDataStatusStopIterationNoBuffer, data]
         case .resumeIteration(let headers, let data):
-          return [kEnvoyFilterDataStatusResumeIteration, headers?.headers as Any, data]
+          return [kEnvoyFilterDataStatusResumeIteration, data, headers?.headers as Any]
         }
       }
 
@@ -54,9 +54,9 @@ extension EnvoyHTTPFilter {
         case .resumeIteration(let headers, let data, let trailers):
           return [
             kEnvoyFilterTrailersStatusResumeIteration,
+            trailers.headers,
             headers?.headers as Any,
             data as Any,
-            trailers.headers,
           ]
         }
       }
@@ -84,7 +84,7 @@ extension EnvoyHTTPFilter {
         case .stopIterationNoBuffer:
           return [kEnvoyFilterDataStatusStopIterationNoBuffer, data]
         case .resumeIteration(let headers, let data):
-          return [kEnvoyFilterDataStatusResumeIteration, headers?.headers as Any, data]
+          return [kEnvoyFilterDataStatusResumeIteration, data, headers?.headers as Any]
         }
       }
 
@@ -98,9 +98,9 @@ extension EnvoyHTTPFilter {
         case .resumeIteration(let headers, let data, let trailers):
           return [
             kEnvoyFilterTrailersStatusResumeIteration,
+            trailers.headers,
             headers?.headers as Any,
             data as Any,
-            trailers.headers,
           ]
         }
       }


### PR DESCRIPTION
Description: The public and private representations of platform filters' compound statuses differ in ordering. In the public case, the ordering aligns with our chosen API, whereas in the private case, it's dictated by constraints in the type representation. This change fixes a bug which arose out of that misalignment. Note that fully-bridged types would avoid the potential for this sort of mapping bug.
Risk Level: Low
Testing: Pending integration

Signed-off-by: Mike Schore <mike.schore@gmail.com>