### PR TITLE
filters: fix edge case where on-data receives Envoy's internal buffer

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -54,7 +54,7 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
   // static_context will contain the necessary platform-specific mechanism to produce a filter
   // instance. instance_context will initially be null, but after initialization, set to the
   // context needed for actual filter invocations.
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::PlatformBridgeFilter", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::PlatformBridgeFilter", filter_name_);
 
   // If init_filter is missing, zero out the rest of the struct for safety.
   if (platform_filter_.init_filter == nullptr) {
@@ -65,7 +65,7 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
 
   // Set the instance_context to the result of the initialization call. Cleanup will ultimately
   // occur during in the onDestroy() invocation below.
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->init_filter", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})->init_filter", filter_name_);
   platform_filter_.instance_context = platform_filter_.init_filter(platform_filter_.static_context);
   ASSERT(platform_filter_.instance_context,
          fmt::format("PlatformBridgeFilter({}): init_filter unsuccessful", filter_name_));
@@ -74,7 +74,7 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
 
 void PlatformBridgeFilter::setDecoderFilterCallbacks(
     Http::StreamDecoderFilterCallbacks& callbacks) {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::setDecoderCallbacks", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::setDecoderCallbacks", filter_name_);
   decoder_callbacks_ = &callbacks;
 
   if (platform_filter_.set_request_callbacks) {
@@ -83,7 +83,7 @@ void PlatformBridgeFilter::setDecoderFilterCallbacks(
     // We use a weak_ptr wrapper for the filter to ensure presence before dispatching callbacks.
     platform_request_callbacks_.callback_context =
         new PlatformBridgeFilterWeakPtr{shared_from_this()};
-    ENVOY_LOG(trace, "PlatformBridgeFilter({})->set_request_callbacks", filter_name_);
+    ENVOY_LOG(debug, "PlatformBridgeFilter({})->set_request_callbacks", filter_name_);
     platform_filter_.set_request_callbacks(platform_request_callbacks_,
                                            platform_filter_.instance_context);
   }
@@ -91,7 +91,7 @@ void PlatformBridgeFilter::setDecoderFilterCallbacks(
 
 void PlatformBridgeFilter::setEncoderFilterCallbacks(
     Http::StreamEncoderFilterCallbacks& callbacks) {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::setEncoderCallbacks", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::setEncoderCallbacks", filter_name_);
   encoder_callbacks_ = &callbacks;
 
   if (platform_filter_.set_response_callbacks) {
@@ -100,14 +100,14 @@ void PlatformBridgeFilter::setEncoderFilterCallbacks(
     // We use a weak_ptr wrapper for the filter to ensure presence before dispatching callbacks.
     platform_response_callbacks_.callback_context =
         new PlatformBridgeFilterWeakPtr{shared_from_this()};
-    ENVOY_LOG(trace, "PlatformBridgeFilter({})->set_response_callbacks", filter_name_);
+    ENVOY_LOG(debug, "PlatformBridgeFilter({})->set_response_callbacks", filter_name_);
     platform_filter_.set_response_callbacks(platform_response_callbacks_,
                                             platform_filter_.instance_context);
   }
 }
 
 void PlatformBridgeFilter::onDestroy() {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::onDestroy", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::onDestroy", filter_name_);
   // Allow nullptr as no-op only if nothing was initialized.
   if (platform_filter_.release_filter == nullptr) {
     ASSERT(!platform_filter_.instance_context,
@@ -115,7 +115,7 @@ void PlatformBridgeFilter::onDestroy() {
     return;
   }
 
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->release_filter", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})->release_filter", filter_name_);
   platform_filter_.release_filter(platform_filter_.instance_context);
   platform_filter_.instance_context = nullptr;
 }
@@ -138,7 +138,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::onHeaders(Http::HeaderMap& heade
   }
 
   envoy_headers in_headers = Http::Utility::toBridgeHeaders(headers);
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_headers", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_*_headers", filter_name_);
   envoy_filter_headers_status result =
       on_headers(in_headers, end_stream, platform_filter_.instance_context);
 
@@ -169,7 +169,7 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
 
   envoy_data in_data;
   bool already_buffering = iteration_state_ == IterationState::Stopped && internal_buffer &&
-                           internal_buffer->length() > 0;
+                           &data != internal_buffer;
 
   if (already_buffering) {
     // Pre-emptively buffer data to present aggregate to platform.
@@ -179,7 +179,7 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
     in_data = Buffer::Utility::copyToBridgeData(data);
   }
 
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_data", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_*_data", filter_name_);
   envoy_filter_data_status result = on_data(in_data, end_stream, platform_filter_.instance_context);
 
   switch (result.status) {
@@ -256,7 +256,7 @@ PlatformBridgeFilter::onTrailers(Http::HeaderMap& trailers, Buffer::Instance* in
   }
 
   envoy_headers in_trailers = Http::Utility::toBridgeHeaders(trailers);
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_trailers", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_*_trailers", filter_name_);
   envoy_filter_trailers_status result = on_trailers(in_trailers, platform_filter_.instance_context);
 
   switch (result.status) {
@@ -305,7 +305,7 @@ PlatformBridgeFilter::onTrailers(Http::HeaderMap& trailers, Buffer::Instance* in
 
 Http::FilterHeadersStatus PlatformBridgeFilter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                               bool end_stream) {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::decodeHeaders", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::decodeHeaders", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   auto status = onHeaders(headers, end_stream, platform_filter_.on_request_headers);
@@ -318,7 +318,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::decodeHeaders(Http::RequestHeade
 
 Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
                                                               bool end_stream) {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::encodeHeaders", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::encodeHeaders", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   auto status = onHeaders(headers, end_stream, platform_filter_.on_response_headers);
@@ -330,7 +330,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
 }
 
 Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, bool end_stream) {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::decodeData", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::decodeData", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
@@ -347,7 +347,7 @@ Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, 
 }
 
 Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, bool end_stream) {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::encodeData", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::encodeData", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
@@ -364,7 +364,7 @@ Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, 
 }
 
 Http::FilterTrailersStatus PlatformBridgeFilter::decodeTrailers(Http::RequestTrailerMap& trailers) {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::decodeTrailers", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::decodeTrailers", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
@@ -385,7 +385,7 @@ Http::FilterTrailersStatus PlatformBridgeFilter::decodeTrailers(Http::RequestTra
 
 Http::FilterTrailersStatus
 PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::encodeTrailers", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::encodeTrailers", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
@@ -405,7 +405,7 @@ PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
 }
 
 void PlatformBridgeFilter::resumeDecoding() {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::resumeDecoding", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::resumeDecoding", filter_name_);
 
   auto weak_self = weak_from_this();
   // TODO(goaway): There's a potential shutdown race here, due to the fact that the shared
@@ -423,7 +423,7 @@ void PlatformBridgeFilter::resumeDecoding() {
 }
 
 void PlatformBridgeFilter::onResumeDecoding() {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::onResumeDecoding", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::onResumeDecoding", filter_name_);
 
   if (iteration_state_ == IterationState::Ongoing) {
     return;
@@ -456,7 +456,7 @@ void PlatformBridgeFilter::onResumeDecoding() {
     pending_trailers = &bridged_trailers;
   }
 
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_resume_request", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_resume_request", filter_name_);
   envoy_filter_resume_status result =
       platform_filter_.on_resume_request(pending_headers, pending_data, pending_trailers,
                                          request_complete_, platform_filter_.instance_context);
@@ -497,7 +497,7 @@ void PlatformBridgeFilter::onResumeDecoding() {
 }
 
 void PlatformBridgeFilter::resumeEncoding() {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::resumeEncoding", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::resumeEncoding", filter_name_);
 
   auto weak_self = weak_from_this();
   dispatcher_.post([weak_self]() -> void {
@@ -508,7 +508,7 @@ void PlatformBridgeFilter::resumeEncoding() {
 }
 
 void PlatformBridgeFilter::onResumeEncoding() {
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})::onResumeEncoding", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})::onResumeEncoding", filter_name_);
 
   if (iteration_state_ == IterationState::Ongoing) {
     return;
@@ -541,7 +541,7 @@ void PlatformBridgeFilter::onResumeEncoding() {
     pending_trailers = &bridged_trailers;
   }
 
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_resume_response", filter_name_);
+  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_resume_response", filter_name_);
   envoy_filter_resume_status result =
       platform_filter_.on_resume_response(pending_headers, pending_data, pending_trailers,
                                           response_complete_, platform_filter_.instance_context);

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -168,11 +168,12 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
   }
 
   envoy_data in_data;
-  bool already_buffering = iteration_state_ == IterationState::Stopped && internal_buffer &&
-                           &data != internal_buffer;
 
-  if (already_buffering) {
-    // Pre-emptively buffer data to present aggregate to platform.
+  // Decide whether to preemptively buffer data to present aggregate to platform.
+  bool prebuffer_data = iteration_state_ == IterationState::Stopped && internal_buffer &&
+                        &data != internal_buffer && internal_buffer->length() > 0;
+
+  if (prebuffer_data) {
     internal_buffer->move(data);
     in_data = Buffer::Utility::copyToBridgeData(*internal_buffer);
   } else {
@@ -191,7 +192,7 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
     return Http::FilterDataStatus::Continue;
 
   case kEnvoyFilterDataStatusStopIterationAndBuffer:
-    if (already_buffering) {
+    if (prebuffer_data) {
       // Data will already have been added to the internal buffer (above).
       return Http::FilterDataStatus::StopIterationNoBuffer;
     }

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -58,7 +58,7 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
 
   // If init_filter is missing, zero out the rest of the struct for safety.
   if (platform_filter_.init_filter == nullptr) {
-    ENVOY_LOG(trace, "PlatformBridgeFilter({}): missing initializer", filter_name_);
+    ENVOY_LOG(debug, "PlatformBridgeFilter({}): missing initializer", filter_name_);
     platform_filter_ = {};
     return;
   }

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -54,18 +54,18 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
   // static_context will contain the necessary platform-specific mechanism to produce a filter
   // instance. instance_context will initially be null, but after initialization, set to the
   // context needed for actual filter invocations.
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::PlatformBridgeFilter", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::PlatformBridgeFilter", filter_name_);
 
   // If init_filter is missing, zero out the rest of the struct for safety.
   if (platform_filter_.init_filter == nullptr) {
-    ENVOY_LOG(debug, "PlatformBridgeFilter({}): missing initializer", filter_name_);
+    ENVOY_LOG(trace, "PlatformBridgeFilter({}): missing initializer", filter_name_);
     platform_filter_ = {};
     return;
   }
 
   // Set the instance_context to the result of the initialization call. Cleanup will ultimately
   // occur during in the onDestroy() invocation below.
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})->init_filter", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->init_filter", filter_name_);
   platform_filter_.instance_context = platform_filter_.init_filter(platform_filter_.static_context);
   ASSERT(platform_filter_.instance_context,
          fmt::format("PlatformBridgeFilter({}): init_filter unsuccessful", filter_name_));
@@ -74,7 +74,7 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
 
 void PlatformBridgeFilter::setDecoderFilterCallbacks(
     Http::StreamDecoderFilterCallbacks& callbacks) {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::setDecoderCallbacks", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::setDecoderCallbacks", filter_name_);
   decoder_callbacks_ = &callbacks;
 
   if (platform_filter_.set_request_callbacks) {
@@ -83,7 +83,7 @@ void PlatformBridgeFilter::setDecoderFilterCallbacks(
     // We use a weak_ptr wrapper for the filter to ensure presence before dispatching callbacks.
     platform_request_callbacks_.callback_context =
         new PlatformBridgeFilterWeakPtr{shared_from_this()};
-    ENVOY_LOG(debug, "PlatformBridgeFilter({})->set_request_callbacks", filter_name_);
+    ENVOY_LOG(trace, "PlatformBridgeFilter({})->set_request_callbacks", filter_name_);
     platform_filter_.set_request_callbacks(platform_request_callbacks_,
                                            platform_filter_.instance_context);
   }
@@ -91,7 +91,7 @@ void PlatformBridgeFilter::setDecoderFilterCallbacks(
 
 void PlatformBridgeFilter::setEncoderFilterCallbacks(
     Http::StreamEncoderFilterCallbacks& callbacks) {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::setEncoderCallbacks", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::setEncoderCallbacks", filter_name_);
   encoder_callbacks_ = &callbacks;
 
   if (platform_filter_.set_response_callbacks) {
@@ -100,14 +100,14 @@ void PlatformBridgeFilter::setEncoderFilterCallbacks(
     // We use a weak_ptr wrapper for the filter to ensure presence before dispatching callbacks.
     platform_response_callbacks_.callback_context =
         new PlatformBridgeFilterWeakPtr{shared_from_this()};
-    ENVOY_LOG(debug, "PlatformBridgeFilter({})->set_response_callbacks", filter_name_);
+    ENVOY_LOG(trace, "PlatformBridgeFilter({})->set_response_callbacks", filter_name_);
     platform_filter_.set_response_callbacks(platform_response_callbacks_,
                                             platform_filter_.instance_context);
   }
 }
 
 void PlatformBridgeFilter::onDestroy() {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::onDestroy", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::onDestroy", filter_name_);
   // Allow nullptr as no-op only if nothing was initialized.
   if (platform_filter_.release_filter == nullptr) {
     ASSERT(!platform_filter_.instance_context,
@@ -115,7 +115,7 @@ void PlatformBridgeFilter::onDestroy() {
     return;
   }
 
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})->release_filter", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->release_filter", filter_name_);
   platform_filter_.release_filter(platform_filter_.instance_context);
   platform_filter_.instance_context = nullptr;
 }
@@ -138,7 +138,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::onHeaders(Http::HeaderMap& heade
   }
 
   envoy_headers in_headers = Http::Utility::toBridgeHeaders(headers);
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_*_headers", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_headers", filter_name_);
   envoy_filter_headers_status result =
       on_headers(in_headers, end_stream, platform_filter_.instance_context);
 
@@ -179,7 +179,7 @@ Http::FilterDataStatus PlatformBridgeFilter::onData(Buffer::Instance& data, bool
     in_data = Buffer::Utility::copyToBridgeData(data);
   }
 
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_*_data", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_data", filter_name_);
   envoy_filter_data_status result = on_data(in_data, end_stream, platform_filter_.instance_context);
 
   switch (result.status) {
@@ -256,7 +256,7 @@ PlatformBridgeFilter::onTrailers(Http::HeaderMap& trailers, Buffer::Instance* in
   }
 
   envoy_headers in_trailers = Http::Utility::toBridgeHeaders(trailers);
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_*_trailers", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_trailers", filter_name_);
   envoy_filter_trailers_status result = on_trailers(in_trailers, platform_filter_.instance_context);
 
   switch (result.status) {
@@ -305,7 +305,7 @@ PlatformBridgeFilter::onTrailers(Http::HeaderMap& trailers, Buffer::Instance* in
 
 Http::FilterHeadersStatus PlatformBridgeFilter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                               bool end_stream) {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::decodeHeaders", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::decodeHeaders", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   auto status = onHeaders(headers, end_stream, platform_filter_.on_request_headers);
@@ -318,7 +318,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::decodeHeaders(Http::RequestHeade
 
 Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
                                                               bool end_stream) {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::encodeHeaders", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::encodeHeaders", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   auto status = onHeaders(headers, end_stream, platform_filter_.on_response_headers);
@@ -330,7 +330,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
 }
 
 Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, bool end_stream) {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::decodeData", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::decodeData", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
@@ -347,7 +347,7 @@ Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, 
 }
 
 Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, bool end_stream) {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::encodeData", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::encodeData", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
@@ -364,7 +364,7 @@ Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, 
 }
 
 Http::FilterTrailersStatus PlatformBridgeFilter::decodeTrailers(Http::RequestTrailerMap& trailers) {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::decodeTrailers", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::decodeTrailers", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
@@ -385,7 +385,7 @@ Http::FilterTrailersStatus PlatformBridgeFilter::decodeTrailers(Http::RequestTra
 
 Http::FilterTrailersStatus
 PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::encodeTrailers", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::encodeTrailers", filter_name_);
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
@@ -405,7 +405,7 @@ PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
 }
 
 void PlatformBridgeFilter::resumeDecoding() {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::resumeDecoding", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::resumeDecoding", filter_name_);
 
   auto weak_self = weak_from_this();
   // TODO(goaway): There's a potential shutdown race here, due to the fact that the shared
@@ -423,7 +423,7 @@ void PlatformBridgeFilter::resumeDecoding() {
 }
 
 void PlatformBridgeFilter::onResumeDecoding() {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::onResumeDecoding", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::onResumeDecoding", filter_name_);
 
   if (iteration_state_ == IterationState::Ongoing) {
     return;
@@ -456,7 +456,7 @@ void PlatformBridgeFilter::onResumeDecoding() {
     pending_trailers = &bridged_trailers;
   }
 
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_resume_request", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_resume_request", filter_name_);
   envoy_filter_resume_status result =
       platform_filter_.on_resume_request(pending_headers, pending_data, pending_trailers,
                                          request_complete_, platform_filter_.instance_context);
@@ -497,7 +497,7 @@ void PlatformBridgeFilter::onResumeDecoding() {
 }
 
 void PlatformBridgeFilter::resumeEncoding() {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::resumeEncoding", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::resumeEncoding", filter_name_);
 
   auto weak_self = weak_from_this();
   dispatcher_.post([weak_self]() -> void {
@@ -508,7 +508,7 @@ void PlatformBridgeFilter::resumeEncoding() {
 }
 
 void PlatformBridgeFilter::onResumeEncoding() {
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})::onResumeEncoding", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})::onResumeEncoding", filter_name_);
 
   if (iteration_state_ == IterationState::Ongoing) {
     return;
@@ -541,7 +541,7 @@ void PlatformBridgeFilter::onResumeEncoding() {
     pending_trailers = &bridged_trailers;
   }
 
-  ENVOY_LOG(debug, "PlatformBridgeFilter({})->on_resume_response", filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_resume_response", filter_name_);
   envoy_filter_resume_status result =
       platform_filter_.on_resume_response(pending_headers, pending_data, pending_trailers,
                                           response_complete_, platform_filter_.instance_context);


### PR DESCRIPTION
Description: In certain cases - for example, when a previous filter in the chain stopped and buffered the request, and a subsequent filter stops iteration as well - the on-data filter invocation receives Envoy's internal buffer directly. This makes sense, since that's where Envoy has buffered all data, but it means that an attempt to preemptively aggregate new data into the buffer should be skipped: it's already there.
Risk Level: Low
Testing: Local and CI (#1157)

Signed-off-by: Mike Schore <mike.schore@gmail.com>
