### PR TITLE
java: show which key is unresolved in config errors

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -19,7 +19,7 @@ public class EnvoyConfiguration {
   public final String appId;
   public final String virtualClusters;
 
-  private static final Pattern KEY_PATTERN = Pattern.compile("\\{\\{ (.+) \\}\\}");
+  private static final Pattern UNRESOLVED_KEY_PATTERN = Pattern.compile("\\{\\{ (.+) \\}\\}");
 
   /**
    * Create a new instance of the configuration.
@@ -84,7 +84,7 @@ public class EnvoyConfiguration {
             .replace("{{ app_id }}", appId)
             .replace("{{ virtual_clusters }}", virtualClusters);
 
-    final Matcher unresolvedKeys = KEY_PATTERN.matcher(resolvedConfiguration);
+    final Matcher unresolvedKeys = UNRESOLVED_KEY_PATTERN.matcher(resolvedConfiguration);
     if (unresolvedKeys.find()) {
       throw new ConfigurationException(unresolvedKeys.group(1));
     }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -19,7 +19,7 @@ public class EnvoyConfiguration {
   public final String appId;
   public final String virtualClusters;
 
-  private static final Pattern KEY_PATTERN = Pattern.compile("{{ (.+) }}");
+  private static final Pattern KEY_PATTERN = Pattern.compile("\\{\\{ (.+) \\}\\}");
 
   /**
    * Create a new instance of the configuration.
@@ -93,7 +93,7 @@ public class EnvoyConfiguration {
 
   static class ConfigurationException extends RuntimeException {
     ConfigurationException(String unresolvedKey) {
-      super(unresolvedKey != null ? "Unresolved template key: " + unresolvedKey : "butts");
+      super("Unresolved template key: " + unresolvedKey);
     }
   }
 }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -1,6 +1,8 @@
 package io.envoyproxy.envoymobile.engine;
 
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;
 
@@ -16,6 +18,8 @@ public class EnvoyConfiguration {
   public final String appVersion;
   public final String appId;
   public final String virtualClusters;
+
+  private static final Pattern KEY_PATTERN = Pattern.compile("{{ (.+) }}");
 
   /**
    * Create a new instance of the configuration.
@@ -80,13 +84,16 @@ public class EnvoyConfiguration {
             .replace("{{ app_id }}", appId)
             .replace("{{ virtual_clusters }}", virtualClusters);
 
-    if (resolvedConfiguration.contains("{{")) {
-      throw new ConfigurationException();
+    final Matcher unresolvedKeys = KEY_PATTERN.matcher(resolvedConfiguration);
+    if (unresolvedKeys.find()) {
+      throw new ConfigurationException(unresolvedKeys.group(1));
     }
     return resolvedConfiguration;
   }
 
   static class ConfigurationException extends RuntimeException {
-    ConfigurationException() { super("Unresolved Template Key"); }
+    ConfigurationException(String unresolvedKey) {
+      super(unresolvedKey != null ? "Unresolved template key: " + unresolvedKey : "butts");
+    }
   }
 }

--- a/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -1,6 +1,7 @@
 package io.envoyproxy.envoymobile.engine
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val TEST_CONFIG =
@@ -46,10 +47,15 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("virtual_clusters: [test]")
   }
 
-  @Test(expected = EnvoyConfiguration.ConfigurationException::class)
+  @Test
   fun `resolve templates with invalid templates will throw on build`() {
     val envoyConfiguration = EnvoyConfiguration("stats.foo.com", 123, 234, 345, 456, emptyList(), 567, "v1.2.3", "com.mydomain.myapp", "[test]")
 
-    envoyConfiguration.resolveTemplate("{{ }}", "")
+    try {
+      envoyConfiguration.resolveTemplate("{{ missing }}", "")
+      fail("Unresolved configuration keys should trigger exception.")
+    } catch (e: EnvoyConfiguration.ConfigurationException) {
+      assertThat(e.message).contains("missing")
+    }
   }
 }


### PR DESCRIPTION
Description: Added to assist while debugging filters.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>