### PR TITLE
stats: add dns counters

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -202,16 +202,19 @@ stats_config:
       patterns:
         - safe_regex:
             google_re2: {}
+            regex: '^client.*'
+        - safe_regex:
+            google_re2: {}
             regex: '^cluster\.[\w]+?\.upstream_cx_[\w]+'
         - safe_regex:
             google_re2: {}
             regex: '^cluster\.[\w]+?\.upstream_rq_[\w]+'
         - safe_regex:
             google_re2: {}
-            regex: '^http.dispatcher.*'
+            regex: '^dns.apple.*'
         - safe_regex:
             google_re2: {}
-            regex: '^client.*'
+            regex: '^http.dispatcher.*'
         - safe_regex:
             google_re2: {}
             regex: '^http.hcm.decompressor.*'


### PR DESCRIPTION
Description: adding stats now available from https://github.com/envoyproxy/envoy/pull/13942
Risk Level: low
Testing: local emission

Signed-off-by: Jose Nino <jnino@lyft.com>
