### PR TITLE
filters: fix on-resume JNI call signature and parameters

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -488,14 +488,9 @@ jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data
       env->GetMethodID(jcls_JvmCallbackContext, method, "(J[BJZ)Ljava/lang/Object;");
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
-  jobjectArray result = static_cast<jobjectArray>(env->CallObjectMethod(
-    j_context,
-    jmid_onResume,
-    headers_length,
-    j_in_data,
-    trailers_length,
-    end_stream ? JNI_TRUE : JNI_FALSE
-  ));
+  jobjectArray result = static_cast<jobjectArray>(
+      env->CallObjectMethod(j_context, jmid_onResume, headers_length, j_in_data, trailers_length,
+                            end_stream ? JNI_TRUE : JNI_FALSE));
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
 

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -485,11 +485,17 @@ jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onResume =
-      env->GetMethodID(jcls_JvmCallbackContext, method, "(J)Ljava/lang/Object;");
+      env->GetMethodID(jcls_JvmCallbackContext, method, "(J[BJZ)Ljava/lang/Object;");
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
-  jobjectArray result = static_cast<jobjectArray>(
-      env->CallObjectMethod(j_context, jmid_onResume, headers_length, j_in_data, trailers_length));
+  jobjectArray result = static_cast<jobjectArray>(env->CallObjectMethod(
+    j_context,
+    jmid_onResume,
+    headers_length,
+    j_in_data,
+    trailers_length,
+    end_stream ? JNI_TRUE : JNI_FALSE
+  ));
 
   env->DeleteLocalRef(jcls_JvmCallbackContext);
 


### PR DESCRIPTION
Description: Fixes error in JNI function signature, and adds missing parameter.
Risk Level: Moderate
Testing: Local and CI (#1167)

Signed-off-by: Mike Schore <mike.schore@gmail.com>