### PR TITLE
platform: add option for specifying custom filter names

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -117,11 +117,10 @@ open class EngineBuilder(
    * @return this builder.
    */
   fun addFilter(name: String = UUID.randomUUID().toString(), factory: () -> Filter):
-    EngineBuilder
-  {
-    this.filterChain.add(FilterFactory(name, factory))
-    return this
-  }
+    EngineBuilder {
+      this.filterChain.add(FilterFactory(name, factory))
+      return this
+    }
 
   /**
    * Set a closure to be called when the engine finishes its async startup and begins running.

--- a/library/kotlin/src/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -109,13 +109,17 @@ open class EngineBuilder(
   /**
    * Add an HTTP filter factory used to create filters for streams sent by this client.
    *
+   * @param name Custom name to use for this filter factory. Useful for having
+   *             more meaningful trace logs, but not required. Should be unique
+   *             per factory registered.
    * @param factory closure returning an instantiated filter.
    *
    * @return this builder.
    */
-  fun addFilter(factory: () -> Filter): EngineBuilder {
-    val filterName = UUID.randomUUID().toString()
-    this.filterChain.add(FilterFactory(filterName, factory))
+  fun addFilter(name: String = UUID.randomUUID().toString(), factory: () -> Filter):
+    EngineBuilder
+  {
+    this.filterChain.add(FilterFactory(name, factory))
     return this
   }
 

--- a/library/swift/src/EngineBuilder.swift
+++ b/library/swift/src/EngineBuilder.swift
@@ -111,13 +111,17 @@ public final class EngineBuilder: NSObject {
 
   /// Add an HTTP filter factory used to construct filters for streams sent by this client.
   ///
+  /// - parameter name:    Custom name to use for this filter factory. Useful for having
+  ///                      more meaningful trace logs, but not required. Should be unique
+  ///                      per factory registered.
   /// - parameter factory: Closure returning an instantiated filter. Called once per stream.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addFilter(factory: @escaping () -> Filter) -> EngineBuilder {
-    let filterName = UUID().uuidString
-    self.filterChain.append(EnvoyHTTPFilterFactory(filterName: filterName, factory: factory))
+  public func addFilter(name: String = UUID().uuidString,
+                        factory: @escaping () -> Filter) -> EngineBuilder
+  {
+    self.filterChain.append(EnvoyHTTPFilterFactory(filterName: name, factory: factory))
     return self
   }
 


### PR DESCRIPTION
Being able to specify a custom name can be helpful for reading `trace` logs which include named filters.

Signed-off-by: Michael Rebello <me@michaelrebello.com>
