### PR TITLE
filters: check iteration state before accessing internal buffer

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -335,7 +335,7 @@ Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, 
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
-  if (decoder_callbacks_->decodingBuffer()) {
+  if (iteration_state_ == IterationState::Stopped && decoder_callbacks_->decodingBuffer()) {
     decoder_callbacks_->modifyDecodingBuffer([&internal_buffer](Buffer::Instance& mutable_buffer) {
       internal_buffer = &mutable_buffer;
     });
@@ -352,7 +352,7 @@ Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, 
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
-  if (encoder_callbacks_->encodingBuffer()) {
+  if (iteration_state_ == IterationState::Stopped && encoder_callbacks_->encodingBuffer()) {
     encoder_callbacks_->modifyEncodingBuffer([&internal_buffer](Buffer::Instance& mutable_buffer) {
       internal_buffer = &mutable_buffer;
     });
@@ -369,7 +369,7 @@ Http::FilterTrailersStatus PlatformBridgeFilter::decodeTrailers(Http::RequestTra
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
-  if (decoder_callbacks_->decodingBuffer()) {
+  if (iteration_state_ == IterationState::Stopped && decoder_callbacks_->decodingBuffer()) {
     decoder_callbacks_->modifyDecodingBuffer([&internal_buffer](Buffer::Instance& mutable_buffer) {
       internal_buffer = &mutable_buffer;
     });
@@ -390,7 +390,7 @@ PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
-  if (encoder_callbacks_->encodingBuffer()) {
+  if (iteration_state_ == IterationState::Stopped && encoder_callbacks_->encodingBuffer()) {
     encoder_callbacks_->modifyEncodingBuffer([&internal_buffer](Buffer::Instance& mutable_buffer) {
       internal_buffer = &mutable_buffer;
     });

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -417,10 +417,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnRequestData) {
 
   Buffer::OwnedImpl decoding_buffer;
   EXPECT_CALL(decoder_callbacks_, decodingBuffer())
-      .Times(3)
+      .Times(2)
       .WillRepeatedly(Return(&decoding_buffer));
   EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer(_))
-      .Times(3)
+      .Times(2)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(decoding_buffer);
       }));
@@ -489,10 +489,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnRequestData) {
 
   Buffer::OwnedImpl decoding_buffer;
   EXPECT_CALL(decoder_callbacks_, decodingBuffer())
-      .Times(2)
+      .Times(1)
       .WillRepeatedly(Return(&decoding_buffer));
   EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer(_))
-      .Times(2)
+      .Times(1)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(decoding_buffer);
       }));
@@ -1190,10 +1190,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnResponseData) {
 
   Buffer::OwnedImpl encoding_buffer;
   EXPECT_CALL(encoder_callbacks_, encodingBuffer())
-      .Times(3)
+      .Times(2)
       .WillRepeatedly(Return(&encoding_buffer));
   EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_))
-      .Times(3)
+      .Times(2)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(encoding_buffer);
       }));
@@ -1262,10 +1262,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnResponseData) {
 
   Buffer::OwnedImpl encoding_buffer;
   EXPECT_CALL(encoder_callbacks_, encodingBuffer())
-      .Times(2)
+      .Times(1)
       .WillRepeatedly(Return(&encoding_buffer));
   EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_))
-      .Times(2)
+      .Times(1)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(encoding_buffer);
       }));


### PR DESCRIPTION
Description: This ensures we don't trip an Envoy assertion when accessing the buffer under certain conditions.
Risk Level: Moderate
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
